### PR TITLE
feat: ontology! proc macro — fluent syntax with static codegen (#103)

### DIFF
--- a/crates/pr4xis-derive/src/lib.rs
+++ b/crates/pr4xis-derive/src/lib.rs
@@ -1,3 +1,5 @@
+mod ontology;
+
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{Data, DeriveInput, Fields};
@@ -51,4 +53,31 @@ pub fn derive_entity(input: TokenStream) -> TokenStream {
     };
 
     expanded.into()
+}
+
+/// Define an ontology with compile-time validation and static code generation.
+///
+/// Generates: Entity enum, Category impl, Relationship impl, reasoning systems,
+/// structural axioms, Vocabulary, and Lemon lexical data — all static.
+///
+/// Concept names in edges/is_a/has_a/causes/opposes are validated at compile time.
+///
+/// # Example
+///
+/// ```ignore
+/// pr4xis::ontology! {
+///     name: "Biology",
+///     source: "Mayr (1982)",
+///     being: AbstractObject,
+///     concepts: [Cell, Tissue, Organism],
+///     labels: {
+///         Cell: ("en", "Cell", "The basic structural unit"),
+///     },
+///     is_a: [(Cell, Tissue), (Tissue, Organism)],
+/// }
+/// ```
+#[proc_macro]
+pub fn ontology(input: TokenStream) -> TokenStream {
+    let def = syn::parse_macro_input!(input as ontology::OntologyDef);
+    ontology::generate(def).into()
 }

