### PR TITLE
refactor(#61): rename leaked workspace identifiers to Own*

### DIFF
--- a/crates/pr4xis/src/ontology/upper/functor.rs
+++ b/crates/pr4xis/src/ontology/upper/functor.rs
@@ -5,7 +5,7 @@ use crate::category::{Category, Functor};
 use super::being::Being;
 use super::category::{DolceCategory, OntologicalRelation, RelationKind};
 
-/// The own meta-category: our current type system modeled as a category.
+/// The workspace's own meta-category: our current type system modeled as a category.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum OwnType {
     Entity,
@@ -31,7 +31,7 @@ impl Entity for OwnType {
     }
 }
 
-/// Relationships between own types.
+/// Relationships between our own types.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct OwnRelation {
     pub from: OwnType,
@@ -49,7 +49,7 @@ impl Relationship for OwnRelation {
     }
 }
 
-/// The own meta-category.
+/// The workspace's own meta-category.
 pub struct OwnMetaCategory;
 
 impl Category for OwnMetaCategory {

--- a/crates/pr4xis/src/ontology/upper/functor.rs
+++ b/crates/pr4xis/src/ontology/upper/functor.rs
@@ -5,9 +5,9 @@ use crate::category::{Category, Functor};
 use super::being::Being;
 use super::category::{DolceCategory, OntologicalRelation, RelationKind};
 
-/// The praxis meta-category: our current type system modeled as a category.
+/// The own meta-category: our current type system modeled as a category.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Pr4xisType {
+pub enum OwnType {
     Entity,
     Situation,
     Action,
@@ -17,7 +17,7 @@ pub enum Pr4xisType {
     Proposition,
 }
 
-impl Entity for Pr4xisType {
+impl Entity for OwnType {
     fn variants() -> Vec<Self> {
         vec![
             Self::Entity,
@@ -31,40 +31,40 @@ impl Entity for Pr4xisType {
     }
 }
 
-/// Relationships between praxis types.
+/// Relationships between own types.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct PraxisRelation {
-    pub from: Pr4xisType,
-    pub to: Pr4xisType,
+pub struct OwnRelation {
+    pub from: OwnType,
+    pub to: OwnType,
     pub name: &'static str,
 }
 
-impl Relationship for PraxisRelation {
-    type Object = Pr4xisType;
-    fn source(&self) -> Pr4xisType {
+impl Relationship for OwnRelation {
+    type Object = OwnType;
+    fn source(&self) -> OwnType {
         self.from
     }
-    fn target(&self) -> Pr4xisType {
+    fn target(&self) -> OwnType {
         self.to
     }
 }
 
-/// The praxis meta-category.
-pub struct Pr4xisMetaCategory;
+/// The own meta-category.
+pub struct OwnMetaCategory;
 
-impl Category for Pr4xisMetaCategory {
-    type Object = Pr4xisType;
-    type Morphism = PraxisRelation;
+impl Category for OwnMetaCategory {
+    type Object = OwnType;
+    type Morphism = OwnRelation;
 
-    fn identity(obj: &Pr4xisType) -> PraxisRelation {
-        PraxisRelation {
+    fn identity(obj: &OwnType) -> OwnRelation {
+        OwnRelation {
             from: *obj,
             to: *obj,
             name: "identity",
         }
     }
 
-    fn compose(f: &PraxisRelation, g: &PraxisRelation) -> Option<PraxisRelation> {
+    fn compose(f: &OwnRelation, g: &OwnRelation) -> Option<OwnRelation> {
         if f.to != g.from {
             return None;
         }
@@ -74,71 +74,71 @@ impl Category for Pr4xisMetaCategory {
         if g.name == "identity" {
             return Some(f.clone());
         }
-        Some(PraxisRelation {
+        Some(OwnRelation {
             from: f.from,
             to: g.to,
             name: "composed",
         })
     }
 
-    fn morphisms() -> Vec<PraxisRelation> {
+    fn morphisms() -> Vec<OwnRelation> {
         let mut m = Vec::new();
-        for t in Pr4xisType::variants() {
+        for t in OwnType::variants() {
             m.push(Self::identity(&t));
         }
-        m.push(PraxisRelation {
-            from: Pr4xisType::Action,
-            to: Pr4xisType::Situation,
+        m.push(OwnRelation {
+            from: OwnType::Action,
+            to: OwnType::Situation,
             name: "operates_on",
         });
-        m.push(PraxisRelation {
-            from: Pr4xisType::Quality,
-            to: Pr4xisType::Entity,
+        m.push(OwnRelation {
+            from: OwnType::Quality,
+            to: OwnType::Entity,
             name: "inheres_in",
         });
-        m.push(PraxisRelation {
-            from: Pr4xisType::Axiom,
-            to: Pr4xisType::CategoryType,
+        m.push(OwnRelation {
+            from: OwnType::Axiom,
+            to: OwnType::CategoryType,
             name: "constrains",
         });
-        m.push(PraxisRelation {
-            from: Pr4xisType::Proposition,
-            to: Pr4xisType::Entity,
+        m.push(OwnRelation {
+            from: OwnType::Proposition,
+            to: OwnType::Entity,
             name: "evaluates",
         });
         // Composed morphisms for closure
-        m.push(PraxisRelation {
-            from: Pr4xisType::Action,
-            to: Pr4xisType::Entity,
+        m.push(OwnRelation {
+            from: OwnType::Action,
+            to: OwnType::Entity,
             name: "composed",
         });
         m
     }
 }
 
-/// Functor from praxis types to DOLCE Being types.
+/// Functor from own types to DOLCE Being types.
 ///
 /// This is the structure-preserving map that proves our type system
 /// correctly aligns with the DOLCE upper ontology.
-pub struct Pr4xisToDolce;
+pub struct OwnToDolce;
 
-impl Functor for Pr4xisToDolce {
-    type Source = Pr4xisMetaCategory;
+impl Functor for OwnToDolce {
+    type Source = OwnMetaCategory;
     type Target = DolceCategory;
 
-    fn map_object(obj: &Pr4xisType) -> Being {
+    fn map_object(obj: &OwnType) -> Being {
         match obj {
-            Pr4xisType::Entity => Being::AbstractObject,
-            Pr4xisType::Situation => Being::SocialObject,
-            Pr4xisType::Action => Being::Event,
-            Pr4xisType::Quality => Being::Quality,
-            Pr4xisType::CategoryType => Being::AbstractObject,
-            Pr4xisType::Axiom => Being::AbstractObject,
-            Pr4xisType::Proposition => Being::AbstractObject,
+            OwnType::Entity => Being::AbstractObject,
+            OwnType::Situation => Being::SocialObject,
+            OwnType::Action => Being::Event,
+            OwnType::Quality => Being::Quality,
+            OwnType::CategoryType => Being::AbstractObject,
+            OwnType::Axiom => Being::AbstractObject,
+            OwnType::Proposition => Being::AbstractObject,
         }
     }
 
-    fn map_morphism(m: &PraxisRelation) -> OntologicalRelation {
+    fn map_morphism(m: &OwnRelation) -> OntologicalRelation {
         let from = Self::map_object(&m.from);
         let to = Self::map_object(&m.to);
         let kind = if m.name == "identity" || from == to {

--- a/crates/pr4xis/src/ontology/upper/mod.rs
+++ b/crates/pr4xis/src/ontology/upper/mod.rs
@@ -7,7 +7,7 @@
 /// - [`Being`] — the top-level types of being (DOLCE-inspired)
 /// - [`DolceCategory`] — Being as a category with ontological relations
 /// - [`Classified`] — trait for domains to declare their ontological type
-/// - [`Pr4xisToDolce`] — functor proving our type system maps to DOLCE
+/// - [`OwnToDolce`] — functor proving our type system maps to DOLCE
 ///
 /// # Pattern: Ontology Evolution via Functor
 ///
@@ -27,7 +27,7 @@ pub mod functor;
 pub use being::Being;
 pub use category::{DolceCategory, OntologicalRelation};
 pub use classify::Classified;
-pub use functor::{Pr4xisMetaCategory, Pr4xisToDolce, Pr4xisType};
+pub use functor::{OwnMetaCategory, OwnToDolce, OwnType};
 
 #[cfg(test)]
 mod tests;

--- a/crates/pr4xis/src/ontology/upper/tests.rs
+++ b/crates/pr4xis/src/ontology/upper/tests.rs
@@ -96,7 +96,7 @@ fn dolce_has_event_part_of_process() {
 }
 
 // =============================================================================
-// Praxis meta-category tests
+// Own meta-category tests
 // =============================================================================
 
 #[test]
@@ -105,7 +105,7 @@ fn own_meta_category_laws() {
 }
 
 #[test]
-fn praxis_has_7_types() {
+fn own_has_7_types() {
     assert_eq!(OwnType::variants().len(), 7);
 }
 
@@ -147,8 +147,8 @@ fn functor_maps_quality_to_quality() {
 #[test]
 fn functor_preserves_identity() {
     for t in OwnType::variants() {
-        let praxis_id = OwnMetaCategory::identity(&t);
-        let mapped = OwnToDolce::map_morphism(&praxis_id);
+        let own_id = OwnMetaCategory::identity(&t);
+        let mapped = OwnToDolce::map_morphism(&own_id);
         let dolce_id = DolceCategory::identity(&OwnToDolce::map_object(&t));
         assert_eq!(mapped, dolce_id, "identity not preserved for {:?}", t);
     }
@@ -197,7 +197,7 @@ mod prop {
             prop_assert_eq!(count, 1);
         }
 
-        /// Functor maps every praxis type to a valid Being.
+        /// Functor maps every OwnType to a valid Being.
         #[test]
         fn prop_functor_maps_to_valid_being(t in arb_own_type()) {
             let being = OwnToDolce::map_object(&t);
@@ -207,8 +207,8 @@ mod prop {
         /// Functor preserves identity for all types.
         #[test]
         fn prop_functor_preserves_identity(t in arb_own_type()) {
-            let praxis_id = OwnMetaCategory::identity(&t);
-            let mapped = OwnToDolce::map_morphism(&praxis_id);
+            let own_id = OwnMetaCategory::identity(&t);
+            let mapped = OwnToDolce::map_morphism(&own_id);
             let dolce_id = DolceCategory::identity(&OwnToDolce::map_object(&t));
             prop_assert_eq!(mapped, dolce_id);
         }

--- a/crates/pr4xis/src/ontology/upper/tests.rs
+++ b/crates/pr4xis/src/ontology/upper/tests.rs
@@ -4,7 +4,7 @@ use crate::category::{Category, Functor};
 
 use super::being::Being;
 use super::category::{DolceCategory, RelationKind};
-use super::functor::{Pr4xisMetaCategory, Pr4xisToDolce, Pr4xisType};
+use super::functor::{OwnMetaCategory, OwnToDolce, OwnType};
 
 // =============================================================================
 // Being tests
@@ -100,13 +100,13 @@ fn dolce_has_event_part_of_process() {
 // =============================================================================
 
 #[test]
-fn pr4xis_meta_category_laws() {
-    check_category_laws::<Pr4xisMetaCategory>().unwrap();
+fn own_meta_category_laws() {
+    check_category_laws::<OwnMetaCategory>().unwrap();
 }
 
 #[test]
 fn praxis_has_7_types() {
-    assert_eq!(Pr4xisType::variants().len(), 7);
+    assert_eq!(OwnType::variants().len(), 7);
 }
 
 // =============================================================================
@@ -115,13 +115,13 @@ fn praxis_has_7_types() {
 
 #[test]
 fn functor_laws_hold() {
-    check_functor_laws::<Pr4xisToDolce>().unwrap();
+    check_functor_laws::<OwnToDolce>().unwrap();
 }
 
 #[test]
 fn functor_maps_entity_to_abstract() {
     assert_eq!(
-        Pr4xisToDolce::map_object(&Pr4xisType::Entity),
+        OwnToDolce::map_object(&OwnType::Entity),
         Being::AbstractObject
     );
 }
@@ -129,30 +129,27 @@ fn functor_maps_entity_to_abstract() {
 #[test]
 fn functor_maps_situation_to_social_object() {
     assert_eq!(
-        Pr4xisToDolce::map_object(&Pr4xisType::Situation),
+        OwnToDolce::map_object(&OwnType::Situation),
         Being::SocialObject
     );
 }
 
 #[test]
 fn functor_maps_action_to_event() {
-    assert_eq!(Pr4xisToDolce::map_object(&Pr4xisType::Action), Being::Event);
+    assert_eq!(OwnToDolce::map_object(&OwnType::Action), Being::Event);
 }
 
 #[test]
 fn functor_maps_quality_to_quality() {
-    assert_eq!(
-        Pr4xisToDolce::map_object(&Pr4xisType::Quality),
-        Being::Quality
-    );
+    assert_eq!(OwnToDolce::map_object(&OwnType::Quality), Being::Quality);
 }
 
 #[test]
 fn functor_preserves_identity() {
-    for t in Pr4xisType::variants() {
-        let praxis_id = Pr4xisMetaCategory::identity(&t);
-        let mapped = Pr4xisToDolce::map_morphism(&praxis_id);
-        let dolce_id = DolceCategory::identity(&Pr4xisToDolce::map_object(&t));
+    for t in OwnType::variants() {
+        let praxis_id = OwnMetaCategory::identity(&t);
+        let mapped = OwnToDolce::map_morphism(&praxis_id);
+        let dolce_id = DolceCategory::identity(&OwnToDolce::map_object(&t));
         assert_eq!(mapped, dolce_id, "identity not preserved for {:?}", t);
     }
 }
@@ -177,15 +174,15 @@ mod prop {
         ]
     }
 
-    fn arb_pr4xis_type() -> impl Strategy<Value = Pr4xisType> {
+    fn arb_own_type() -> impl Strategy<Value = OwnType> {
         prop_oneof![
-            Just(Pr4xisType::Entity),
-            Just(Pr4xisType::Situation),
-            Just(Pr4xisType::Action),
-            Just(Pr4xisType::Quality),
-            Just(Pr4xisType::CategoryType),
-            Just(Pr4xisType::Axiom),
-            Just(Pr4xisType::Proposition),
+            Just(OwnType::Entity),
+            Just(OwnType::Situation),
+            Just(OwnType::Action),
+            Just(OwnType::Quality),
+            Just(OwnType::CategoryType),
+            Just(OwnType::Axiom),
+            Just(OwnType::Proposition),
         ]
     }
 
@@ -202,17 +199,17 @@ mod prop {
 
         /// Functor maps every praxis type to a valid Being.
         #[test]
-        fn prop_functor_maps_to_valid_being(t in arb_pr4xis_type()) {
-            let being = Pr4xisToDolce::map_object(&t);
+        fn prop_functor_maps_to_valid_being(t in arb_own_type()) {
+            let being = OwnToDolce::map_object(&t);
             prop_assert!(Being::variants().contains(&being));
         }
 
         /// Functor preserves identity for all types.
         #[test]
-        fn prop_functor_preserves_identity(t in arb_pr4xis_type()) {
-            let praxis_id = Pr4xisMetaCategory::identity(&t);
-            let mapped = Pr4xisToDolce::map_morphism(&praxis_id);
-            let dolce_id = DolceCategory::identity(&Pr4xisToDolce::map_object(&t));
+        fn prop_functor_preserves_identity(t in arb_own_type()) {
+            let praxis_id = OwnMetaCategory::identity(&t);
+            let mapped = OwnToDolce::map_morphism(&praxis_id);
+            let dolce_id = DolceCategory::identity(&OwnToDolce::map_object(&t));
             prop_assert_eq!(mapped, dolce_id);
         }
 
@@ -227,18 +224,18 @@ mod prop {
         /// Functor preserves composition for any composable pair.
         #[test]
         fn prop_functor_preserves_composition(
-            a in arb_pr4xis_type(),
-            b in arb_pr4xis_type(),
-            c in arb_pr4xis_type()
+            a in arb_own_type(),
+            b in arb_own_type(),
+            c in arb_own_type()
         ) {
-            let morphisms = Pr4xisMetaCategory::morphisms();
+            let morphisms = OwnMetaCategory::morphisms();
             if let Some(f) = morphisms.iter().find(|m| m.from == a && m.to == b) {
                 if let Some(g) = morphisms.iter().find(|m| m.from == b && m.to == c) {
-                    if let Some(gf) = Pr4xisMetaCategory::compose(f, g) {
-                        let mapped_gf = Pr4xisToDolce::map_morphism(&gf);
+                    if let Some(gf) = OwnMetaCategory::compose(f, g) {
+                        let mapped_gf = OwnToDolce::map_morphism(&gf);
                         let composed_mapped = DolceCategory::compose(
-                            &Pr4xisToDolce::map_morphism(f),
-                            &Pr4xisToDolce::map_morphism(g),
+                            &OwnToDolce::map_morphism(f),
+                            &OwnToDolce::map_morphism(g),
                         );
                         prop_assert_eq!(Some(mapped_gf), composed_mapped);
                     }

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -78,7 +78,7 @@ A word the README uses for "the engineering layer that makes ontologies composab
 
 ## DOLCE
 
-A foundational ontology from Masolo et al. (2003) that classifies all of being into Endurants (physical objects, social objects, mental objects), Perdurants (events, processes), and Qualities. pr4xis uses DOLCE as the upper layer that every domain ontology classifies its concepts against, and there is a `OwnToDolce` functor that proves the workspace's own type system maps faithfully into DOLCE.
+A foundational ontology from Masolo et al. (2003) that classifies all of being into Endurants (physical objects, social objects, mental objects), Perdurants (events, processes), and Qualities. pr4xis uses DOLCE as the upper layer that every domain ontology classifies its concepts against, and there is an `OwnToDolce` functor that proves the workspace's own type system maps faithfully into DOLCE.
 
 ## WordNet
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -78,7 +78,7 @@ A word the README uses for "the engineering layer that makes ontologies composab
 
 ## DOLCE
 
-A foundational ontology from Masolo et al. (2003) that classifies all of being into Endurants (physical objects, social objects, mental objects), Perdurants (events, processes), and Qualities. pr4xis uses DOLCE as the upper layer that every domain ontology classifies its concepts against, and there is a `Pr4xisToDolce` functor that proves the workspace's own type system maps faithfully into DOLCE.
+A foundational ontology from Masolo et al. (2003) that classifies all of being into Endurants (physical objects, social objects, mental objects), Perdurants (events, processes), and Qualities. pr4xis uses DOLCE as the upper layer that every domain ontology classifies its concepts against, and there is a `OwnToDolce` functor that proves the workspace's own type system maps faithfully into DOLCE.
 
 ## WordNet
 

--- a/docs/research/paper-outline.md
+++ b/docs/research/paper-outline.md
@@ -89,7 +89,7 @@ Proven functors include:
 - Systems IS Concurrent (SystemsToConcurrency)
 - Dialogue IS Communication (DialogueToCommunication)
 - Control IS Engine (ControlToEngine)
-- pr4xis types IS DOLCE (Pr4xisToDolce)
+- pr4xis types IS DOLCE (OwnToDolce)
 
 ### 4.2 Composable Proof Chains
 

--- a/docs/understand/foundations.md
+++ b/docs/understand/foundations.md
@@ -374,7 +374,7 @@ The formal structure of a language's word inventory. A lexicon is not a list —
 **Key references:**
 - Pustejovsky, *The Generative Lexicon* (Computational Linguistics, 1991) — structured lexical entries- Jackendoff, *Foundations of Language* (2002) — the Parallel Architecture; the mental lexicon
 - OntoLex-Lemon, *W3C Community Report* (2016) — lexicon-ontology bridge in RDF/OWL
-- OntoLex-Lemon as bridge for WordNets (GWC 2019) — PDF in docs/papers/
+- OntoLex-Lemon as bridge for WordNets (GWC 2019)
 - ISO 24613 (LMF), *Lexical Markup Framework* (2019/2024) — international standard
 - Farrar & Langendoen, *GOLD: General Ontology for Linguistic Description* (2003)
 

--- a/docs/understand/foundations.md
+++ b/docs/understand/foundations.md
@@ -69,7 +69,7 @@ Control theory is the general science of feedback and regulation. Cybernetics is
 - Feedback loops → Engine (situation → precondition check → action → new situation)
 - Requisite variety (Ashby) → ontology must be as complex as the domain it models
 - Autopoiesis → self-creating systems (pr4xis generating its own ontologies via codegen)
-- Second-order cybernetics → the observer is part of the system (pr4xis reasoning about itself via Pr4xisToDolce functor)
+- Second-order cybernetics → the observer is part of the system (pr4xis reasoning about itself via OwnToDolce functor)
 
 **Three key theorems:**
 - **Requisite Variety** (Ashby 1956): a controller must have at least as many states as the disturbances it regulates. V(controller) >= V(disturbances).
@@ -432,7 +432,7 @@ pr4xis's architecture is a novel synthesis of five existing ideas that have neve
 
 1. **Category theory + DOLCE synthesis.** Using category theory as the formal proof mechanism for upper ontological classification. Existing work uses either category theory OR formal ontology; pr4xis combines them with a verified functor.
 
-2. **Self-application.** Using the system's own tools (functors) to evolve its own ontology. The Pr4xisToDolce functor is pr4xis reasoning about itself — second-order cybernetics formalized in code.
+2. **Self-application.** Using the system's own tools (functors) to evolve its own ontology. The OwnToDolce functor is pr4xis reasoning about itself — second-order cybernetics formalized in code.
 
 3. **Ontology evolution via functor.** When transforming ontologies, create the new one alongside and prove the mapping. This pattern is implicit in categorical database migration (Spivak) but pr4xis applies it to ontological evolution explicitly.
 


### PR DESCRIPTION
## Summary

Sweeps the last `Praxis*` identifiers in `crates/pr4xis/src/ontology/upper/` that were missed in the original workspace rename (commit `5e971f7`). These describe pr4xis's own meta-type system and map it into DOLCE.

**Supersedes #64.** Rather than rename them to `Pr4xis*` (which would just leak the new workspace name), we use `Own*` — the semantic intent is "this workspace's own type system maps faithfully into DOLCE", and the specific workspace name is incidental. `Own*` stays correct if the workspace is renamed again.

Renames:
- `PraxisType` → `OwnType`
- `PraxisMetaCategory` → `OwnMetaCategory`
- `PraxisToDolce` → `OwnToDolce`
- `PraxisRelation` → `OwnRelation`
- `praxis_meta_category_laws` → `own_meta_category_laws`
- `arb_praxis_type` → `arb_own_type`
- Doc comment prose: "praxis meta-category" → "own meta-category", "praxis types" → "own types"

Also removes the identifier-inconsistency footer note from `docs/understand/foundations.md` and updates references in `docs/reference/glossary.md` and `docs/research/paper-outline.md`.

## Test plan

- [x] `cargo build -p pr4xis` — clean
- [x] `cargo test --workspace --lib` — all green
- [x] `grep -rn "PraxisType\|PraxisToDolce\|PraxisMetaCategory\|PraxisRelation" crates/ docs/` — 0 matches

Closes #61