### PR TITLE
docs(#173): per-ontology rollout for 5 new HMI sub-ontologies

### DIFF
--- a/crates/domains/src/applied/hmi/explorer/README.md
+++ b/crates/domains/src/applied/hmi/explorer/README.md
@@ -1,0 +1,55 @@
+# Explorer -- Self-referential visualization of reasoning traces
+
+Models the ontology explorer as a first-class domain. The explorer visualizes pr4xis's own reasoning process in real time: **concept nodes light up as axioms evaluate**, colored by the active theme, with edges drawn for taxonomy / mereology / causation / opposition. It is deliberately self-referential — the explorer is itself a pr4xis ontology, consumed by any surface that wants to render reasoning traces.
+
+The self-referential claim is concrete: the explorer uses `applied/hmi/theming/`'s `ThemePalette` to color its own nodes, so changing the active theme re-colors the visualization of the theming ontology through which the theme is changed. This is Brian Smith 1984 reflective-tower in a small frame.
+
+Key references:
+- Mendez et al. 2023: *Evonne* (EuroVis 2023) — proof-tree visualization
+- Srisuchinnawong et al. 2021: *NeuroVis* — neural activation encoding
+- Wongsuphasawat et al. 2017: *TensorFlow Graph Visualizer* (IEEE VAST) — dataflow graphs at scale
+- Beck et al. 2017: *A Taxonomy and Survey of Dynamic Graph Visualization* (Computer Graphics Forum) — temporal animation
+- Smith 1984: *Reflection and Semantics in a Procedural Language* — reflective towers
+- W3C PROV-O 2013 — provenance data model
+
+## Entities
+
+| Category | Entities |
+|---|---|
+| Graph primitives | `ConceptNode { id, label, kind, activation }`, `ConceptEdge { from, to, label, kind }`, `OntologyGraph { nodes, edges }` |
+| Concept kinds | `Entity`, `Relation`, `Quality`, `Axiom` |
+| Edge kinds | `IsA` (taxonomy), `PartOf` (mereology), `Causes` (causation), `Opposes` (opposition), `Uses` (reference) |
+| Trace | `TraceStep { step, activated, reasons }`, `ReasoningTrace { question, steps, result }` |
+| Activation | `ActivationState` — Inactive, Active, Evaluated, Satisfied, Violated |
+| Shader params | `ShaderParams { uniforms, ... }` — GPU-side controls for the trace renderer |
+
+## Qualities
+
+| Quality | Type | Description |
+|---|---|---|
+| ShaderUniform | f32 / Rgb / Vec3 | Parameters for the trace renderer's fragment shader (activation intensity, pulse speed, glow radius) |
+
+## Axioms
+
+| Axiom | Description | Source |
+|---|---|---|
+| (structural) | Identity and composition laws | auto-generated |
+| ActivationThemeMapped | Every activation state maps to a distinct palette slot in the active theme | self-referential invariant |
+| GraphConnected | The ontology graph is connected — no orphan concepts | graph well-formedness |
+| TraceMinimalSteps | A reasoning trace has at most one activation per step per concept | Evonne / NeuroVis |
+
+See `ontology.rs` for the full `impl Axiom for …` blocks.
+
+## Functors
+
+No cross-domain functors yet — see [Compose via functor](../../../../../../docs/use/compose-via-functor.md) to add one. The explorer is a **consumer** of `applied/hmi/theming/` (for palette) and `applied/hmi/visualization/` (for Bertin's visual variables and accuracy ranking). It is the **target** of any ontology that wants to render its own reasoning — including the future pr4xis.dev `/visualize/ontologies/` page, which will render the 106-ontology graph live.
+
+## Files
+
+- `ontology.rs` -- `ConceptNode`, `ConceptEdge`, `ActivationState`, `TraceStep`, `ReasoningTrace`, `OntologyGraph`, `ActivationThemeMapped`, `GraphConnected`, `TraceMinimalSteps` axioms, tests
+- `shader_params.rs` -- `ShaderParams` for GPU-side trace rendering, uniforms, `Interval`-bounded ranges
+- `README.md` -- this file
+- `citings.md` -- per-ontology bibliography
+- `mod.rs` -- module declarations
+
+Previous home: `applied/theming/explorer.rs` + `shader_params.rs`, moved here by [#66](https://github.com/i-am-logger/pr4xis/pull/66).

--- a/crates/domains/src/applied/hmi/explorer/citings.md
+++ b/crates/domains/src/applied/hmi/explorer/citings.md
@@ -1,0 +1,33 @@
+# Citings — Explorer -- Self-referential visualization of reasoning traces
+
+Every published source this ontology stands on. Entries below are drawn from the ontology's [README.md](README.md) and the doc comments on its axioms. Where a full bibliographic entry exists in the workspace-wide [`docs/papers/references.md`](../../../../../../docs/papers/references.md), the short form here is a pointer.
+
+## Primary sources
+
+- Mendez et al. 2023: *Evonne* (EuroVis 2023) — proof-tree visualization
+- Srisuchinnawong et al. 2021: *NeuroVis* — neural activation encoding
+- Wongsuphasawat et al. 2017: *TensorFlow Graph Visualizer* (IEEE VAST) — dataflow graphs at scale
+- Beck et al. 2017: *A Taxonomy and Survey of Dynamic Graph Visualization* (Computer Graphics Forum) — temporal animation
+- Smith 1984: *Reflection and Semantics in a Procedural Language* — reflective towers
+- W3C PROV-O 2013 — provenance data model
+
+## Cross-references
+
+- Workspace bibliography: [`docs/papers/references.md`](../../../../../../docs/papers/references.md)
+- Source attributions per axiom: see the `Source` column in the `## Axioms` table in [`README.md`](README.md)
+- Code-level citations: `grep -n 'Source:\|Reference:' *.rs` in this directory
+
+## Pending verification
+
+Every entry under **Primary sources** is a short pointer. For each one, confirm that a full citation (Author, Year, Title, DOI/URL) exists in `docs/papers/references.md`. Where no entry exists, add it (or a local PDF under a `papers/` subdirectory) before declaring the ontology citation-complete.
+
+Open items for human review:
+
+- [ ] Cross-check every primary source against `docs/papers/references.md`
+- [ ] Add code-comment-level citations (`// Source: ...`) to axioms that currently lack attribution
+- [ ] If this ontology depends on a paper not yet in the workspace bibliography, move/copy the PDF into a local `papers/` subdirectory and link it from the primary source line above
+
+---
+
+- **Document date:** 2026-04-15
+- **How this file is maintained:** initialized by the per-ontology rollout (issue #57 / #173) from `README.md`'s *Key references* section. Update by hand as code-comment citations, local PDFs, and `docs/papers/references.md` entries are added.

--- a/crates/domains/src/applied/hmi/input/README.md
+++ b/crates/domains/src/applied/hmi/input/README.md
@@ -1,0 +1,49 @@
+# Input -- Interaction modes and keybindings
+
+Models user input as a structured two-layer ontology: **modes** are states in a statechart (Harel 1987), and **keybindings** are the morphisms that trigger transitions between them. Together they form the interaction algebra — the formal substrate for "what does this key do right now?" and "what keys are available in this context?".
+
+Every rich-interaction surface (terminal, window manager, editor, shell, chat UI, WASM site) is a consumer: a surface loads a `ModeGraph` and a `KeybindingTable`, then routes every input event through them deterministically.
+
+Key references:
+- Harel 1987: *Statecharts: a visual formalism for complex systems* (Science of Computer Programming 8:3) — mode graphs, parallel regions, hierarchical states
+- Thimbleby 2004: *User Interface Design with Matrix Algebra* (ACM TOCHI 11:2) — interaction as algebra over state and input
+- Raskin 2000: *The Humane Interface* — monotony, modelessness discipline
+- Beaudouin-Lafon 2000: *Instrumental Interaction* (CHI 2000) — the interaction algebra framing
+- ECMA-48 5th Ed 1991 — terminal input conventions
+- VT520/xterm escape sequences — the de facto terminal input grammar
+
+## Entities
+
+| Category | Entities |
+|---|---|
+| Modes (Harel) | `ModeId(String)`, `ModeProperties { catchall, parent, ... }`, `Transition { from, to }`, `ModeGraph { root, modes, transitions }` |
+| Keys | `Key` — `Letter(char)`, `Number(u8)`, `Function(u8)`, `Named(NamedKey)`, `Mouse(MouseButton)` |
+| Named keys | `Enter`, `Escape`, `Space`, `Tab`, `Backspace`, `Delete`, `Arrow{Up,Down,Left,Right}`, `Home`, `End`, `PageUp`, `PageDown` |
+| Modifiers | `Shift`, `Ctrl`, `Alt`, `Meta` |
+| Mouse buttons | `Left`, `Right`, `Middle`, `Scroll{Up,Down}` |
+
+## Axioms
+
+| Axiom | Description | Source |
+|---|---|---|
+| (structural) | Identity and composition laws over the mode graph | auto-generated |
+| RootModeIsUnique | A `ModeGraph` has exactly one root mode | Harel 1987 |
+| TransitionsReferExistingModes | Every `Transition { from, to }` names modes that exist in the graph | well-formedness |
+| EscapeReturnsToParent | If a mode has a parent, an Escape keybinding returns to the parent | Harel 1987 / Raskin 2000 |
+| NoOrphanModes | Every non-root mode is reachable from the root via some transition | graph connectivity |
+
+See `modes.rs` and `keybindings.rs` for the `impl Axiom for …` blocks.
+
+## Functors
+
+No cross-domain functors yet — see [Compose via functor](../../../../../../docs/use/compose-via-functor.md) to add one. The input ontology is a substrate for every surface that needs modal input — the future `ChatSurface` will consume a `ModeGraph` for its chat-vs-command-vs-search modes, and the future `BrowserSurface` will expose a `KeybindingTable` for the site's navigation.
+
+## Files
+
+- `modes.rs` -- `ModeId`, `ModeProperties`, `Transition`, `ModeGraph`, mode-graph axioms, tests
+- `keybindings.rs` -- `Key`, `NamedKey`, `Modifier`, `MouseButton`, keybinding tables, tests
+- `README.md` -- this file
+- `citings.md` -- per-ontology bibliography
+- `mod.rs` -- module declarations
+
+Previous home: `applied/theming/modes.rs` + `applied/theming/keybindings.rs`, moved here by [#66](https://github.com/i-am-logger/pr4xis/pull/66).

--- a/crates/domains/src/applied/hmi/input/citings.md
+++ b/crates/domains/src/applied/hmi/input/citings.md
@@ -1,0 +1,33 @@
+# Citings — Input -- Interaction modes and keybindings
+
+Every published source this ontology stands on. Entries below are drawn from the ontology's [README.md](README.md) and the doc comments on its axioms. Where a full bibliographic entry exists in the workspace-wide [`docs/papers/references.md`](../../../../../../docs/papers/references.md), the short form here is a pointer.
+
+## Primary sources
+
+- Harel 1987: *Statecharts: a visual formalism for complex systems* (Science of Computer Programming 8:3) — mode graphs, parallel regions, hierarchical states
+- Thimbleby 2004: *User Interface Design with Matrix Algebra* (ACM TOCHI 11:2) — interaction as algebra over state and input
+- Raskin 2000: *The Humane Interface* — monotony, modelessness discipline
+- Beaudouin-Lafon 2000: *Instrumental Interaction* (CHI 2000) — the interaction algebra framing
+- ECMA-48 5th Ed 1991 — terminal input conventions
+- VT520/xterm escape sequences — the de facto terminal input grammar
+
+## Cross-references
+
+- Workspace bibliography: [`docs/papers/references.md`](../../../../../../docs/papers/references.md)
+- Source attributions per axiom: see the `Source` column in the `## Axioms` table in [`README.md`](README.md)
+- Code-level citations: `grep -n 'Source:\|Reference:' *.rs` in this directory
+
+## Pending verification
+
+Every entry under **Primary sources** is a short pointer. For each one, confirm that a full citation (Author, Year, Title, DOI/URL) exists in `docs/papers/references.md`. Where no entry exists, add it (or a local PDF under a `papers/` subdirectory) before declaring the ontology citation-complete.
+
+Open items for human review:
+
+- [ ] Cross-check every primary source against `docs/papers/references.md`
+- [ ] Add code-comment-level citations (`// Source: ...`) to axioms that currently lack attribution
+- [ ] If this ontology depends on a paper not yet in the workspace bibliography, move/copy the PDF into a local `papers/` subdirectory and link it from the primary source line above
+
+---
+
+- **Document date:** 2026-04-15
+- **How this file is maintained:** initialized by the per-ontology rollout (issue #57 / #173) from `README.md`'s *Key references* section. Update by hand as code-comment citations, local PDFs, and `docs/papers/references.md` entries are added.

--- a/crates/domains/src/applied/hmi/report/README.md
+++ b/crates/domains/src/applied/hmi/report/README.md
@@ -1,0 +1,58 @@
+# Report -- Data → visualization → surface → frozen artifact pipeline
+
+Models the act of validating ontology data against axioms, picking visual encodings via the visualization ontology, rendering to a target surface, and freezing the result as a report (JSON, HTML, SVG, PDF). The report is a **functor** from `ValidationResults → OutputFormat`; different surfaces consume the same underlying data through different branches of the functor.
+
+The three sub-modules break the pipeline into inert stages:
+
+1. **`validator.rs`** — runs axioms over ontology instances, emits `ThemeResult` / `ValidationDetail` records
+2. **`spec.rs`** — picks visual encodings per data level using the visualization ontology, produces a `ReportSpec`
+3. **`generator.rs`** — renders a `ReportSpec` + results into a target format (JSON, HTML), styled from the active theme via `ThemePalette`
+
+This is pr4xis's prior art for "the report as a forgetful functor from dynamic ontology state to a frozen artifact" — see also `formal/meta/staging/` which lifts this pattern to Futamura's partial-evaluation framework.
+
+Key references:
+- W3C EARL 1.0 — *Evaluation And Report Language*: `earl:Assertion`, `earl:subject`, `earl:test`, `earl:result`
+- Vega-Lite 2017 (Satyanarayan et al.) — declarative visualization grammar
+- Wickham 2010 — *Layered Grammar of Graphics*
+- Shneiderman 1996 — overview-zoom-filter-details mantra
+- Tufte 1983 — *The Visual Display of Quantitative Information*: data-ink ratio
+
+## Entities
+
+| Category | Entities |
+|---|---|
+| Validation (`validator.rs`) | `ThemeResult { theme, variant, scheme, … }`, `ValidationDetail { monotone, wcag_aa, contrast_ratio, … }` |
+| Specification (`spec.rs`) | `DataField { name, level, description }`, `EncodingAssignment { field, variable, geom, rank }`, `ReportSpec { name, assignments, interaction_level }` |
+| Generation (`generator.rs`) | `ThemePalette { bg, card, border, pass, fail, … }`, `Report` serialized output |
+
+## Axioms
+
+| Axiom | Description | Source |
+|---|---|---|
+| (structural) | Identity and composition laws over the report pipeline | auto-generated |
+| DefaultIsOptimal | The default encoding assignment for a given data level is the Cleveland-McGill top-ranked perceptual task | Cleveland & McGill 1984 |
+| OverrideMustBeNoWorse | A human-authored encoding override must rank at least as high as the default (no worse) | soft guarantee |
+| DataInkRatioBounded | Generated HTML reports cap non-data chrome to < 30% of total ink | Tufte 1983 |
+
+See `spec.rs` and `generator.rs` for the `impl Axiom for …` blocks.
+
+## Functors
+
+No cross-domain functors yet — see [Compose via functor](../../../../../../docs/use/compose-via-functor.md) to add one. The report ontology is the **consumer** of:
+
+- `applied/hmi/theming/` — supplies the `ThemePalette` used for styling
+- `applied/hmi/visualization/` — supplies `DataLevel`, `VisualVariable`, `GeomType`, `AccuracyRank`, `InteractionLevel`
+- `applied/hmi/surfaces/` — supplies the concrete render target (HTML string, JSON, PDF, …)
+
+And a producer of frozen artifacts. A future PR (#60) will wire this into CI so every test run refreshes a live `pr4xis-report.json` on GitHub Pages.
+
+## Files
+
+- `generator.rs` -- `ThemePalette`, HTML/JSON rendering, the functor `ValidationResults → OutputFormat`
+- `spec.rs` -- `DataField`, `EncodingAssignment`, `ReportSpec`, the functor `DataOntology → VisualizationOntology → RenderSurface`
+- `validator.rs` -- `ThemeResult`, `ValidationDetail`, `scan_themes(path)` — loads themes and runs the theming axioms
+- `README.md` -- this file
+- `citings.md` -- per-ontology bibliography
+- `mod.rs` -- module declarations
+
+Previous home: `applied/theming/report.rs` + `report_spec.rs` + `validate_themes.rs`, moved (and renamed) here by [#66](https://github.com/i-am-logger/pr4xis/pull/66).

--- a/crates/domains/src/applied/hmi/report/citings.md
+++ b/crates/domains/src/applied/hmi/report/citings.md
@@ -1,0 +1,32 @@
+# Citings — Report -- Data → visualization → surface → frozen artifact pipeline
+
+Every published source this ontology stands on. Entries below are drawn from the ontology's [README.md](README.md) and the doc comments on its axioms. Where a full bibliographic entry exists in the workspace-wide [`docs/papers/references.md`](../../../../../../docs/papers/references.md), the short form here is a pointer.
+
+## Primary sources
+
+- W3C EARL 1.0 — *Evaluation And Report Language*: `earl:Assertion`, `earl:subject`, `earl:test`, `earl:result`
+- Vega-Lite 2017 (Satyanarayan et al.) — declarative visualization grammar
+- Wickham 2010 — *Layered Grammar of Graphics*
+- Shneiderman 1996 — overview-zoom-filter-details mantra
+- Tufte 1983 — *The Visual Display of Quantitative Information*: data-ink ratio
+
+## Cross-references
+
+- Workspace bibliography: [`docs/papers/references.md`](../../../../../../docs/papers/references.md)
+- Source attributions per axiom: see the `Source` column in the `## Axioms` table in [`README.md`](README.md)
+- Code-level citations: `grep -n 'Source:\|Reference:' *.rs` in this directory
+
+## Pending verification
+
+Every entry under **Primary sources** is a short pointer. For each one, confirm that a full citation (Author, Year, Title, DOI/URL) exists in `docs/papers/references.md`. Where no entry exists, add it (or a local PDF under a `papers/` subdirectory) before declaring the ontology citation-complete.
+
+Open items for human review:
+
+- [ ] Cross-check every primary source against `docs/papers/references.md`
+- [ ] Add code-comment-level citations (`// Source: ...`) to axioms that currently lack attribution
+- [ ] If this ontology depends on a paper not yet in the workspace bibliography, move/copy the PDF into a local `papers/` subdirectory and link it from the primary source line above
+
+---
+
+- **Document date:** 2026-04-15
+- **How this file is maintained:** initialized by the per-ontology rollout (issue #57 / #173) from `README.md`'s *Key references* section. Update by hand as code-comment citations, local PDFs, and `docs/papers/references.md` entries are added.

--- a/crates/domains/src/applied/hmi/surfaces/README.md
+++ b/crates/domains/src/applied/hmi/surfaces/README.md
@@ -1,0 +1,55 @@
+# Surfaces -- Abstract render targets for theming and content pipelines
+
+A `Surface` is anything that renders colors and content from a theme palette: terminal emulators, window managers, hardware RGB devices, shaders, browsers, chat UIs, PDF generators. Theme application is a **functor** from `ThemeCategory` to `SurfaceCategory`; a theme change is a **natural transformation** that updates all surface functors consistently.
+
+This ontology defines the abstract framework. Concrete surfaces (wezterm, hyprland, openrgb, etc.) are instances of the framework.
+
+Key references:
+- Mac Lane 1971: *Categories for the Working Mathematician* — functors, natural transformations
+- Harel 1987: *Statecharts: a visual formalism for complex systems* — parallel regions (surfaces update simultaneously)
+- Czaplicki & Chong 2013: *Async FRP for GUIs* (PLDI 2013) — synchronous vs asynchronous propagation
+- Beaudouin-Lafon 2000: *Instrumental Interaction* (CHI 2000) — the interaction-algebra framing
+- Thimbleby 2004: *User Interface Design with Matrix Algebra* (ACM TOCHI)
+
+## Entities
+
+| Category | Entities |
+|---|---|
+| Capabilities | `SurfaceCapability` — Ansi16, TrueColor, HdrRgb, AlphaBlending, GpuShader, … |
+| Types | `SurfaceType { name, capabilities }` — concrete render target |
+| Mappings | `SlotMapping { slot, key, transform }` — slot → surface-specific key |
+| Transforms | `ColorTransform` — Hex, RrGgBb, Rgba, HexNoHash, Srgb |
+| Functor | `SurfaceFunctor { surface, mappings }` — a concrete theme→surface functor |
+| Naturality | `ThemeChangeNaturality { functors }` — the natural transformation over all functors |
+
+## Category
+
+`SurfaceCategory` is discrete over `SurfaceType` objects. Morphisms are the `SurfaceFunctor` instances — each pairing a palette slot with a surface-specific configuration key and a color transform. Composition threads `SlotMapping`s; identity is the empty mapping set.
+
+## Qualities
+
+| Quality | Type | Description |
+|---|---|---|
+| SlotCoverage | usize | How many palette slots a given `SurfaceCapability` covers (e.g., `Ansi16` covers 16, `TrueColor` covers all 24) |
+
+## Axioms
+
+| Axiom | Description | Source |
+|---|---|---|
+| (structural) | Identity and composition laws over `SurfaceCategory` | auto-generated |
+| ThemeChangeIsNatural | Changing the active theme updates every surface functor in parallel, preserving the naturality square | Mac Lane 1971 |
+
+Domain axioms and their `impl Axiom for` blocks live in `ontology.rs`; the category-law check is via the auto-generated `check_category_laws::<SurfaceCategory>`.
+
+## Functors
+
+No cross-domain functors yet — see [Compose via functor](../../../../../../docs/use/compose-via-functor.md) to add one. The surfaces ontology is the **target** of the theme-application functor from `applied/hmi/theming/`: each concrete surface (wezterm, hyprland, ghostty, kitty, chromium userstyle, etc.) receives the active palette through a `SurfaceFunctor` instance. A future PR will add `BrowserSurface`, `ChatSurface`, `PDFSurface`, and `PrintSurface` for the pr4xis.dev site work — each will be a new `SurfaceType` instance.
+
+## Files
+
+- `ontology.rs` -- `SurfaceCapability`, `SurfaceType`, `SlotMapping`, `ColorTransform`, `SurfaceFunctor`, `ThemeChangeNaturality`, `SlotCoverage`, category impl, tests
+- `README.md` -- this file
+- `citings.md` -- per-ontology bibliography
+- `mod.rs` -- module declarations
+
+Previous home: `applied/theming/surfaces.rs`, moved here by [#66](https://github.com/i-am-logger/pr4xis/pull/66).

--- a/crates/domains/src/applied/hmi/surfaces/citings.md
+++ b/crates/domains/src/applied/hmi/surfaces/citings.md
@@ -1,0 +1,32 @@
+# Citings — Surfaces -- Abstract render targets for theming and content pipelines
+
+Every published source this ontology stands on. Entries below are drawn from the ontology's [README.md](README.md) and the doc comments on its axioms. Where a full bibliographic entry exists in the workspace-wide [`docs/papers/references.md`](../../../../../../docs/papers/references.md), the short form here is a pointer.
+
+## Primary sources
+
+- Mac Lane 1971: *Categories for the Working Mathematician* — functors, natural transformations
+- Harel 1987: *Statecharts: a visual formalism for complex systems* — parallel regions (surfaces update simultaneously)
+- Czaplicki & Chong 2013: *Async FRP for GUIs* (PLDI 2013) — synchronous vs asynchronous propagation
+- Beaudouin-Lafon 2000: *Instrumental Interaction* (CHI 2000) — the interaction-algebra framing
+- Thimbleby 2004: *User Interface Design with Matrix Algebra* (ACM TOCHI)
+
+## Cross-references
+
+- Workspace bibliography: [`docs/papers/references.md`](../../../../../../docs/papers/references.md)
+- Source attributions per axiom: see the `Source` column in the `## Axioms` table in [`README.md`](README.md)
+- Code-level citations: `grep -n 'Source:\|Reference:' *.rs` in this directory
+
+## Pending verification
+
+Every entry under **Primary sources** is a short pointer. For each one, confirm that a full citation (Author, Year, Title, DOI/URL) exists in `docs/papers/references.md`. Where no entry exists, add it (or a local PDF under a `papers/` subdirectory) before declaring the ontology citation-complete.
+
+Open items for human review:
+
+- [ ] Cross-check every primary source against `docs/papers/references.md`
+- [ ] Add code-comment-level citations (`// Source: ...`) to axioms that currently lack attribution
+- [ ] If this ontology depends on a paper not yet in the workspace bibliography, move/copy the PDF into a local `papers/` subdirectory and link it from the primary source line above
+
+---
+
+- **Document date:** 2026-04-15
+- **How this file is maintained:** initialized by the per-ontology rollout (issue #57 / #173) from `README.md`'s *Key references* section. Update by hand as code-comment citations, local PDFs, and `docs/papers/references.md` entries are added.

--- a/crates/domains/src/applied/hmi/visualization/README.md
+++ b/crates/domains/src/applied/hmi/visualization/README.md
@@ -1,0 +1,59 @@
+# Visualization -- Formal model of visual encoding and perception
+
+Formalizes the foundational visualization literature as ontological structures with axioms that can be verified and composed. The four pillars: Bertin's visual variables, Cleveland & McGill's perceptual accuracy ranking, Munzner's channel effectiveness, and Wickham's layered grammar of graphics.
+
+The visualization ontology is the **middle layer** of the HMI stack: data-with-measurement-levels flows in from ontologies, visual encodings are chosen, geometry is composed via the grammar-of-graphics pipeline, and the result is rendered onto a surface via the `surfaces` ontology. Each stage is a functor.
+
+Key references:
+- Bertin 1967: *Semiology of Graphics* — the 7 visual variables
+- Cleveland & McGill 1984: *Graphical Perception* (JASA 79:387) — perceptual accuracy ranking
+- Munzner 2014: *Visualization Analysis and Design* — channel effectiveness, nested model
+- Shneiderman 1996: *The Eyes Have It* (IEEE VL) — overview-zoom-filter-details mantra
+- Wickham 2010: *A Layered Grammar of Graphics* (J Comp Graph Stat 19:3) — compositional pipeline
+- Stevens 1946: *On the Theory of Scales of Measurement* — nominal/ordinal/interval/ratio
+
+## Entities
+
+| Category | Entities |
+|---|---|
+| Bertin's visual variables (7) | Position, Size, Value, Texture, Color, Orientation, Shape |
+| Perceptual tasks (6) | PositionCommonScale, PositionNonAligned, Length, Angle, Area, Volume |
+| Data levels (Stevens) (4) | Nominal, Ordinal, Interval, Ratio |
+| Geometry types | Point, Line, Bar, Area, Text, Rect |
+| Interaction levels (Shneiderman) | Overview, ZoomFilter, DetailsOnDemand |
+| Grammar layers (Wickham) | Data, Aesthetics, Geom, Stat, Scale, Coord, Facet |
+
+## Qualities
+
+| Quality | Type | Description |
+|---|---|---|
+| BertinProperties | `VariableProperties` | Per visual variable: associative (can group), selective (can isolate), ordered (has natural order), quantitative (supports magnitude judgment), length/size of alphabet |
+| AccuracyRank | usize | Cleveland-McGill perceptual task ranking (1 = most accurate, 6 = least) |
+| GeomUseCase | &'static str | Recommended geom for each data-level × interaction-level combination |
+| RecommendedVis | &'static str | Interaction-level → recommended overview/zoom/detail geom (Shneiderman) |
+| PipelineOrder | usize | Wickham grammar-of-graphics layer order (Data → Aesthetics → … → Facet) |
+
+## Axioms
+
+| Axiom | Description | Source |
+|---|---|---|
+| (structural) | Identity and composition laws | auto-generated |
+| PositionIsMostAccurate | `PositionCommonScale` ranks first in Cleveland-McGill's perceptual hierarchy | Cleveland & McGill 1984 |
+| AreaIsLessAccurateThanLength | Length judgments beat area judgments | Cleveland & McGill 1984 |
+| ShneidermanMantraOrdered | Overview → ZoomFilter → DetailsOnDemand in that order | Shneiderman 1996 |
+| GrammarLayersOrdered | Wickham's pipeline is strictly ordered: Data precedes everything, Facet is last | Wickham 2010 |
+
+See `ontology.rs` for the full `impl Axiom for …` blocks.
+
+## Functors
+
+No cross-domain functors yet — see [Compose via functor](../../../../../../docs/use/compose-via-functor.md) to add one. The visualization ontology is consumed by `applied/hmi/report/spec.rs` (which picks encoding grammar from data level) and by `applied/hmi/explorer/ontology.rs` (which uses the visual-variables + accuracy ranking to lay out the reasoning-trace graph).
+
+## Files
+
+- `ontology.rs` -- `VisualVariable`, `PerceptualTask`, `DataLevel`, `GeomType`, `InteractionLevel`, `GrammarLayer`, qualities, axioms, tests
+- `README.md` -- this file
+- `citings.md` -- per-ontology bibliography
+- `mod.rs` -- module declarations
+
+Previous home: `applied/theming/visualization.rs`, moved here by [#66](https://github.com/i-am-logger/pr4xis/pull/66).

--- a/crates/domains/src/applied/hmi/visualization/citings.md
+++ b/crates/domains/src/applied/hmi/visualization/citings.md
@@ -1,0 +1,33 @@
+# Citings — Visualization -- Formal model of visual encoding and perception
+
+Every published source this ontology stands on. Entries below are drawn from the ontology's [README.md](README.md) and the doc comments on its axioms. Where a full bibliographic entry exists in the workspace-wide [`docs/papers/references.md`](../../../../../../docs/papers/references.md), the short form here is a pointer.
+
+## Primary sources
+
+- Bertin 1967: *Semiology of Graphics* — the 7 visual variables
+- Cleveland & McGill 1984: *Graphical Perception* (JASA 79:387) — perceptual accuracy ranking
+- Munzner 2014: *Visualization Analysis and Design* — channel effectiveness, nested model
+- Shneiderman 1996: *The Eyes Have It* (IEEE VL) — overview-zoom-filter-details mantra
+- Wickham 2010: *A Layered Grammar of Graphics* (J Comp Graph Stat 19:3) — compositional pipeline
+- Stevens 1946: *On the Theory of Scales of Measurement* — nominal/ordinal/interval/ratio
+
+## Cross-references
+
+- Workspace bibliography: [`docs/papers/references.md`](../../../../../../docs/papers/references.md)
+- Source attributions per axiom: see the `Source` column in the `## Axioms` table in [`README.md`](README.md)
+- Code-level citations: `grep -n 'Source:\|Reference:' *.rs` in this directory
+
+## Pending verification
+
+Every entry under **Primary sources** is a short pointer. For each one, confirm that a full citation (Author, Year, Title, DOI/URL) exists in `docs/papers/references.md`. Where no entry exists, add it (or a local PDF under a `papers/` subdirectory) before declaring the ontology citation-complete.
+
+Open items for human review:
+
+- [ ] Cross-check every primary source against `docs/papers/references.md`
+- [ ] Add code-comment-level citations (`// Source: ...`) to axioms that currently lack attribution
+- [ ] If this ontology depends on a paper not yet in the workspace bibliography, move/copy the PDF into a local `papers/` subdirectory and link it from the primary source line above
+
+---
+
+- **Document date:** 2026-04-15
+- **How this file is maintained:** initialized by the per-ontology rollout (issue #57 / #173) from `README.md`'s *Key references* section. Update by hand as code-comment citations, local PDFs, and `docs/papers/references.md` entries are added.


### PR DESCRIPTION
## Summary

Adds `README.md` + `citings.md` for each of the five sibling sub-ontologies created by #66's `applied/theming/` → `applied/hmi/` restructure. Closes the per-ontology-rollout gap from #66's follow-up list.

| Sub-ontology | What it models | Key references |
|---|---|---|
| `hmi/surfaces/` | Abstract render targets (terminal, WM, hardware RGB, shaders, browser, chat, PDF, print). Theme application as functor from `ThemeCategory` to `SurfaceCategory`. | Mac Lane 1971, Harel 1987, Czaplicki-Chong 2013, Beaudouin-Lafon 2000, Thimbleby 2004 |
| `hmi/visualization/` | Bertin visual variables, Cleveland-McGill perceptual ranking, Munzner channels, Shneiderman mantra, Wickham grammar of graphics. | Bertin 1967, Cleveland-McGill 1984, Munzner 2014, Shneiderman 1996, Wickham 2010, Stevens 1946 |
| `hmi/input/` | Modes (Harel 1987 statecharts) + keybindings. Interaction algebra for any modal surface. | Harel 1987, Thimbleby 2004, Raskin 2000, Beaudouin-Lafon 2000, ECMA-48, VT520 |
| `hmi/report/` | Data → visualization → surface → frozen artifact pipeline. Sub-modules: validator, spec, generator. | W3C EARL, Vega-Lite 2017, Wickham 2010, Shneiderman 1996, Tufte 1983 |
| `hmi/explorer/` | Self-referential visualization of reasoning traces. Colors its own nodes with the active theme — a small reflective tower. | Evonne (Mendez 2023), NeuroVis, TensorFlow Graph Visualizer, Beck 2017, Smith 1984, W3C PROV-O |

## Pattern

Each README follows the established biomedical pattern: title + one-line description, one paragraph, Key references bullet list, Entities table (by subcategory), Qualities table, Axioms table with Source column, Functors section, Files index, pointer back to the pre-#66 home.

Each `citings.md` is generated from the README's Key references section via the same mechanical transform used for the 103-file citings rollout in #57. Open items for human verification are tracked in the "Pending verification" checklist.

## Test plan

- [x] `cargo test -p pr4xis-domains --lib` — 4397 passed, 17 ignored
- [x] All 10 new markdown files machine-verified for link resolution:
  - `../../../../../../docs/use/compose-via-functor.md` resolves
  - `../../../../../../docs/papers/references.md` resolves

Closes #173