--- a/crates/pr4xis-derive/src/ontology.rs
+++ b/crates/pr4xis-derive/src/ontology.rs
@@ -1,0 +1,641 @@
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::{Ident, LitStr, Token, braced, bracketed, parenthesized};
+
+struct LabelEntry {
+    concept: Ident,
+    lang: LitStr,
+    label: LitStr,
+    definition: Option<LitStr>,
+}
+
+impl Parse for LabelEntry {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let concept: Ident = input.parse()?;
+        input.parse::<Token![:]>()?;
+        let content;
+        parenthesized!(content in input);
+        let lang: LitStr = content.parse()?;
+        content.parse::<Token![,]>()?;
+        let label: LitStr = content.parse()?;
+        let definition = if content.peek(Token![,]) {
+            content.parse::<Token![,]>()?;
+            Some(content.parse::<LitStr>()?)
+        } else {
+            None
+        };
+        Ok(LabelEntry {
+            concept,
+            lang,
+            label,
+            definition,
+        })
+    }
+}
+
+struct EdgeEntry {
+    from: Ident,
+    to: Ident,
+    kind: Ident,
+}
+
+impl Parse for EdgeEntry {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let content;
+        parenthesized!(content in input);
+        let from: Ident = content.parse()?;
+        content.parse::<Token![,]>()?;
+        let to: Ident = content.parse()?;
+        content.parse::<Token![,]>()?;
+        let kind: Ident = content.parse()?;
+        Ok(EdgeEntry { from, to, kind })
+    }
+}
+
+struct PairEntry {
+    a: Ident,
+    b: Ident,
+}
+
+impl Parse for PairEntry {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let content;
+        parenthesized!(content in input);
+        let a: Ident = content.parse()?;
+        content.parse::<Token![,]>()?;
+        let b: Ident = content.parse()?;
+        Ok(PairEntry { a, b })
+    }
+}
+
+struct ComposedEntry {
+    from: Ident,
+    to: Ident,
+}
+
+impl Parse for ComposedEntry {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let content;
+        parenthesized!(content in input);
+        let from: Ident = content.parse()?;
+        content.parse::<Token![,]>()?;
+        let to: Ident = content.parse()?;
+        Ok(ComposedEntry { from, to })
+    }
+}
+
+pub struct OntologyDef {
+    name: LitStr,
+    source: Option<LitStr>,
+    being: Option<Ident>,
+    concepts: Vec<Ident>,
+    labels: Vec<LabelEntry>,
+    edges: Vec<EdgeEntry>,
+    composed: Vec<ComposedEntry>,
+    is_a: Vec<PairEntry>,
+    has_a: Vec<PairEntry>,
+    causes: Vec<PairEntry>,
+    opposes: Vec<PairEntry>,
+}
+
+impl Parse for OntologyDef {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut name = None;
+        let mut source = None;
+        let mut being = None;
+        let mut concepts = Vec::new();
+        let mut labels = Vec::new();
+        let mut edges = Vec::new();
+        let mut composed = Vec::new();
+        let mut is_a = Vec::new();
+        let mut has_a = Vec::new();
+        let mut causes = Vec::new();
+        let mut opposes = Vec::new();
+
+        while !input.is_empty() {
+            let key: Ident = input.parse()?;
+            input.parse::<Token![:]>()?;
+
+            match key.to_string().as_str() {
+                "name" => {
+                    name = Some(input.parse::<LitStr>()?);
+                }
+                "source" => {
+                    source = Some(input.parse::<LitStr>()?);
+                }
+                "being" => {
+                    being = Some(input.parse::<Ident>()?);
+                }
+                "concepts" => {
+                    let content;
+                    bracketed!(content in input);
+                    concepts = Punctuated::<Ident, Token![,]>::parse_terminated(&content)?
+                        .into_iter()
+                        .collect();
+                }
+                "labels" => {
+                    let content;
+                    braced!(content in input);
+                    labels = Punctuated::<LabelEntry, Token![,]>::parse_terminated(&content)?
+                        .into_iter()
+                        .collect();
+                }
+                "edges" => {
+                    let content;
+                    bracketed!(content in input);
+                    edges = Punctuated::<EdgeEntry, Token![,]>::parse_terminated(&content)?
+                        .into_iter()
+                        .collect();
+                }
+                "composed" => {
+                    let content;
+                    bracketed!(content in input);
+                    composed = Punctuated::<ComposedEntry, Token![,]>::parse_terminated(&content)?
+                        .into_iter()
+                        .collect();
+                }
+                "is_a" => {
+                    let content;
+                    bracketed!(content in input);
+                    is_a = Punctuated::<PairEntry, Token![,]>::parse_terminated(&content)?
+                        .into_iter()
+                        .collect();
+                }
+                "has_a" => {
+                    let content;
+                    bracketed!(content in input);
+                    has_a = Punctuated::<PairEntry, Token![,]>::parse_terminated(&content)?
+                        .into_iter()
+                        .collect();
+                }
+                "causes" => {
+                    let content;
+                    bracketed!(content in input);
+                    causes = Punctuated::<PairEntry, Token![,]>::parse_terminated(&content)?
+                        .into_iter()
+                        .collect();
+                }
+                "opposes" => {
+                    let content;
+                    bracketed!(content in input);
+                    opposes = Punctuated::<PairEntry, Token![,]>::parse_terminated(&content)?
+                        .into_iter()
+                        .collect();
+                }
+                other => {
+                    return Err(syn::Error::new_spanned(
+                        &key,
+                        format!("unknown field: {other}"),
+                    ));
+                }
+            }
+
+            if input.peek(Token![,]) {
+                input.parse::<Token![,]>()?;
+            }
+        }
+
+        let name = name.ok_or_else(|| input.error("missing required field: name"))?;
+
+        Ok(OntologyDef {
+            name,
+            source,
+            being,
+            concepts,
+            labels,
+            edges,
+            composed,
+            is_a,
+            has_a,
+            causes,
+            opposes,
+        })
+    }
+}
+
+pub fn generate(def: OntologyDef) -> TokenStream {
+    let name_str = def.name.value();
+    let ont_name = format_ident!("{}Ontology", name_str);
+    let cat_name = format_ident!("{}Category", name_str);
+    let entity_name = format_ident!("{}Concept", name_str);
+    let relation_name = format_ident!("{}Relation", name_str);
+
+    let concept_idents = &def.concepts;
+    let concept_names: Vec<String> = concept_idents.iter().map(|c| c.to_string()).collect();
+
+    // Validate that edges/is_a/has_a/causes/opposes reference declared concepts
+    let concept_set: std::collections::HashSet<String> = concept_names.iter().cloned().collect();
+
+    for edge in &def.edges {
+        if !concept_set.contains(&edge.from.to_string()) {
+            return syn::Error::new_spanned(
+                &edge.from,
+                format!("concept '{}' not declared in concepts list", edge.from),
+            )
+            .to_compile_error();
+        }
+        if !concept_set.contains(&edge.to.to_string()) {
+            return syn::Error::new_spanned(
+                &edge.to,
+                format!("concept '{}' not declared in concepts list", edge.to),
+            )
+            .to_compile_error();
+        }
+    }
+
+    for pair in def
+        .is_a
+        .iter()
+        .chain(def.has_a.iter())
+        .chain(def.causes.iter())
+        .chain(def.opposes.iter())
+    {
+        if !concept_set.contains(&pair.a.to_string()) {
+            return syn::Error::new_spanned(
+                &pair.a,
+                format!("concept '{}' not declared in concepts list", pair.a),
+            )
+            .to_compile_error();
+        }
+        if !concept_set.contains(&pair.b.to_string()) {
+            return syn::Error::new_spanned(
+                &pair.b,
+                format!("concept '{}' not declared in concepts list", pair.b),
+            )
+            .to_compile_error();
+        }
+    }
+
+    for label in &def.labels {
+        if !concept_set.contains(&label.concept.to_string()) {
+            return syn::Error::new_spanned(
+                &label.concept,
+                format!("concept '{}' not declared in concepts list", label.concept),
+            )
+            .to_compile_error();
+        }
+    }
+
+    let has_custom_edges = !def.edges.is_empty();
+
+    // Collect unique edge kinds
+    let edge_kinds: Vec<&Ident> = def.edges.iter().map(|e| &e.kind).collect();
+    let unique_kinds: Vec<&Ident> = {
+        let mut seen = std::collections::HashSet::new();
+        edge_kinds
+            .iter()
+            .filter(|k| seen.insert(k.to_string()))
+            .copied()
+            .collect()
+    };
+
+    // Generate label static data
+    let label_entries: Vec<TokenStream> = def
+        .labels
+        .iter()
+        .map(|l| {
+            let concept = &l.concept;
+            let lang = &l.lang;
+            let label = &l.label;
+            let def_str = l
+                .definition
+                .as_ref()
+                .map(|d| quote! { #d })
+                .unwrap_or(quote! { "" });
+            quote! {
+                (#entity_name::#concept, #lang, #label, #def_str)
+            }
+        })
+        .collect();
+
+    // Source and being
+    let source_tokens = def
+        .source
+        .as_ref()
+        .map(|s| quote! { #s })
+        .unwrap_or(quote! { "" });
+
+    let being_tokens = if let Some(ref b) = def.being {
+        quote! { Some(pr4xis::ontology::upper::being::Being::#b) }
+    } else {
+        quote! { None }
+    };
+
+    let being_classified = def.being.as_ref().map(|b| {
+        quote! {
+            impl pr4xis::ontology::upper::classify::Classified for #cat_name {
+                fn being() -> pr4xis::ontology::upper::being::Being {
+                    pr4xis::ontology::upper::being::Being::#b
+                }
+                fn classification_reason() -> &'static str {
+                    concat!("DOLCE D18 ", stringify!(#b), "; ", module_path!())
+                }
+            }
+        }
+    });
+
+    // Generate taxonomy
+    let tax_name = format_ident!("{}Taxonomy", name_str);
+    let tax_pairs: Vec<TokenStream> = def
+        .is_a
+        .iter()
+        .map(|p| {
+            let a = &p.a;
+            let b = &p.b;
+            quote! { (#entity_name::#a, #entity_name::#b) }
+        })
+        .collect();
+    let has_taxonomy = !def.is_a.is_empty();
+
+    // Generate mereology
+    let mer_name = format_ident!("{}Mereology", name_str);
+    let mer_pairs: Vec<TokenStream> = def
+        .has_a
+        .iter()
+        .map(|p| {
+            let a = &p.a;
+            let b = &p.b;
+            quote! { (#entity_name::#a, #entity_name::#b) }
+        })
+        .collect();
+    let has_mereology = !def.has_a.is_empty();
+
+    // Generate causation
+    let caus_name = format_ident!("{}Causation", name_str);
+    let caus_pairs: Vec<TokenStream> = def
+        .causes
+        .iter()
+        .map(|p| {
+            let a = &p.a;
+            let b = &p.b;
+            quote! { (#entity_name::#a, #entity_name::#b) }
+        })
+        .collect();
+    let has_causation = !def.causes.is_empty();
+
+    // Generate opposition
+    let opp_name = format_ident!("{}Opposition", name_str);
+    let opp_pairs: Vec<TokenStream> = def
+        .opposes
+        .iter()
+        .map(|p| {
+            let a = &p.a;
+            let b = &p.b;
+            quote! { (#entity_name::#a, #entity_name::#b) }
+        })
+        .collect();
+    let has_opposition = !def.opposes.is_empty();
+
+    // Category generation — kinded or dense
+    let category_impl = if has_custom_edges {
+        let kind_name = format_ident!("{}RelationKind", name_str);
+        let edge_from: Vec<&Ident> = def.edges.iter().map(|e| &e.from).collect();
+        let edge_to: Vec<&Ident> = def.edges.iter().map(|e| &e.to).collect();
+        let edge_kind: Vec<&Ident> = def.edges.iter().map(|e| &e.kind).collect();
+        let comp_from: Vec<&Ident> = def.composed.iter().map(|c| &c.from).collect();
+        let comp_to: Vec<&Ident> = def.composed.iter().map(|c| &c.to).collect();
+
+        quote! {
+            #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+            pub enum #kind_name {
+                Identity,
+                #(#unique_kinds,)*
+                Composed,
+            }
+
+            #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+            pub struct #relation_name {
+                pub from: #entity_name,
+                pub to: #entity_name,
+                pub kind: #kind_name,
+            }
+
+            impl pr4xis::category::Relationship for #relation_name {
+                type Object = #entity_name;
+                fn source(&self) -> #entity_name { self.from }
+                fn target(&self) -> #entity_name { self.to }
+            }
+
+            pub struct #cat_name;
+
+            impl pr4xis::category::Category for #cat_name {
+                type Object = #entity_name;
+                type Morphism = #relation_name;
+
+                fn identity(obj: &#entity_name) -> #relation_name {
+                    #relation_name { from: *obj, to: *obj, kind: #kind_name::Identity }
+                }
+
+                fn compose(f: &#relation_name, g: &#relation_name) -> Option<#relation_name> {
+                    if f.to != g.from { return None; }
+                    if f.kind == #kind_name::Identity { return Some(g.clone()); }
+                    if g.kind == #kind_name::Identity { return Some(f.clone()); }
+                    Some(#relation_name { from: f.from, to: g.to, kind: #kind_name::Composed })
+                }
+
+                fn morphisms() -> Vec<#relation_name> {
+                    use pr4xis::category::Entity;
+                    let mut m = Vec::new();
+                    for c in #entity_name::variants() {
+                        m.push(#relation_name { from: c, to: c, kind: #kind_name::Identity });
+                    }
+                    #(m.push(#relation_name { from: #entity_name::#edge_from, to: #entity_name::#edge_to, kind: #kind_name::#edge_kind });)*
+                    #(m.push(#relation_name { from: #entity_name::#comp_from, to: #entity_name::#comp_to, kind: #kind_name::Composed });)*
+                    for c in #entity_name::variants() {
+                        m.push(#relation_name { from: c, to: c, kind: #kind_name::Composed });
+                    }
+                    m
+                }
+            }
+        }
+    } else {
+        // Dense category
+        quote! {
+            #[derive(Debug, Clone, PartialEq, Eq)]
+            pub struct #relation_name {
+                pub from: #entity_name,
+                pub to: #entity_name,
+            }
+
+            impl pr4xis::category::Relationship for #relation_name {
+                type Object = #entity_name;
+                fn source(&self) -> #entity_name { self.from }
+                fn target(&self) -> #entity_name { self.to }
+            }
+
+            pub struct #cat_name;
+
+            impl pr4xis::category::Category for #cat_name {
+                type Object = #entity_name;
+                type Morphism = #relation_name;
+
+                fn identity(obj: &#entity_name) -> #relation_name {
+                    #relation_name { from: *obj, to: *obj }
+                }
+
+                fn compose(f: &#relation_name, g: &#relation_name) -> Option<#relation_name> {
+                    if f.to != g.from { return None; }
+                    Some(#relation_name { from: f.from, to: g.to })
+                }
+
+                fn morphisms() -> Vec<#relation_name> {
+                    use pr4xis::category::Entity;
+                    let variants = #entity_name::variants();
+                    variants.iter()
+                        .flat_map(|&a| variants.iter().map(move |&b| #relation_name { from: a, to: b }))
+                        .collect()
+                }
+            }
+        }
+    };
+
+    // Reasoning systems
+    let taxonomy_impl = if has_taxonomy {
+        quote! {
+            pub struct #tax_name;
+            impl pr4xis::ontology::reasoning::taxonomy::TaxonomyDef for #tax_name {
+                type Entity = #entity_name;
+                fn relations() -> Vec<(#entity_name, #entity_name)> {
+                    vec![#(#tax_pairs),*]
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
+
+    let mereology_impl = if has_mereology {
+        quote! {
+            pub struct #mer_name;
+            impl pr4xis::ontology::reasoning::mereology::MereologyDef for #mer_name {
+                type Entity = #entity_name;
+                fn relations() -> Vec<(#entity_name, #entity_name)> {
+                    vec![#(#mer_pairs),*]
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
+
+    let causation_impl = if has_causation {
+        quote! {
+            pub struct #caus_name;
+            impl pr4xis::ontology::reasoning::causation::CausalDef for #caus_name {
+                type Entity = #entity_name;
+                fn relations() -> Vec<(#entity_name, #entity_name)> {
+                    vec![#(#caus_pairs),*]
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
+
+    let opposition_impl = if has_opposition {
+        quote! {
+            pub struct #opp_name;
+            impl pr4xis::ontology::reasoning::opposition::OppositionDef for #opp_name {
+                type Entity = #entity_name;
+                fn pairs() -> Vec<(#entity_name, #entity_name)> {
+                    vec![#(#opp_pairs),*]
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
+
+    // Structural axioms
+    let mut axiom_pushes = Vec::new();
+    if has_taxonomy {
+        axiom_pushes.push(quote! {
+            axioms.push(Box::new(
+                pr4xis::ontology::reasoning::taxonomy::NoCycles::<#tax_name>::new()
+            ));
+            axioms.push(Box::new(
+                pr4xis::ontology::reasoning::taxonomy::Antisymmetric::<#tax_name>::new()
+            ));
+        });
+    }
+    if has_mereology {
+        axiom_pushes.push(quote! {
+            axioms.push(Box::new(
+                pr4xis::ontology::reasoning::mereology::NoCycles::<#mer_name>::new()
+            ));
+        });
+    }
+    if has_causation {
+        axiom_pushes.push(quote! {
+            axioms.push(Box::new(
+                pr4xis::ontology::reasoning::causation::Asymmetric::<#caus_name>::new()
+            ));
+            axioms.push(Box::new(
+                pr4xis::ontology::reasoning::causation::NoSelfCausation::<#caus_name>::new()
+            ));
+        });
+    }
+    if has_opposition {
+        axiom_pushes.push(quote! {
+            axioms.push(Box::new(
+                pr4xis::ontology::reasoning::opposition::Symmetric::<#opp_name>::new()
+            ));
+            axioms.push(Box::new(
+                pr4xis::ontology::reasoning::opposition::Irreflexive::<#opp_name>::new()
+            ));
+        });
+    }
+
+    let name_lit = &def.name;
+
+    quote! {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, pr4xis::category::Entity)]
+        pub enum #entity_name {
+            #(#concept_idents,)*
+        }
+
+        #category_impl
+
+        #taxonomy_impl
+        #mereology_impl
+        #causation_impl
+        #opposition_impl
+
+        #being_classified
+
+        pub struct #ont_name;
+
+        impl #ont_name {
+            pub fn generated_structural_axioms() -> Vec<Box<dyn pr4xis::ontology::Axiom>> {
+                let mut axioms: Vec<Box<dyn pr4xis::ontology::Axiom>> = Vec::new();
+                #(#axiom_pushes)*
+                axioms
+            }
+
+            pub const fn meta() -> pr4xis::ontology::OntologyMeta {
+                pr4xis::ontology::OntologyMeta {
+                    name: #name_lit,
+                    module_path: module_path!(),
+                }
+            }
+
+            #[allow(dead_code, unused_assignments)]
+            pub fn vocabulary() -> pr4xis::ontology::Vocabulary {
+                pr4xis::ontology::Vocabulary {
+                    ontology_name: #name_lit,
+                    module_path: module_path!(),
+                    source: #source_tokens,
+                    being: #being_tokens,
+                    concept_count: <#entity_name as pr4xis::category::entity::Entity>::variants().len(),
+                    morphism_count: <#cat_name as pr4xis::category::Category>::morphisms().len(),
+                }
+            }
+
+            pub fn labels() -> &'static [(#entity_name, &'static str, &'static str, &'static str)] {
+                &[#(#label_entries,)*]
+            }
+        }
+    }
+}

--- a/crates/pr4xis-derive/src/ontology.rs
+++ b/crates/pr4xis-derive/src/ontology.rs
@@ -268,6 +268,23 @@ pub fn generate(def: OntologyDef) -> TokenStream {
         }
     }
 
+    for comp in &def.composed {
+        if !concept_set.contains(&comp.from.to_string()) {
+            return syn::Error::new_spanned(
+                &comp.from,
+                format!("concept '{}' not declared in concepts list", comp.from),
+            )
+            .to_compile_error();
+        }
+        if !concept_set.contains(&comp.to.to_string()) {
+            return syn::Error::new_spanned(
+                &comp.to,
+                format!("concept '{}' not declared in concepts list", comp.to),
+            )
+            .to_compile_error();
+        }
+    }
+
     for label in &def.labels {
         if !concept_set.contains(&label.concept.to_string()) {
             return syn::Error::new_spanned(

--- a/crates/pr4xis/src/lib.rs
+++ b/crates/pr4xis/src/lib.rs
@@ -5,3 +5,5 @@ pub mod codegen_data;
 pub mod engine;
 pub mod logic;
 pub mod ontology;
+
+pub use pr4xis_derive::ontology;

--- a/crates/pr4xis/src/ontology/tests.rs
+++ b/crates/pr4xis/src/ontology/tests.rs
@@ -513,3 +513,100 @@ mod ontology_macro_test {
         AnimalOntology::validate().unwrap();
     }
 }
+
+// =============================================================================
+// proc macro ontology! — Communication as proof of concept
+// =============================================================================
+
+mod proc_macro_test {
+    use crate as pr4xis;
+    use crate::category::Entity;
+    use crate::category::validate::check_category_laws;
+
+    pr4xis_derive::ontology! {
+        name: "Communication",
+        source: "Shannon (1948); Jakobson (1960)",
+        being: AbstractObject,
+
+        concepts: [Sender, Receiver, Message, Channel, Code, Noise, Feedback, Context],
+
+        labels: {
+            Sender: ("en", "Sender", "The agent producing the message"),
+            Receiver: ("en", "Receiver", "The agent interpreting the message"),
+            Message: ("en", "Message", "The information being communicated"),
+            Channel: ("en", "Channel", "The medium of transmission"),
+            Code: ("en", "Code", "The shared encoding/decoding system"),
+            Noise: ("en", "Noise", "Interference corrupting the message"),
+            Feedback: ("en", "Feedback", "Receiver's response to sender"),
+            Context: ("en", "Context", "Shared referential frame"),
+        },
+
+        edges: [
+            (Sender, Message, Produces),
+            (Message, Channel, TransmittedThrough),
+            (Receiver, Message, Interprets),
+            (Code, Message, EncodesDecodes),
+            (Noise, Channel, Corrupts),
+            (Feedback, Sender, FlowsBack),
+            (Receiver, Feedback, Produces),
+            (Context, Message, Grounds),
+            (Sender, Code, Shares),
+            (Receiver, Code, Shares),
+        ],
+
+        composed: [
+            (Sender, Channel),
+            (Sender, Receiver),
+            (Noise, Message),
+            (Receiver, Sender),
+        ],
+
+        opposes: [(Noise, Code)],
+    }
+
+    #[test]
+    fn proc_macro_generates_entity() {
+        let concepts = CommunicationConcept::variants();
+        assert_eq!(concepts.len(), 8);
+    }
+
+    #[test]
+    fn proc_macro_generates_category() {
+        check_category_laws::<CommunicationCategory>().unwrap();
+    }
+
+    #[test]
+    fn proc_macro_generates_vocabulary() {
+        let vocab = CommunicationOntology::vocabulary();
+        assert_eq!(vocab.concept_count, 8);
+        assert!(vocab.morphism_count > 0);
+        assert_eq!(vocab.source, "Shannon (1948); Jakobson (1960)");
+    }
+
+    #[test]
+    fn proc_macro_validates_concept_names() {
+        let sender = CommunicationConcept::Sender;
+        assert_eq!(sender.name(), "Sender");
+    }
+
+    #[test]
+    fn proc_macro_labels() {
+        let labels = CommunicationOntology::labels();
+        assert_eq!(labels.len(), 8);
+        let sender_label = labels
+            .iter()
+            .find(|(c, _, _, _)| *c == CommunicationConcept::Sender);
+        assert!(sender_label.is_some());
+        let (_, lang, label, def) = sender_label.unwrap();
+        assert_eq!(*lang, "en");
+        assert_eq!(*label, "Sender");
+        assert!(def.contains("agent"));
+    }
+
+    #[test]
+    fn proc_macro_opposition() {
+        use crate::ontology::reasoning::opposition::OppositionDef;
+        let pairs = CommunicationOpposition::pairs();
+        assert!(pairs.contains(&(CommunicationConcept::Noise, CommunicationConcept::Code)));
+    }
+}

--- a/crates/pr4xis/src/ontology/tests.rs
+++ b/crates/pr4xis/src/ontology/tests.rs
@@ -610,3 +610,64 @@ mod proc_macro_test {
         assert!(pairs.contains(&(CommunicationConcept::Noise, CommunicationConcept::Code)));
     }
 }
+
+// =============================================================================
+// proc macro ontology! — dense category case (no explicit edges)
+// =============================================================================
+
+mod proc_macro_dense_test {
+    use crate as pr4xis;
+    use crate::category::Entity;
+    use crate::category::validate::check_category_laws;
+
+    pr4xis::ontology! {
+        name: "Biology",
+        source: "Mayr (1982)",
+        being: AbstractObject,
+
+        concepts: [Cell, Tissue, Organ, Organism],
+
+        labels: {
+            Cell: ("en", "Cell", "The basic structural unit of all organisms"),
+            Tissue: ("en", "Tissue", "Aggregation of similar cells"),
+        },
+
+        is_a: [
+            (Cell, Tissue),
+            (Tissue, Organ),
+            (Organ, Organism),
+        ],
+    }
+
+    #[test]
+    fn dense_category_generated() {
+        let concepts = BiologyConcept::variants();
+        assert_eq!(concepts.len(), 4);
+    }
+
+    #[test]
+    fn dense_category_laws() {
+        check_category_laws::<BiologyCategory>().unwrap();
+    }
+
+    #[test]
+    fn dense_vocabulary() {
+        let vocab = BiologyOntology::vocabulary();
+        assert_eq!(vocab.concept_count, 4);
+        assert_eq!(vocab.source, "Mayr (1982)");
+    }
+
+    #[test]
+    fn dense_taxonomy() {
+        use crate::ontology::reasoning::taxonomy::TaxonomyDef;
+        let rels = BiologyTaxonomy::relations();
+        assert_eq!(rels.len(), 3);
+        assert!(rels.contains(&(BiologyConcept::Cell, BiologyConcept::Tissue)));
+    }
+
+    #[test]
+    fn dense_labels() {
+        let labels = BiologyOntology::labels();
+        assert_eq!(labels.len(), 2);
+    }
+}

--- a/crates/pr4xis/src/ontology/tests.rs
+++ b/crates/pr4xis/src/ontology/tests.rs
@@ -523,7 +523,7 @@ mod proc_macro_test {
     use crate::category::Entity;
     use crate::category::validate::check_category_laws;
 
-    pr4xis_derive::ontology! {
+    pr4xis::ontology! {
         name: "Communication",
         source: "Shannon (1948); Jakobson (1960)",
         being: AbstractObject,


### PR DESCRIPTION
## Summary

- Adds `ontology!` proc macro for defining ontologies with fluent declarative syntax
- Generates static enums, typed Category impl, reasoning systems, Vocabulary, Lemon lexical data
- **Compile-time concept validation** — referencing an undeclared concept in edges/is_a/opposes is a build error
- Communication ontology as proof-of-concept migration

## Syntax

```rust
pr4xis::ontology! {
    name: "Communication",
    source: "Shannon (1948); Jakobson (1960)",
    being: AbstractObject,

    concepts: [Sender, Receiver, Message, Channel, Code, Noise, Feedback, Context],

    labels: {
        Sender: ("en", "Sender", "The agent producing the message"),
        Message: ("en", "Message", "The information being communicated"),
    },

    edges: [
        (Sender, Message, Produces),
        (Message, Channel, TransmittedThrough),
        (Receiver, Message, Interprets),
    ],

    composed: [(Sender, Receiver)],
    opposes: [(Noise, Code)],
}
```

## What it generates

- `CommunicationConcept` enum with `#[derive(Entity)]`
- `CommunicationCategory` with typed kinded edges
- `CommunicationRelation` and `CommunicationRelationKind`
- `CommunicationOntology` struct with `vocabulary()` and `labels()`
- `CommunicationOpposition` reasoning system
- DOLCE `Classified` impl
- Dense category for ontologies without explicit edges

## Test plan

- [x] 6 proc macro tests (entity gen, category laws, vocabulary, labels, concept names, opposition)
- [x] `devenv ci` — all 5 checks green
- [x] Existing 4800+ tests unaffected