### PR TITLE
refactor(#113): batch 2 — dialogue/pragmatics cluster (7 ontologies)

### DIFF
--- a/crates/chat/src/lib.rs
+++ b/crates/chat/src/lib.rs
@@ -234,7 +234,7 @@ fn attempt_partial_understanding(
     let entities: Vec<String> = known_words.iter().map(|s| s.to_string()).collect();
 
     let response = match state {
-        epistemics::EpistemicState::UnknownKnown => {
+        epistemics::EpistemicConcept::UnknownKnown => {
             if known_words.len() == 1 {
                 define_word(en, known_words[0])
             } else {
@@ -254,18 +254,18 @@ fn attempt_partial_understanding(
                 }
             }
         }
-        epistemics::EpistemicState::KnownUnknown => {
+        epistemics::EpistemicConcept::KnownUnknown => {
             let mut content = ResponseContent::new(frame);
             for w in &unknown_words {
                 content = content.with_entity(w);
             }
             realize::realize(&content)
         }
-        epistemics::EpistemicState::KnownKnown => {
+        epistemics::EpistemicConcept::KnownKnown => {
             let content = ResponseContent::new(frame).with_predicate(&_meaning.describe());
             realize::realize(&content)
         }
-        epistemics::EpistemicState::UnknownUnknown => {
+        epistemics::EpistemicConcept::UnknownUnknown => {
             realize::realize(&ResponseContent::new(frame))
         }
     };

--- a/crates/domains/docs/report.html
+++ b/crates/domains/docs/report.html
@@ -139,7 +139,7 @@ const D = {
   "meta": {
     "generator": "vogix-ontology",
     "dataset": "all (base16 + base24 + vogix16)",
-    "generated": "2026-04-17T03:29:54Z"
+    "generated": "2026-04-17T14:38:14Z"
   },
   "summary": {
     "total": 464,

--- a/crates/domains/docs/report.json
+++ b/crates/domains/docs/report.json
@@ -2,7 +2,7 @@
   "meta": {
     "generator": "vogix-ontology",
     "dataset": "all",
-    "generated": "2026-04-17T03:29:54Z"
+    "generated": "2026-04-17T14:38:14Z"
   },
   "summary": {
     "total": 464,

--- a/crates/domains/src/cognitive/cognition/consciousness/monitoring_functor.rs
+++ b/crates/domains/src/cognitive/cognition/consciousness/monitoring_functor.rs
@@ -18,7 +18,7 @@ use pr4xis::category::Functor;
 
 use super::ontology::{C2Category, C2Concept, C2Relation, C2RelationKind};
 use crate::cognitive::cognition::metacognition::{
-    MetaCognitionCategory, MetaConcept, MetaRelation, MetaRelationKind,
+    MetaCognitionCategory, MetaCognitionConcept, MetaCognitionRelation, MetaCognitionRelationKind,
 };
 
 pub struct C2ToMetacognition;
@@ -27,30 +27,30 @@ impl Functor for C2ToMetacognition {
     type Source = C2Category;
     type Target = MetaCognitionCategory;
 
-    fn map_object(obj: &C2Concept) -> MetaConcept {
+    fn map_object(obj: &C2Concept) -> MetaCognitionConcept {
         match obj {
-            C2Concept::HigherOrderRepresentation => MetaConcept::MetaLevel,
-            C2Concept::FirstOrderState => MetaConcept::ObjectLevel,
-            C2Concept::AccessConsciousness => MetaConcept::Trace,
-            C2Concept::CauseEffectStructure => MetaConcept::Evaluation,
-            C2Concept::Mechanism => MetaConcept::Monitoring,
-            C2Concept::Repertoire => MetaConcept::Control,
-            C2Concept::PhenomenalConsciousness => MetaConcept::EpistemicAssessment,
+            C2Concept::HigherOrderRepresentation => MetaCognitionConcept::MetaLevel,
+            C2Concept::FirstOrderState => MetaCognitionConcept::ObjectLevel,
+            C2Concept::AccessConsciousness => MetaCognitionConcept::Trace,
+            C2Concept::CauseEffectStructure => MetaCognitionConcept::Evaluation,
+            C2Concept::Mechanism => MetaCognitionConcept::Monitoring,
+            C2Concept::Repertoire => MetaCognitionConcept::Control,
+            C2Concept::PhenomenalConsciousness => MetaCognitionConcept::EpistemicAssessment,
         }
     }
 
-    fn map_morphism(m: &C2Relation) -> MetaRelation {
+    fn map_morphism(m: &C2Relation) -> MetaCognitionRelation {
         let from = Self::map_object(&m.from);
         let to = Self::map_object(&m.to);
         let kind = match m.kind {
-            C2RelationKind::Identity => MetaRelationKind::Identity,
-            C2RelationKind::Represents => MetaRelationKind::Observes,
-            C2RelationKind::Generates => MetaRelationKind::Records,
-            C2RelationKind::HasComponent => MetaRelationKind::Assesses,
-            C2RelationKind::Enables => MetaRelationKind::Classifies,
-            C2RelationKind::Composed => MetaRelationKind::Composed,
+            C2RelationKind::Identity => MetaCognitionRelationKind::Identity,
+            C2RelationKind::Represents => MetaCognitionRelationKind::Observes,
+            C2RelationKind::Generates => MetaCognitionRelationKind::Records,
+            C2RelationKind::HasComponent => MetaCognitionRelationKind::Assesses,
+            C2RelationKind::Enables => MetaCognitionRelationKind::Classifies,
+            C2RelationKind::Composed => MetaCognitionRelationKind::Composed,
         };
-        MetaRelation { from, to, kind }
+        MetaCognitionRelation { from, to, kind }
     }
 }
 

--- a/crates/domains/src/cognitive/cognition/distinction.rs
+++ b/crates/domains/src/cognitive/cognition/distinction.rs
@@ -43,9 +43,6 @@ pr4xis::ontology! {
     ],
 }
 
-/// Backward-compatibility re-export for existing callers (supports glob imports).
-pub use DistinctionConcept as DistinctionElement;
-
 /// Draw a distinction — the fundamental cognitive act.
 /// Returns the two sides of the distinction.
 pub fn draw_distinction<T: Clone + PartialEq + std::fmt::Debug>(marked: T, unmarked: T) -> (T, T) {

--- a/crates/domains/src/cognitive/cognition/distinction.rs
+++ b/crates/domains/src/cognitive/cognition/distinction.rs
@@ -1,80 +1,50 @@
-use pr4xis::category::Entity;
-use pr4xis::define_ontology;
+//! Distinction — the most fundamental act of cognition.
+//!
+//! "Draw a distinction." — G. Spencer-Brown, Laws of Form (1969)
+//!
+//! Before categories, before logic, before knowledge — there is distinction.
+//! The act of drawing a boundary that separates "this" from "not this."
+//! Everything in praxis — Entity, Opposition, Boundary, Bit — is a distinction.
+//!
+//! References:
+//! - Spencer-Brown, Laws of Form (1969)
+//! - Kauffman, Laws of Form — An Exploration
+//! - von Foerster, Observing Systems (1981) — distinction as basis of observation
 
-// Distinction — the most fundamental act of cognition.
-//
-// "Draw a distinction." — G. Spencer-Brown, Laws of Form (1969)
-//
-// Before categories, before logic, before knowledge — there is distinction.
-// The act of drawing a boundary that separates "this" from "not this."
-// Everything in praxis — Entity, Opposition, Boundary, Bit — is a distinction.
-//
-// References:
-// - Spencer-Brown, Laws of Form (1969)
-// - Kauffman, Laws of Form — An Exploration (docs/papers/)
-// - von Foerster, Observing Systems (1981) — distinction as basis of observation
+pr4xis::ontology! {
+    name: "Distinction",
+    source: "Spencer-Brown (1969)",
+    being: AbstractObject,
 
-/// The elements of distinction — what exists when a boundary is drawn.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Entity)]
-pub enum DistinctionElement {
-    /// The unmarked state — the void before any distinction is made.
-    Void,
-    /// The mark — the act of indicating one side of a distinction.
-    Mark,
-    /// The boundary — the distinction itself, separating marked from unmarked.
-    Boundary,
-    /// The marked space — what is indicated (this side).
-    MarkedSpace,
-    /// The unmarked space — what is not indicated (the other side).
-    UnmarkedSpace,
-    /// Re-entry — the distinction applied to itself (self-reference).
-    /// This creates time and self-awareness (Spencer-Brown Ch. 11).
-    ReEntry,
+    concepts: [Void, Mark, Boundary, MarkedSpace, UnmarkedSpace, ReEntry],
+
+    labels: {
+        Void: ("en", "Void", "The unmarked state — the void before any distinction is made."),
+        Mark: ("en", "Mark", "The act of indicating one side of a distinction."),
+        Boundary: ("en", "Boundary", "The distinction itself, separating marked from unmarked."),
+        MarkedSpace: ("en", "Marked space", "What is indicated (this side of the boundary)."),
+        UnmarkedSpace: ("en", "Unmarked space", "What is not indicated (the other side)."),
+        ReEntry: ("en", "Re-entry", "The distinction applied to itself (self-reference). Creates time and self-awareness (Spencer-Brown Ch. 11)."),
+    },
+
+    edges: [
+        // Law of calling: Mark creates Boundary.
+        (Mark, Boundary, Creates),
+        // Law of crossing: Boundary separates spaces.
+        (Boundary, MarkedSpace, Separates),
+        (Boundary, UnmarkedSpace, Separates),
+        // Mark indicates MarkedSpace.
+        (Mark, MarkedSpace, Indicates),
+        // Void → Mark (distinction emerges from void).
+        (Void, Mark, Creates),
+        // ReEntry: distinction applied to itself.
+        (ReEntry, Mark, AppliesTo),
+        (ReEntry, Boundary, AppliesTo),
+    ],
 }
 
-define_ontology! {
-    /// Distinction — the most fundamental cognitive act (Spencer-Brown 1969).
-    pub DistinctionOntology for DistinctionCategory {
-        concepts: DistinctionElement,
-        relation: DistinctionRelation,
-        kind: DistinctionRelationKind,
-        kinds: [
-            /// Mark creates Boundary (the act of distinguishing).
-            Creates,
-            /// Boundary separates MarkedSpace from UnmarkedSpace.
-            Separates,
-            /// ReEntry applies distinction to itself (self-reference).
-            AppliesTo,
-            /// Mark indicates MarkedSpace.
-            Indicates,
-        ],
-        edges: [
-            // The two axioms of Laws of Form:
-            // 1. Mark creates Boundary (the law of calling)
-            (Mark, Boundary, Creates),
-            // 2. Boundary separates spaces (the law of crossing)
-            (Boundary, MarkedSpace, Separates),
-            (Boundary, UnmarkedSpace, Separates),
-            // Mark indicates MarkedSpace
-            (Mark, MarkedSpace, Indicates),
-            // Void → Mark (distinction emerges from void)
-            (Void, Mark, Creates),
-            // ReEntry: distinction applied to itself
-            (ReEntry, Mark, AppliesTo),
-            (ReEntry, Boundary, AppliesTo),
-        ],
-        composed: [
-            (Void, Boundary),
-            (Void, MarkedSpace),
-            (Mark, UnmarkedSpace),
-            (ReEntry, MarkedSpace),
-            (ReEntry, UnmarkedSpace),
-        ],
-
-        being: AbstractObject,
-        source: "Spencer-Brown (1969)",
-    }
-}
+/// Backward-compatibility re-export for existing callers (supports glob imports).
+pub use DistinctionConcept as DistinctionElement;
 
 /// Draw a distinction — the fundamental cognitive act.
 /// Returns the two sides of the distinction.

--- a/crates/domains/src/cognitive/cognition/epistemics.rs
+++ b/crates/domains/src/cognitive/cognition/epistemics.rs
@@ -1,79 +1,51 @@
-use pr4xis::category::Entity;
-use pr4xis::define_ontology;
+//! Epistemics — what you know about what you know.
+//!
+//! The Rumsfeld matrix formalized as an ontology:
+//!   Known Known    — knowledge exists AND is accessible
+//!   Known Unknown  — absence of knowledge is detected
+//!   Unknown Known  — knowledge exists but is NOT accessible (ontology gap)
+//!   Unknown Unknown — absence is not even detectable
+//!
+//! Second-order cybernetics moves things between these states:
+//!   Self-observation turns Unknown Unknowns → Known Unknowns
+//!   Ontology repair turns Unknown Knowns → Known Knowns
+//!   Learning turns Known Unknowns → Known Knowns
+//!
+//! Open World Assumption:
+//!   Failure to find ≠ falsity. "I don't know" is a valid epistemic state.
 
-// Epistemics — what you know about what you know.
-//
-// The Rumsfeld matrix formalized as an ontology:
-//   Known Known    — knowledge exists AND is accessible
-//   Known Unknown  — absence of knowledge is detected
-//   Unknown Known  — knowledge exists but is NOT accessible (ontology gap)
-//   Unknown Unknown — absence is not even detectable
-//
-// Second-order cybernetics moves things between these states:
-//   Self-observation turns Unknown Unknowns → Known Unknowns
-//   Ontology repair turns Unknown Knowns → Known Knowns
-//   Learning turns Known Unknowns → Known Knowns
-//
-// Open World Assumption:
-//   Failure to find ≠ falsity. "I don't know" is a valid epistemic state.
+pr4xis::ontology! {
+    name: "Epistemic",
+    source: "von Foerster (1981)",
+    being: MentalObject,
 
-/// Epistemic states — what the system knows about its own knowledge.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Entity)]
-pub enum EpistemicState {
-    /// I know it and can access it. "Dogs are mammals" — in taxonomy, query works.
-    KnownKnown,
-    /// I know I don't know. "What is a quark?" — not in my ontology, I detect the gap.
-    KnownUnknown,
-    /// I know it but can't access it. "Is a dog a mammal?" — answer exists but grammar can't parse the question.
-    UnknownKnown,
-    /// I don't know that I don't know. Not even aware of the gap.
-    UnknownUnknown,
+    concepts: [KnownKnown, KnownUnknown, UnknownKnown, UnknownUnknown],
+
+    labels: {
+        KnownKnown: ("en", "Known known", "I know it and can access it. 'Dogs are mammals' — in taxonomy, query works."),
+        KnownUnknown: ("en", "Known unknown", "I know I don't know. 'What is a quark?' — not in my ontology, I detect the gap."),
+        UnknownKnown: ("en", "Unknown known", "I know it but can't access it. Answer exists but grammar can't parse the question."),
+        UnknownUnknown: ("en", "Unknown unknown", "I don't know that I don't know. Not even aware of the gap."),
+    },
+
+    edges: [
+        // Self-observation: UU → KU (now I know I don't know)
+        (UnknownUnknown, KnownUnknown, Observation),
+        // Learning: KU → KK (acquired knowledge)
+        (KnownUnknown, KnownKnown, Learning),
+        // Repair: UK → KK (fixed the access gap)
+        (UnknownKnown, KnownKnown, Repair),
+        // Discovery: UK → KK (realized I had the answer)
+        (UnknownKnown, KnownKnown, Discovery),
+        // Forgetting: KK → UK (lost access)
+        (KnownKnown, UnknownKnown, Forgetting),
+    ],
 }
 
-define_ontology! {
-    /// Epistemics — second-order knowledge states (von Foerster 1981).
-    pub EpistemicOntology for EpistemicCategory {
-        concepts: EpistemicState,
-        relation: EpistemicTransition,
-        kind: TransitionKind,
-        kinds: [
-            /// Self-observation: detecting that something is missing.
-            /// UnknownUnknown → KnownUnknown (I now know I don't know).
-            Observation,
-            /// Learning: acquiring new knowledge.
-            /// KnownUnknown → KnownKnown (I learned the answer).
-            Learning,
-            /// Repair: fixing an ontology gap that blocked access.
-            /// UnknownKnown → KnownKnown (the grammar now parses the question).
-            Repair,
-            /// Discovery: finding knowledge you didn't know you had.
-            /// UnknownKnown → KnownKnown (realized I could answer this all along).
-            Discovery,
-            /// Forgetting: knowledge becomes inaccessible.
-            /// KnownKnown → UnknownKnown (cache expired, index stale).
-            Forgetting,
-        ],
-        edges: [
-            // Self-observation: UU → KU (now I know I don't know)
-            (UnknownUnknown, KnownUnknown, Observation),
-            // Learning: KU → KK (acquired knowledge)
-            (KnownUnknown, KnownKnown, Learning),
-            // Repair: UK → KK (fixed the access gap)
-            (UnknownKnown, KnownKnown, Repair),
-            // Discovery: UK → KK (realized I had the answer)
-            (UnknownKnown, KnownKnown, Discovery),
-            // Forgetting: KK → UK (lost access)
-            (KnownKnown, UnknownKnown, Forgetting),
-        ],
-        composed: [
-            // Transitive: UU → KU → KK (observe then learn)
-            (UnknownUnknown, KnownKnown),
-        ],
-
-        being: MentalObject,
-        source: "von Foerster (1981)",
-    }
-}
+/// Backward-compatibility re-exports for existing callers.
+pub use EpistemicConcept as EpistemicState;
+pub use EpistemicRelation as EpistemicTransition;
+pub use EpistemicRelationKind as TransitionKind;
 
 /// Classify the epistemic state of a query result.
 pub fn classify_result<T>(
@@ -86,10 +58,9 @@ pub fn classify_result<T>(
         (true, false, false) => EpistemicState::KnownUnknown,
         (false, true, false) => EpistemicState::UnknownKnown,
         (false, false, false) => EpistemicState::UnknownUnknown,
-        // Edge cases
-        (true, true, false) => EpistemicState::UnknownKnown, // parsed but couldn't retrieve
-        (true, false, true) => EpistemicState::KnownKnown, // shouldn't happen but handle gracefully
-        (false, true, true) => EpistemicState::KnownKnown, // got result despite parse failure
-        (false, false, true) => EpistemicState::KnownKnown, // shouldn't happen
+        (true, true, false) => EpistemicState::UnknownKnown,
+        (true, false, true) => EpistemicState::KnownKnown,
+        (false, true, true) => EpistemicState::KnownKnown,
+        (false, false, true) => EpistemicState::KnownKnown,
     }
 }

--- a/crates/domains/src/cognitive/cognition/epistemics.rs
+++ b/crates/domains/src/cognitive/cognition/epistemics.rs
@@ -42,25 +42,20 @@ pr4xis::ontology! {
     ],
 }
 
-/// Backward-compatibility re-exports for existing callers.
-pub use EpistemicConcept as EpistemicState;
-pub use EpistemicRelation as EpistemicTransition;
-pub use EpistemicRelationKind as TransitionKind;
-
 /// Classify the epistemic state of a query result.
 pub fn classify_result<T>(
     query_parsed: bool,
     knowledge_exists: bool,
     result: Option<T>,
-) -> EpistemicState {
+) -> EpistemicConcept {
     match (query_parsed, knowledge_exists, result.is_some()) {
-        (true, true, true) => EpistemicState::KnownKnown,
-        (true, false, false) => EpistemicState::KnownUnknown,
-        (false, true, false) => EpistemicState::UnknownKnown,
-        (false, false, false) => EpistemicState::UnknownUnknown,
-        (true, true, false) => EpistemicState::UnknownKnown,
-        (true, false, true) => EpistemicState::KnownKnown,
-        (false, true, true) => EpistemicState::KnownKnown,
-        (false, false, true) => EpistemicState::KnownKnown,
+        (true, true, true) => EpistemicConcept::KnownKnown,
+        (true, false, false) => EpistemicConcept::KnownUnknown,
+        (false, true, false) => EpistemicConcept::UnknownKnown,
+        (false, false, false) => EpistemicConcept::UnknownUnknown,
+        (true, true, false) => EpistemicConcept::UnknownKnown,
+        (true, false, true) => EpistemicConcept::KnownKnown,
+        (false, true, true) => EpistemicConcept::KnownKnown,
+        (false, false, true) => EpistemicConcept::KnownKnown,
     }
 }

--- a/crates/domains/src/cognitive/cognition/epistemics_planning_functor.rs
+++ b/crates/domains/src/cognitive/cognition/epistemics_planning_functor.rs
@@ -14,7 +14,7 @@
 use pr4xis::category::Functor;
 
 use crate::cognitive::cognition::epistemics::{
-    EpistemicCategory, EpistemicState, EpistemicTransition, TransitionKind,
+    EpistemicCategory, EpistemicConcept, EpistemicRelation, EpistemicRelationKind,
 };
 use crate::cognitive::linguistics::pragmatics::planning::ontology::{
     PlanningCategory, PlanningConcept, PlanningRelation, PlanningRelationKind,
@@ -26,26 +26,26 @@ impl Functor for EpistemicsToPlanning {
     type Source = EpistemicCategory;
     type Target = PlanningCategory;
 
-    fn map_object(obj: &EpistemicState) -> PlanningConcept {
+    fn map_object(obj: &EpistemicConcept) -> PlanningConcept {
         match obj {
-            EpistemicState::KnownKnown => PlanningConcept::Belief,
-            EpistemicState::KnownUnknown => PlanningConcept::Desire,
-            EpistemicState::UnknownKnown => PlanningConcept::Precondition,
-            EpistemicState::UnknownUnknown => PlanningConcept::CommunicativeGoal,
+            EpistemicConcept::KnownKnown => PlanningConcept::Belief,
+            EpistemicConcept::KnownUnknown => PlanningConcept::Desire,
+            EpistemicConcept::UnknownKnown => PlanningConcept::Precondition,
+            EpistemicConcept::UnknownUnknown => PlanningConcept::CommunicativeGoal,
         }
     }
 
-    fn map_morphism(m: &EpistemicTransition) -> PlanningRelation {
+    fn map_morphism(m: &EpistemicRelation) -> PlanningRelation {
         let from = Self::map_object(&m.from);
         let to = Self::map_object(&m.to);
         let kind = match m.kind {
-            TransitionKind::Identity => PlanningRelationKind::Identity,
-            TransitionKind::Observation => PlanningRelationKind::Produces,
-            TransitionKind::Learning => PlanningRelationKind::Produces,
-            TransitionKind::Repair => PlanningRelationKind::Produces,
-            TransitionKind::Discovery => PlanningRelationKind::Produces,
-            TransitionKind::Forgetting => PlanningRelationKind::Updates,
-            TransitionKind::Composed => PlanningRelationKind::Composed,
+            EpistemicRelationKind::Identity => PlanningRelationKind::Identity,
+            EpistemicRelationKind::Observation => PlanningRelationKind::Produces,
+            EpistemicRelationKind::Learning => PlanningRelationKind::Produces,
+            EpistemicRelationKind::Repair => PlanningRelationKind::Produces,
+            EpistemicRelationKind::Discovery => PlanningRelationKind::Produces,
+            EpistemicRelationKind::Forgetting => PlanningRelationKind::Updates,
+            EpistemicRelationKind::Composed => PlanningRelationKind::Composed,
         };
         PlanningRelation { from, to, kind }
     }

--- a/crates/domains/src/cognitive/cognition/epistemics_response_functor.rs
+++ b/crates/domains/src/cognitive/cognition/epistemics_response_functor.rs
@@ -12,7 +12,7 @@
 use pr4xis::category::Functor;
 
 use crate::cognitive::cognition::epistemics::{
-    EpistemicCategory, EpistemicState, EpistemicTransition,
+    EpistemicCategory, EpistemicConcept, EpistemicRelation,
 };
 use crate::cognitive::linguistics::pragmatics::response::{
     ResponseCategory, ResponseConcept, ResponseRelation, ResponseRelationKind,
@@ -24,20 +24,20 @@ impl Functor for EpistemicsToResponse {
     type Source = EpistemicCategory;
     type Target = ResponseCategory;
 
-    fn map_object(obj: &EpistemicState) -> ResponseConcept {
+    fn map_object(obj: &EpistemicConcept) -> ResponseConcept {
         match obj {
             // KnownKnown → SpeechActType (we know → we can assert)
-            EpistemicState::KnownKnown => ResponseConcept::SpeechActType,
+            EpistemicConcept::KnownKnown => ResponseConcept::SpeechActType,
             // KnownUnknown → EpistemicFrame (we know what we don't know)
-            EpistemicState::KnownUnknown => ResponseConcept::EpistemicFrame,
+            EpistemicConcept::KnownUnknown => ResponseConcept::EpistemicFrame,
             // UnknownKnown → Content (knowledge exists but needs surfacing)
-            EpistemicState::UnknownKnown => ResponseConcept::Content,
+            EpistemicConcept::UnknownKnown => ResponseConcept::Content,
             // UnknownUnknown → Context (we need more context)
-            EpistemicState::UnknownUnknown => ResponseConcept::Context,
+            EpistemicConcept::UnknownUnknown => ResponseConcept::Context,
         }
     }
 
-    fn map_morphism(m: &EpistemicTransition) -> ResponseRelation {
+    fn map_morphism(m: &EpistemicRelation) -> ResponseRelation {
         let from = Self::map_object(&m.from);
         let to = Self::map_object(&m.to);
         let kind = if from == to && m.from == m.to {

--- a/crates/domains/src/cognitive/cognition/metacognition.rs
+++ b/crates/domains/src/cognitive/cognition/metacognition.rs
@@ -1,105 +1,78 @@
-use pr4xis::category::Entity;
-use pr4xis::define_ontology;
+//! Metacognition — the system observing its own reasoning.
+//!
+//! Second-order cybernetics formalized: the observer IS part of the system.
+//! The meta-level monitors, evaluates, and controls the object level.
+//!
+//! When the grammar fails to parse, the meta-level:
+//! 1. Detects the failure (monitoring)
+//! 2. Diagnoses the cause (evaluation — which type reduction failed?)
+//! 3. Decides what to do (control — ask for clarification? attempt repair?)
+//!
+//! References:
+//! - von Foerster, Observing Systems (1981)
+//! - Glanville, Second Order Cybernetics
+//! - Olivares-Alarcos et al., MOI: Meta-Ontology for Introspection (2023)
 
-// Metacognition — the system observing its own reasoning.
-//
-// Second-order cybernetics formalized: the observer IS part of the system.
-// The meta-level monitors, evaluates, and controls the object level.
-//
-// When the grammar fails to parse, the meta-level:
-// 1. Detects the failure (monitoring)
-// 2. Diagnoses the cause (evaluation — which type reduction failed?)
-// 3. Decides what to do (control — ask for clarification? attempt repair?)
-//
-// References:
-// - von Foerster, Observing Systems (1981)
-// - Glanville, Second Order Cybernetics (docs/papers/)
-// - Olivares-Alarcos et al., MOI: Meta-Ontology for Introspection (2023)
+pr4xis::ontology! {
+    name: "MetaCognition",
+    source: "von Foerster (1981); Olivares-Alarcos MOI (2023)",
+    being: MentalObject,
 
-/// Metacognitive concepts — the bi-level architecture.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Entity)]
-pub enum MetaConcept {
-    /// The actual reasoning happening (grammar, semantics, queries).
-    ObjectLevel,
-    /// The observer of the reasoning (monitors, evaluates, controls).
-    MetaLevel,
-    /// What the meta-level watches: the trace of object-level steps.
-    Monitoring,
-    /// Assessing whether the object level succeeded or failed.
-    Evaluation,
-    /// Deciding what to do based on evaluation (continue, repair, ask).
-    Control,
-    /// The record of what happened at the object level (the Engine Trace).
-    Trace,
-    /// A detected gap — something the object level couldn't handle.
-    Gap,
-    /// An attempt to fix a gap without external help.
-    Repair,
-    /// A request for external help (asking the user to clarify).
-    Clarification,
-    /// The epistemic state assessment (from epistemics.rs).
-    EpistemicAssessment,
+    concepts: [
+        ObjectLevel,
+        MetaLevel,
+        Monitoring,
+        Evaluation,
+        Control,
+        Trace,
+        Gap,
+        Repair,
+        Clarification,
+        EpistemicAssessment,
+    ],
+
+    labels: {
+        ObjectLevel: ("en", "Object level", "The actual reasoning happening (grammar, semantics, queries)."),
+        MetaLevel: ("en", "Meta level", "The observer of the reasoning (monitors, evaluates, controls)."),
+        Monitoring: ("en", "Monitoring", "What the meta-level watches: the trace of object-level steps."),
+        Evaluation: ("en", "Evaluation", "Assessing whether the object level succeeded or failed."),
+        Control: ("en", "Control", "Deciding what to do based on evaluation (continue, repair, ask)."),
+        Trace: ("en", "Trace", "The record of what happened at the object level (the Engine Trace)."),
+        Gap: ("en", "Gap", "A detected gap — something the object level couldn't handle."),
+        Repair: ("en", "Repair", "An attempt to fix a gap without external help."),
+        Clarification: ("en", "Clarification", "A request for external help (asking the user to clarify)."),
+        EpistemicAssessment: ("en", "Epistemic assessment", "The epistemic state assessment (from epistemics.rs)."),
+    },
+
+    edges: [
+        // MetaLevel observes ObjectLevel
+        (MetaLevel, ObjectLevel, Observes),
+        // MetaLevel orchestrates its three sub-processes — monitoring,
+        // evaluation, control. These make transitive closure reach the
+        // leaf concepts (Trace, Gap, Repair, Clarification).
+        (MetaLevel, Monitoring, Orchestrates),
+        (MetaLevel, Evaluation, Orchestrates),
+        (MetaLevel, Control, Orchestrates),
+        (MetaLevel, EpistemicAssessment, Orchestrates),
+        // Monitoring records Trace; Evaluation feeds on Trace.
+        (Monitoring, Trace, Records),
+        (Monitoring, Evaluation, Feeds),
+        // Evaluation assesses Trace and detects Gap.
+        (Evaluation, Trace, Assesses),
+        (Evaluation, Gap, Detects),
+        (Evaluation, Control, Feeds),
+        // Control decides Repair or Clarification.
+        (Control, Repair, Decides),
+        (Control, Clarification, Decides),
+        // Gap triggers Repair / Clarification.
+        (Gap, Repair, Triggers),
+        (Gap, Clarification, Triggers),
+        // EpistemicAssessment classifies Gap.
+        (EpistemicAssessment, Gap, Classifies),
+    ],
 }
 
-define_ontology! {
-    /// Metacognition — the system observing its own reasoning (von Foerster 1981).
-    pub MetaCognitionOntology for MetaCognitionCategory {
-        concepts: MetaConcept,
-        relation: MetaRelation,
-        kind: MetaRelationKind,
-        kinds: [
-            /// MetaLevel observes ObjectLevel.
-            Observes,
-            /// Monitoring produces Trace.
-            Records,
-            /// Evaluation assesses Trace.
-            Assesses,
-            /// Evaluation detects Gap.
-            Detects,
-            /// Control decides action (Repair or Clarification).
-            Decides,
-            /// Gap triggers Repair or Clarification.
-            Triggers,
-            /// EpistemicAssessment classifies the state of knowledge.
-            Classifies,
-        ],
-        edges: [
-            // MetaLevel observes ObjectLevel
-            (MetaLevel, ObjectLevel, Observes),
-            // Monitoring records Trace
-            (Monitoring, Trace, Records),
-            // Evaluation assesses Trace
-            (Evaluation, Trace, Assesses),
-            // Evaluation detects Gap
-            (Evaluation, Gap, Detects),
-            // Control decides Repair or Clarification
-            (Control, Repair, Decides),
-            (Control, Clarification, Decides),
-            // Gap triggers Repair
-            (Gap, Repair, Triggers),
-            // Gap triggers Clarification
-            (Gap, Clarification, Triggers),
-            // EpistemicAssessment classifies Gap
-            (EpistemicAssessment, Gap, Classifies),
-        ],
-        composed: [
-            // The second-order loop: MetaLevel → ... → everything
-            (MetaLevel, EpistemicAssessment),
-            (MetaLevel, Monitoring),
-            (MetaLevel, Trace),
-            (MetaLevel, Evaluation),
-            (MetaLevel, Gap),
-            (MetaLevel, Control),
-            (MetaLevel, Repair),
-            (MetaLevel, Clarification),
-            (Monitoring, Evaluation),
-            (Monitoring, Gap),
-            (Evaluation, Repair),
-            (Evaluation, Clarification),
-            (Evaluation, Control),
-        ],
-
-        being: MentalObject,
-        source: "von Foerster (1981); Olivares-Alarcos MOI (2023)",
-    }
-}
+/// Backward-compatibility re-exports for existing callers.
+pub use MetaCognitionConcept as MetaConcept;
+pub use MetaCognitionRelation as MetaRelation;
+pub use MetaCognitionRelationKind as MetaRelationKind;

--- a/crates/domains/src/cognitive/cognition/metacognition.rs
+++ b/crates/domains/src/cognitive/cognition/metacognition.rs
@@ -71,8 +71,3 @@ pr4xis::ontology! {
         (EpistemicAssessment, Gap, Classifies),
     ],
 }
-
-/// Backward-compatibility re-exports for existing callers.
-pub use MetaCognitionConcept as MetaConcept;
-pub use MetaCognitionRelation as MetaRelation;
-pub use MetaCognitionRelationKind as MetaRelationKind;

--- a/crates/domains/src/cognitive/cognition/metacognition_epistemics_functor.rs
+++ b/crates/domains/src/cognitive/cognition/metacognition_epistemics_functor.rs
@@ -15,10 +15,10 @@
 use pr4xis::category::Functor;
 
 use crate::cognitive::cognition::epistemics::{
-    EpistemicCategory, EpistemicState, EpistemicTransition, TransitionKind,
+    EpistemicCategory, EpistemicConcept, EpistemicRelation, EpistemicRelationKind,
 };
 use crate::cognitive::cognition::metacognition::{
-    MetaCognitionCategory, MetaConcept, MetaRelation,
+    MetaCognitionCategory, MetaCognitionConcept, MetaCognitionRelation,
 };
 
 pub struct MetacognitionToEpistemics;
@@ -27,50 +27,50 @@ impl Functor for MetacognitionToEpistemics {
     type Source = MetaCognitionCategory;
     type Target = EpistemicCategory;
 
-    fn map_object(obj: &MetaConcept) -> EpistemicState {
+    fn map_object(obj: &MetaCognitionConcept) -> EpistemicConcept {
         match obj {
             // MetaLevel IS knowing-that-you-know
-            MetaConcept::MetaLevel => EpistemicState::KnownKnown,
+            MetaCognitionConcept::MetaLevel => EpistemicConcept::KnownKnown,
             // ObjectLevel may be inaccessible (processing without awareness)
-            MetaConcept::ObjectLevel => EpistemicState::UnknownKnown,
+            MetaCognitionConcept::ObjectLevel => EpistemicConcept::UnknownKnown,
             // Monitoring IS self-observation
-            MetaConcept::Monitoring => EpistemicState::KnownKnown,
+            MetaCognitionConcept::Monitoring => EpistemicConcept::KnownKnown,
             // Evaluation produces knowledge
-            MetaConcept::Evaluation => EpistemicState::KnownKnown,
+            MetaCognitionConcept::Evaluation => EpistemicConcept::KnownKnown,
             // Control directs learning
-            MetaConcept::Control => EpistemicState::KnownKnown,
+            MetaCognitionConcept::Control => EpistemicConcept::KnownKnown,
             // Trace IS evidence of knowledge
-            MetaConcept::Trace => EpistemicState::KnownKnown,
+            MetaCognitionConcept::Trace => EpistemicConcept::KnownKnown,
             // Gap IS knowing you don't know (Rumsfeld's known unknown)
-            MetaConcept::Gap => EpistemicState::KnownUnknown,
+            MetaCognitionConcept::Gap => EpistemicConcept::KnownUnknown,
             // Repair maps directly
-            MetaConcept::Repair => EpistemicState::KnownKnown,
+            MetaCognitionConcept::Repair => EpistemicConcept::KnownKnown,
             // Clarification = acknowledging ignorance
-            MetaConcept::Clarification => EpistemicState::KnownUnknown,
+            MetaCognitionConcept::Clarification => EpistemicConcept::KnownUnknown,
             // EpistemicAssessment IS already epistemic
-            MetaConcept::EpistemicAssessment => EpistemicState::KnownKnown,
+            MetaCognitionConcept::EpistemicAssessment => EpistemicConcept::KnownKnown,
         }
     }
 
-    fn map_morphism(m: &MetaRelation) -> EpistemicTransition {
+    fn map_morphism(m: &MetaCognitionRelation) -> EpistemicRelation {
         let from = Self::map_object(&m.from);
         let to = Self::map_object(&m.to);
         let kind = if from == to && m.from == m.to {
-            TransitionKind::Identity
+            EpistemicRelationKind::Identity
         } else if from == to {
-            TransitionKind::Composed
+            EpistemicRelationKind::Composed
         } else {
             match (&from, &to) {
-                (EpistemicState::UnknownKnown, EpistemicState::KnownKnown) => {
-                    TransitionKind::Repair
+                (EpistemicConcept::UnknownKnown, EpistemicConcept::KnownKnown) => {
+                    EpistemicRelationKind::Repair
                 }
-                (EpistemicState::KnownUnknown, EpistemicState::KnownKnown) => {
-                    TransitionKind::Learning
+                (EpistemicConcept::KnownUnknown, EpistemicConcept::KnownKnown) => {
+                    EpistemicRelationKind::Learning
                 }
-                _ => TransitionKind::Composed,
+                _ => EpistemicRelationKind::Composed,
             }
         };
-        EpistemicTransition { from, to, kind }
+        EpistemicRelation { from, to, kind }
     }
 }
 

--- a/crates/domains/src/cognitive/cognition/self_model.rs
+++ b/crates/domains/src/cognitive/cognition/self_model.rs
@@ -184,8 +184,8 @@ impl AwarenessLevel {
 pub struct SelfModelToMetacognition;
 
 impl SelfModelToMetacognition {
-    pub fn map_object(obj: &SelfModelConcept) -> super::metacognition::MetaConcept {
-        use super::metacognition::MetaConcept as M;
+    pub fn map_object(obj: &SelfModelConcept) -> super::metacognition::MetaCognitionConcept {
+        use super::metacognition::MetaCognitionConcept as M;
         match obj {
             SelfModelConcept::SelfModel => M::MetaLevel,
             SelfModelConcept::Component => M::ObjectLevel,
@@ -218,8 +218,8 @@ impl SelfModelToMetacognition {
 pub struct SelfModelToEpistemics;
 
 impl SelfModelToEpistemics {
-    pub fn map_object(obj: &SelfModelConcept) -> super::epistemics::EpistemicState {
-        use super::epistemics::EpistemicState as E;
+    pub fn map_object(obj: &SelfModelConcept) -> super::epistemics::EpistemicConcept {
+        use super::epistemics::EpistemicConcept as E;
         match obj {
             // The system with a self-model knows itself
             SelfModelConcept::SelfModel => E::KnownKnown,
@@ -399,12 +399,12 @@ mod tests {
 
     #[test]
     fn functor_to_metacognition_covers_all_concepts() {
-        // Every SelfModel concept maps to a valid MetaConcept
+        // Every SelfModel concept maps to a valid MetaCognitionConcept
         for obj in SelfModelConcept::variants() {
             let mapped = SelfModelToMetacognition::map_object(&obj);
             assert!(
-                super::super::metacognition::MetaConcept::variants().contains(&mapped),
-                "{:?} maps to {:?} which is not a valid MetaConcept",
+                super::super::metacognition::MetaCognitionConcept::variants().contains(&mapped),
+                "{:?} maps to {:?} which is not a valid MetaCognitionConcept",
                 obj,
                 mapped
             );
@@ -415,7 +415,10 @@ mod tests {
     fn functor_to_epistemics_self_model_is_known_known() {
         // A system with a self-model knows itself — KnownKnown
         let state = SelfModelToEpistemics::map_object(&SelfModelConcept::SelfModel);
-        assert_eq!(state, super::super::epistemics::EpistemicState::KnownKnown);
+        assert_eq!(
+            state,
+            super::super::epistemics::EpistemicConcept::KnownKnown
+        );
     }
 
     #[test]
@@ -424,7 +427,7 @@ mod tests {
         let state = SelfModelToEpistemics::map_object(&SelfModelConcept::Justification);
         assert_eq!(
             state,
-            super::super::epistemics::EpistemicState::KnownUnknown
+            super::super::epistemics::EpistemicConcept::KnownUnknown
         );
     }
 

--- a/crates/domains/src/cognitive/cognition/tests.rs
+++ b/crates/domains/src/cognitive/cognition/tests.rs
@@ -17,14 +17,14 @@ fn distinction_category_laws() {
 
 #[test]
 fn distinction_has_6_elements() {
-    assert_eq!(DistinctionElement::variants().len(), 6);
+    assert_eq!(DistinctionConcept::variants().len(), 6);
 }
 
 #[test]
 fn mark_creates_boundary() {
     let m = DistinctionCategory::morphisms();
-    assert!(m.iter().any(|r| r.from == DistinctionElement::Mark
-        && r.to == DistinctionElement::Boundary
+    assert!(m.iter().any(|r| r.from == DistinctionConcept::Mark
+        && r.to == DistinctionConcept::Boundary
         && r.kind == DistinctionRelationKind::Creates));
 }
 
@@ -33,15 +33,15 @@ fn void_precedes_mark() {
     let m = DistinctionCategory::morphisms();
     assert!(
         m.iter()
-            .any(|r| r.from == DistinctionElement::Void && r.to == DistinctionElement::Mark)
+            .any(|r| r.from == DistinctionConcept::Void && r.to == DistinctionConcept::Mark)
     );
 }
 
 #[test]
 fn reentry_is_self_reference() {
     let m = DistinctionCategory::morphisms();
-    assert!(m.iter().any(|r| r.from == DistinctionElement::ReEntry
-        && r.to == DistinctionElement::Mark
+    assert!(m.iter().any(|r| r.from == DistinctionConcept::ReEntry
+        && r.to == DistinctionConcept::Mark
         && r.kind == DistinctionRelationKind::AppliesTo));
 }
 
@@ -69,55 +69,55 @@ fn epistemic_category_laws() {
 
 #[test]
 fn epistemic_has_4_states() {
-    assert_eq!(EpistemicState::variants().len(), 4);
+    assert_eq!(EpistemicConcept::variants().len(), 4);
 }
 
 #[test]
 fn observation_detects_gap() {
     let m = EpistemicCategory::morphisms();
-    assert!(m.iter().any(|r| r.from == EpistemicState::UnknownUnknown
-        && r.to == EpistemicState::KnownUnknown
-        && r.kind == TransitionKind::Observation));
+    assert!(m.iter().any(|r| r.from == EpistemicConcept::UnknownUnknown
+        && r.to == EpistemicConcept::KnownUnknown
+        && r.kind == EpistemicRelationKind::Observation));
 }
 
 #[test]
 fn learning_fills_gap() {
     let m = EpistemicCategory::morphisms();
-    assert!(m.iter().any(|r| r.from == EpistemicState::KnownUnknown
-        && r.to == EpistemicState::KnownKnown
-        && r.kind == TransitionKind::Learning));
+    assert!(m.iter().any(|r| r.from == EpistemicConcept::KnownUnknown
+        && r.to == EpistemicConcept::KnownKnown
+        && r.kind == EpistemicRelationKind::Learning));
 }
 
 #[test]
 fn repair_fixes_access() {
     let m = EpistemicCategory::morphisms();
-    assert!(m.iter().any(|r| r.from == EpistemicState::UnknownKnown
-        && r.to == EpistemicState::KnownKnown
-        && r.kind == TransitionKind::Repair));
+    assert!(m.iter().any(|r| r.from == EpistemicConcept::UnknownKnown
+        && r.to == EpistemicConcept::KnownKnown
+        && r.kind == EpistemicRelationKind::Repair));
 }
 
 #[test]
 fn classify_known_known() {
     let state = classify_result(true, true, Some("dog is a mammal"));
-    assert_eq!(state, EpistemicState::KnownKnown);
+    assert_eq!(state, EpistemicConcept::KnownKnown);
 }
 
 #[test]
 fn classify_known_unknown() {
     let state = classify_result::<&str>(true, false, None);
-    assert_eq!(state, EpistemicState::KnownUnknown);
+    assert_eq!(state, EpistemicConcept::KnownUnknown);
 }
 
 #[test]
 fn classify_unknown_known() {
     let state = classify_result::<&str>(false, true, None);
-    assert_eq!(state, EpistemicState::UnknownKnown);
+    assert_eq!(state, EpistemicConcept::UnknownKnown);
 }
 
 #[test]
 fn classify_unknown_unknown() {
     let state = classify_result::<&str>(false, false, None);
-    assert_eq!(state, EpistemicState::UnknownUnknown);
+    assert_eq!(state, EpistemicConcept::UnknownUnknown);
 }
 
 // =============================================================================
@@ -131,23 +131,23 @@ fn metacognition_category_laws() {
 
 #[test]
 fn metacognition_has_10_concepts() {
-    assert_eq!(MetaConcept::variants().len(), 10);
+    assert_eq!(MetaCognitionConcept::variants().len(), 10);
 }
 
 #[test]
 fn meta_observes_object() {
     let m = MetaCognitionCategory::morphisms();
-    assert!(m.iter().any(|r| r.from == MetaConcept::MetaLevel
-        && r.to == MetaConcept::ObjectLevel
-        && r.kind == MetaRelationKind::Observes));
+    assert!(m.iter().any(|r| r.from == MetaCognitionConcept::MetaLevel
+        && r.to == MetaCognitionConcept::ObjectLevel
+        && r.kind == MetaCognitionRelationKind::Observes));
 }
 
 #[test]
 fn evaluation_detects_gap() {
     let m = MetaCognitionCategory::morphisms();
-    assert!(m.iter().any(|r| r.from == MetaConcept::Evaluation
-        && r.to == MetaConcept::Gap
-        && r.kind == MetaRelationKind::Detects));
+    assert!(m.iter().any(|r| r.from == MetaCognitionConcept::Evaluation
+        && r.to == MetaCognitionConcept::Gap
+        && r.kind == MetaCognitionRelationKind::Detects));
 }
 
 #[test]
@@ -155,22 +155,19 @@ fn gap_triggers_repair_or_clarification() {
     let m = MetaCognitionCategory::morphisms();
     assert!(
         m.iter()
-            .any(|r| r.from == MetaConcept::Gap && r.to == MetaConcept::Repair)
+            .any(|r| r.from == MetaCognitionConcept::Gap && r.to == MetaCognitionConcept::Repair)
     );
-    assert!(
-        m.iter()
-            .any(|r| r.from == MetaConcept::Gap && r.to == MetaConcept::Clarification)
-    );
+    assert!(m.iter().any(
+        |r| r.from == MetaCognitionConcept::Gap && r.to == MetaCognitionConcept::Clarification
+    ));
 }
 
 #[test]
 fn meta_reaches_clarification() {
     // The full loop: MetaLevel → ... → Clarification
     let m = MetaCognitionCategory::morphisms();
-    assert!(
-        m.iter()
-            .any(|r| r.from == MetaConcept::MetaLevel && r.to == MetaConcept::Clarification)
-    );
+    assert!(m.iter().any(|r| r.from == MetaCognitionConcept::MetaLevel
+        && r.to == MetaCognitionConcept::Clarification));
 }
 
 // =============================================================================
@@ -181,27 +178,27 @@ mod prop {
     use super::*;
     use proptest::prelude::*;
 
-    fn arb_epistemic() -> impl Strategy<Value = EpistemicState> {
+    fn arb_epistemic() -> impl Strategy<Value = EpistemicConcept> {
         prop_oneof![
-            Just(EpistemicState::KnownKnown),
-            Just(EpistemicState::KnownUnknown),
-            Just(EpistemicState::UnknownKnown),
-            Just(EpistemicState::UnknownUnknown),
+            Just(EpistemicConcept::KnownKnown),
+            Just(EpistemicConcept::KnownUnknown),
+            Just(EpistemicConcept::UnknownKnown),
+            Just(EpistemicConcept::UnknownUnknown),
         ]
     }
 
-    fn arb_meta() -> impl Strategy<Value = MetaConcept> {
+    fn arb_meta() -> impl Strategy<Value = MetaCognitionConcept> {
         prop_oneof![
-            Just(MetaConcept::ObjectLevel),
-            Just(MetaConcept::MetaLevel),
-            Just(MetaConcept::Monitoring),
-            Just(MetaConcept::Evaluation),
-            Just(MetaConcept::Control),
-            Just(MetaConcept::Trace),
-            Just(MetaConcept::Gap),
-            Just(MetaConcept::Repair),
-            Just(MetaConcept::Clarification),
-            Just(MetaConcept::EpistemicAssessment),
+            Just(MetaCognitionConcept::ObjectLevel),
+            Just(MetaCognitionConcept::MetaLevel),
+            Just(MetaCognitionConcept::Monitoring),
+            Just(MetaCognitionConcept::Evaluation),
+            Just(MetaCognitionConcept::Control),
+            Just(MetaCognitionConcept::Trace),
+            Just(MetaCognitionConcept::Gap),
+            Just(MetaCognitionConcept::Repair),
+            Just(MetaCognitionConcept::Clarification),
+            Just(MetaCognitionConcept::EpistemicAssessment),
         ]
     }
 
@@ -222,7 +219,7 @@ mod prop {
         #[test]
         fn prop_known_known_reachable(s in arb_epistemic()) {
             let m = EpistemicCategory::morphisms();
-            let reaches = m.iter().any(|r| r.from == s && r.to == EpistemicState::KnownKnown);
+            let reaches = m.iter().any(|r| r.from == s && r.to == EpistemicConcept::KnownKnown);
             prop_assert!(reaches, "{:?} should be able to reach KnownKnown", s);
         }
 
@@ -230,7 +227,7 @@ mod prop {
         #[test]
         fn prop_meta_reaches_all(c in arb_meta()) {
             let m = MetaCognitionCategory::morphisms();
-            let reaches = m.iter().any(|r| r.from == MetaConcept::MetaLevel && r.to == c);
+            let reaches = m.iter().any(|r| r.from == MetaCognitionConcept::MetaLevel && r.to == c);
             prop_assert!(reaches, "MetaLevel should reach {:?}", c);
         }
 
@@ -248,11 +245,11 @@ mod prop {
         fn prop_boundary_separates_both(_dummy in 0..1i32) {
             let m = DistinctionCategory::morphisms();
             let to_marked = m.iter().any(|r|
-                r.from == DistinctionElement::Boundary
-                && r.to == DistinctionElement::MarkedSpace);
+                r.from == DistinctionConcept::Boundary
+                && r.to == DistinctionConcept::MarkedSpace);
             let to_unmarked = m.iter().any(|r|
-                r.from == DistinctionElement::Boundary
-                && r.to == DistinctionElement::UnmarkedSpace);
+                r.from == DistinctionConcept::Boundary
+                && r.to == DistinctionConcept::UnmarkedSpace);
             prop_assert!(to_marked, "Boundary must separate to MarkedSpace");
             prop_assert!(to_unmarked, "Boundary must separate to UnmarkedSpace");
         }
@@ -262,8 +259,8 @@ mod prop {
         fn prop_void_reaches_mark(_dummy in 0..1i32) {
             let m = DistinctionCategory::morphisms();
             let reaches = m.iter().any(|r|
-                r.from == DistinctionElement::Void
-                && r.to == DistinctionElement::Mark);
+                r.from == DistinctionConcept::Void
+                && r.to == DistinctionConcept::Mark);
             prop_assert!(reaches);
         }
 
@@ -272,11 +269,11 @@ mod prop {
         fn prop_reentry_reaches_both_spaces(_dummy in 0..1i32) {
             let m = DistinctionCategory::morphisms();
             let to_marked = m.iter().any(|r|
-                r.from == DistinctionElement::ReEntry
-                && r.to == DistinctionElement::MarkedSpace);
+                r.from == DistinctionConcept::ReEntry
+                && r.to == DistinctionConcept::MarkedSpace);
             let to_unmarked = m.iter().any(|r|
-                r.from == DistinctionElement::ReEntry
-                && r.to == DistinctionElement::UnmarkedSpace);
+                r.from == DistinctionConcept::ReEntry
+                && r.to == DistinctionConcept::UnmarkedSpace);
             prop_assert!(to_marked);
             prop_assert!(to_unmarked);
         }
@@ -288,8 +285,8 @@ mod prop {
         fn prop_observe_then_learn(_dummy in 0..1i32) {
             let m = EpistemicCategory::morphisms();
             let uu_to_kk = m.iter().any(|r|
-                r.from == EpistemicState::UnknownUnknown
-                && r.to == EpistemicState::KnownKnown);
+                r.from == EpistemicConcept::UnknownUnknown
+                && r.to == EpistemicConcept::KnownKnown);
             prop_assert!(uu_to_kk, "UU should reach KK via observation+learning");
         }
 
@@ -298,13 +295,13 @@ mod prop {
         fn prop_forgetting_recoverable(_dummy in 0..1i32) {
             let m = EpistemicCategory::morphisms();
             let forgets = m.iter().any(|r|
-                r.from == EpistemicState::KnownKnown
-                && r.to == EpistemicState::UnknownKnown
-                && r.kind == TransitionKind::Forgetting);
+                r.from == EpistemicConcept::KnownKnown
+                && r.to == EpistemicConcept::UnknownKnown
+                && r.kind == EpistemicRelationKind::Forgetting);
             let repairs = m.iter().any(|r|
-                r.from == EpistemicState::UnknownKnown
-                && r.to == EpistemicState::KnownKnown
-                && r.kind == TransitionKind::Repair);
+                r.from == EpistemicConcept::UnknownKnown
+                && r.to == EpistemicConcept::KnownKnown
+                && r.kind == EpistemicRelationKind::Repair);
             prop_assert!(forgets, "KK should be able to forget to UK");
             prop_assert!(repairs, "UK should be repairable back to KK");
         }
@@ -324,9 +321,9 @@ mod prop {
         fn prop_gap_never_stuck(_dummy in 0..1i32) {
             let m = MetaCognitionCategory::morphisms();
             let to_repair = m.iter().any(|r|
-                r.from == MetaConcept::Gap && r.to == MetaConcept::Repair);
+                r.from == MetaCognitionConcept::Gap && r.to == MetaCognitionConcept::Repair);
             let to_clarification = m.iter().any(|r|
-                r.from == MetaConcept::Gap && r.to == MetaConcept::Clarification);
+                r.from == MetaCognitionConcept::Gap && r.to == MetaCognitionConcept::Clarification);
             prop_assert!(to_repair || to_clarification,
                 "Gap must lead to Repair or Clarification");
             prop_assert!(to_repair, "Gap must be able to trigger Repair");
@@ -338,8 +335,8 @@ mod prop {
         fn prop_monitoring_before_evaluation(_dummy in 0..1i32) {
             let m = MetaCognitionCategory::morphisms();
             let chain = m.iter().any(|r|
-                r.from == MetaConcept::Monitoring
-                && r.to == MetaConcept::Evaluation);
+                r.from == MetaCognitionConcept::Monitoring
+                && r.to == MetaCognitionConcept::Evaluation);
             prop_assert!(chain);
         }
 
@@ -348,20 +345,20 @@ mod prop {
         fn prop_evaluation_informs_control(_dummy in 0..1i32) {
             let m = MetaCognitionCategory::morphisms();
             let chain = m.iter().any(|r|
-                r.from == MetaConcept::Evaluation
-                && r.to == MetaConcept::Control);
+                r.from == MetaCognitionConcept::Evaluation
+                && r.to == MetaCognitionConcept::Control);
             prop_assert!(chain);
         }
     }
 
-    fn arb_distinction() -> impl Strategy<Value = DistinctionElement> {
+    fn arb_distinction() -> impl Strategy<Value = DistinctionConcept> {
         prop_oneof![
-            Just(DistinctionElement::Void),
-            Just(DistinctionElement::Mark),
-            Just(DistinctionElement::Boundary),
-            Just(DistinctionElement::MarkedSpace),
-            Just(DistinctionElement::UnmarkedSpace),
-            Just(DistinctionElement::ReEntry),
+            Just(DistinctionConcept::Void),
+            Just(DistinctionConcept::Mark),
+            Just(DistinctionConcept::Boundary),
+            Just(DistinctionConcept::MarkedSpace),
+            Just(DistinctionConcept::UnmarkedSpace),
+            Just(DistinctionConcept::ReEntry),
         ]
     }
 }

--- a/crates/domains/src/cognitive/linguistics/orthography/channel.rs
+++ b/crates/domains/src/cognitive/linguistics/orthography/channel.rs
@@ -1,95 +1,60 @@
-use pr4xis::category::Entity;
-use pr4xis::define_ontology;
+//! Noisy Channel Model — spelling correction as categorical adjunction.
+//!
+//! Shannon (1948): communication through a noisy channel.
+//! Kernighan, Church & Gale (1990): applied to spelling correction.
+//! Brill & Moore (2000): string-to-string partition model.
+//!
+//! The channel and its Bayesian inverse form an ADJUNCTION, not an isomorphism:
+//!   F: Lang → Obs  (the channel functor — words become misspellings)
+//!   G: Obs → Lang  (Bayesian right adjoint — correction)
+//!   G∘F ≠ Id       (information loss through channel)
+//!   η: Id → G∘F    (unit: the "correction accuracy" natural transformation)
+//!
+//! This is NOT a simple inverse functor because:
+//! - The channel destroys information (many words can produce the same misspelling)
+//! - Correction is probabilistic (argmax, not exact inverse)
+//! - G∘F approaches Id as the language model and error model improve
 
-// Noisy Channel Model — spelling correction as categorical adjunction.
-//
-// Shannon (1948): communication through a noisy channel.
-// Kernighan, Church & Gale (1990): applied to spelling correction.
-// Brill & Moore (2000): string-to-string partition model.
-//
-// The channel and its Bayesian inverse form an ADJUNCTION, not an isomorphism:
-//   F: Lang → Obs  (the channel functor — words become misspellings)
-//   G: Obs → Lang  (Bayesian right adjoint — correction)
-//   G∘F ≠ Id       (information loss through channel)
-//   η: Id → G∘F    (unit: the "correction accuracy" natural transformation)
-//
-// This is NOT a simple inverse functor because:
-// - The channel destroys information (many words can produce the same misspelling)
-// - Correction is probabilistic (argmax, not exact inverse)
-// - G∘F approaches Id as the language model and error model improve
+pr4xis::ontology! {
+    name: "Channel",
+    source: "Shannon (1948); Kernighan et al. (1990); Brill & Moore (2000)",
+    being: AbstractObject,
 
-/// Concepts in the noisy channel model.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Entity)]
-pub enum ChannelConcept {
-    /// A word in the language, with its prior probability P(w).
-    Word,
-    /// An observed string (possibly misspelled).
-    Observation,
-    /// The error model P(x|w) — probability of misspelling x given intended word w.
-    /// Parameterized by confusion matrices (Kernighan, Church & Gale 1990).
-    ErrorModel,
-    /// The language model P(w) — prior probability of the word.
-    LanguageModel,
-    /// The correction: argmax_w P(x|w) * P(w).
-    Correction,
-    /// A confusion matrix — edit probabilities for a specific operation type.
-    /// del[x,y], ins[x,y], sub[x,y], trans[x,y].
-    ConfusionMatrix,
-}
+    concepts: [Word, Observation, ErrorModel, LanguageModel, Correction, ConfusionMatrix],
 
-define_ontology! {
-    /// Noisy Channel Model — spelling correction as categorical adjunction (Shannon 1948).
-    pub ChannelOntology for ChannelCategory {
-        concepts: ChannelConcept,
-        relation: ChannelRelation,
-        kind: ChannelRelationKind,
-        kinds: [
-            /// Word → Observation: the channel corrupts (F: Lang → Obs).
-            Corrupts,
-            /// Observation → Word: Bayesian inverse correction (G: Obs → Lang).
-            Corrects,
-            /// ErrorModel parameterizes the corruption.
-            Parameterizes,
-            /// LanguageModel provides prior probabilities.
-            Weights,
-            /// ConfusionMatrix provides edit-level probabilities.
-            Provides,
-            /// Correction uses both ErrorModel and LanguageModel.
-            Uses,
-        ],
-        edges: [
-            // The channel: Word → Observation (corruption)
-            (Word, Observation, Corrupts),
-            // The inverse: Observation → Word (correction / adjoint)
-            (Observation, Word, Corrects),
-            // ErrorModel parameterizes the channel
-            (ErrorModel, Observation, Parameterizes),
-            // LanguageModel weights the prior
-            (LanguageModel, Word, Weights),
-            // ConfusionMatrix provides edit probabilities to ErrorModel
-            (ConfusionMatrix, ErrorModel, Provides),
-            // Correction uses both models
-            (Correction, ErrorModel, Uses),
-            (Correction, LanguageModel, Uses),
-            // The adjunction: Observation → Correction → Word
-            (Correction, Word, Corrects),
-        ],
-        composed: [
-            // The adjunction: G∘F ≈ Id (correction after corruption ≈ identity)
-            (Observation, Correction),
-            (Word, Word),
-            (ConfusionMatrix, Observation),
-        ],
+    labels: {
+        Word: ("en", "Word", "A word in the language, with its prior probability P(w)."),
+        Observation: ("en", "Observation", "An observed string (possibly misspelled)."),
+        ErrorModel: ("en", "Error model", "P(x|w) — probability of misspelling x given intended word w."),
+        LanguageModel: ("en", "Language model", "P(w) — prior probability of the word."),
+        Correction: ("en", "Correction", "argmax_w P(x|w) * P(w). The Bayesian right adjoint."),
+        ConfusionMatrix: ("en", "Confusion matrix", "Edit probabilities for a specific operation type: del, ins, sub, trans."),
+    },
 
-        being: AbstractObject,
-        source: "Shannon (1948); Kernighan et al. (1990)",
-    }
+    edges: [
+        // The channel: Word → Observation (corruption)
+        (Word, Observation, Corrupts),
+        // The inverse: Observation → Word (correction / adjoint)
+        (Observation, Word, Corrects),
+        // ErrorModel parameterizes the channel
+        (ErrorModel, Observation, Parameterizes),
+        // LanguageModel weights the prior
+        (LanguageModel, Word, Weights),
+        // ConfusionMatrix provides edit probabilities to ErrorModel
+        (ConfusionMatrix, ErrorModel, Provides),
+        // Correction uses both models
+        (Correction, ErrorModel, Uses),
+        (Correction, LanguageModel, Uses),
+        // The adjunction: Observation → Correction → Word
+        (Correction, Word, Corrects),
+    ],
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use pr4xis::category::Category;
+    use pr4xis::category::Entity;
     use pr4xis::category::validate::check_category_laws;
 
     #[test]
@@ -124,8 +89,6 @@ mod tests {
 
     #[test]
     fn adjunction_composes() {
-        // F: Word → Observation, G: Observation → Word
-        // G∘F: Word → Word (should exist as composition)
         let f = ChannelRelation {
             from: ChannelConcept::Word,
             to: ChannelConcept::Observation,

--- a/crates/domains/src/cognitive/linguistics/pipeline/ontology.rs
+++ b/crates/domains/src/cognitive/linguistics/pipeline/ontology.rs
@@ -1,148 +1,106 @@
-// Parse ⊣ Generate — the bidirectional language pipeline as adjunction.
-//
-// The central theorem: parsing and generation are adjoint functors
-// over the same grammar. Parse is the left adjoint (surface → meaning),
-// Generate is the right adjoint (meaning → surface).
-//
-// de Groote ACG (2001): a lexicon IS a homomorphism L: Σ_abstract → Σ_object.
-// Parsing = finding the pre-image of L (hard: proof search).
-// Generation = applying L (easy: beta-reduction).
-// The SAME grammar does both — the direction is the adjunction.
-//
-// Coecke, Sadrzadeh & Clark DisCoCat (2010): meaning IS a strong
-// monoidal functor F: Grammar → Semantics. The functor maps
-// grammatical composition to semantic composition.
-//
-// Lambek & Scott (1986): parsing IS proof search in the type logic.
-// A proof term IS the parse tree. Generation = proof normalization.
-//
-// Levelt (1989): generation follows Conceptualizer → Formulator →
-// Articulator. The parse direction reverses this: Articulator →
-// Formulator → Conceptualizer (surface → syntax → semantics).
-//
-// Di Lavore & de Felice (2022): monoidal streams for incremental
-// processing — the pipeline produces partial results over time via
-// coKleisli arrows of a comonad.
-//
-// Source: de Groote (2001); Lambek (1958); Lambek & Scott (1986);
-//         Coecke, Sadrzadeh & Clark (2010); Levelt (1989);
-//         Di Lavore & de Felice (2022)
+//! Parse ⊣ Generate — the bidirectional language pipeline as adjunction.
+//!
+//! The central theorem: parsing and generation are adjoint functors
+//! over the same grammar. Parse is the left adjoint (surface → meaning),
+//! Generate is the right adjoint (meaning → surface).
+//!
+//! de Groote ACG (2001): a lexicon IS a homomorphism L: Σ_abstract → Σ_object.
+//! Parsing = finding the pre-image of L (hard: proof search).
+//! Generation = applying L (easy: beta-reduction).
+//! The SAME grammar does both — the direction is the adjunction.
+//!
+//! Coecke, Sadrzadeh & Clark DisCoCat (2010): meaning IS a strong
+//! monoidal functor F: Grammar → Semantics.
+//!
+//! Lambek & Scott (1986): parsing IS proof search in the type logic.
+//!
+//! Levelt (1989): generation follows Conceptualizer → Formulator → Articulator.
+//!
+//! Di Lavore & de Felice (2022): monoidal streams for incremental processing.
+//!
+//! Source: de Groote (2001); Lambek (1958); Lambek & Scott (1986);
+//!         Coecke, Sadrzadeh & Clark (2010); Levelt (1989);
+//!         Di Lavore & de Felice (2022)
 
-use pr4xis::category::Entity;
-use pr4xis::define_ontology;
 use pr4xis::ontology::{Axiom, Ontology, Quality};
 
-/// Concepts in the Parse ⊣ Generate pipeline ontology.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Entity)]
-pub enum PipelineConcept {
-    // === The adjunction (Mac Lane 1971 Ch. IV) ===
-    /// The Parse functor — left adjoint. Surface → Meaning.
-    /// Proof search in the type logic (Lambek 1958).
-    Parse,
+pr4xis::ontology! {
+    name: "Pipeline",
+    source: "de Groote (2001); Lambek (1958); Coecke et al. (2010); Levelt (1989); Di Lavore & de Felice (2022)",
+    being: Process,
 
-    /// The Generate functor — right adjoint. Meaning → Surface.
-    /// Beta-reduction of the lexicon homomorphism (de Groote 2001).
-    Generate,
+    concepts: [
+        // The adjunction (Mac Lane 1971 Ch. IV)
+        Parse,
+        Generate,
+        Unit,
+        Counit,
+        // Pipeline stages (Levelt 1989 + de Groote 2001)
+        SurfaceForm,
+        SyntacticStructure,
+        SemanticRepresentation,
+        LexiconHomomorphism,
+        ProofTerm,
+        MeaningFunctor,
+        // Streaming / incremental (Di Lavore & de Felice 2022)
+        PartialResult,
+        Stream,
+    ],
 
-    /// η: Id → G∘F — the unit of the adjunction.
-    /// What survives the round trip: parse then generate.
-    /// A meaning that can be expressed (not all meanings can).
-    Unit,
+    labels: {
+        Parse: ("en", "Parse", "The Parse functor — left adjoint. Surface → Meaning. Proof search in the type logic (Lambek 1958)."),
+        Generate: ("en", "Generate", "The Generate functor — right adjoint. Meaning → Surface. Beta-reduction of the lexicon homomorphism (de Groote 2001)."),
+        Unit: ("en", "Unit", "η: Id → G∘F — the unit of the adjunction. What survives the round trip: parse then generate."),
+        Counit: ("en", "Counit", "ε: F∘G → Id — the counit of the adjunction. What survives generating then parsing back."),
+        SurfaceForm: ("en", "Surface form", "Text as it appears. NIF Context/Word layer. The object vocabulary (de Groote)."),
+        SyntacticStructure: ("en", "Syntactic structure", "The proof term / parse tree. Lambek type assignment + reduction."),
+        SemanticRepresentation: ("en", "Semantic representation", "The meaning. DisCoCat functor image. The abstract vocabulary (de Groote)."),
+        LexiconHomomorphism: ("en", "Lexicon homomorphism", "L: Σ_abstract → Σ_object (de Groote 2001). Bridges abstract ↔ object."),
+        ProofTerm: ("en", "Proof term", "A proof term in the type logic — parsing IS proof search (Lambek & Scott 1986)."),
+        MeaningFunctor: ("en", "Meaning functor", "DisCoCat F: Grammar → Semantics. Strong monoidal: preserves composition."),
+        PartialResult: ("en", "Partial result", "A partial result in the pipeline — not yet complete. Comonadic: carries context."),
+        Stream: ("en", "Stream", "The stream of partial results over time. Monoidal stream: composition of incremental steps."),
+    },
 
-    /// ε: F∘G → Id — the counit of the adjunction.
-    /// What survives generating then parsing back.
-    /// A surface form that parses unambiguously.
-    Counit,
+    is_a: [
+        (Unit, Parse),
+        (Counit, Generate),
+        (ProofTerm, SyntacticStructure),
+        (PartialResult, Stream),
+    ],
 
-    // === Pipeline stages (Levelt 1989 + de Groote 2001) ===
-    /// The surface form — text as it appears.
-    /// NIF Context/Word layer. The object vocabulary (de Groote).
-    SurfaceForm,
+    has_a: [
+        // Parse has stages: SurfaceForm → SyntacticStructure → SemanticRepresentation
+        (Parse, SurfaceForm),
+        (Parse, SyntacticStructure),
+        (Parse, SemanticRepresentation),
+        // Generate has stages in reverse
+        (Generate, SemanticRepresentation),
+        (Generate, SyntacticStructure),
+        (Generate, SurfaceForm),
+        // The lexicon homomorphism is shared
+        (Parse, LexiconHomomorphism),
+        (Generate, LexiconHomomorphism),
+        // The meaning functor connects grammar to semantics
+        (Parse, MeaningFunctor),
+        // Stream contains partial results
+        (Stream, PartialResult),
+    ],
 
-    /// Syntactic analysis — the proof term / parse tree.
-    /// Lambek type assignment + reduction.
-    SyntacticStructure,
+    causes: [
+        // Parse direction: surface causes syntactic, syntactic causes semantic
+        (SurfaceForm, SyntacticStructure),
+        (SyntacticStructure, SemanticRepresentation),
+        // LexiconHomomorphism enables proof construction
+        (LexiconHomomorphism, ProofTerm),
+    ],
 
-    /// Semantic representation — the meaning.
-    /// DisCoCat functor image. The abstract vocabulary (de Groote).
-    SemanticRepresentation,
-
-    /// The lexicon homomorphism — bridges abstract ↔ object.
-    /// de Groote (2001): L: Σ_abstract → Σ_object.
-    /// THIS is what makes parse and generate use the same grammar.
-    LexiconHomomorphism,
-
-    /// A proof term in the type logic — parsing IS proof search.
-    /// Lambek & Scott (1986): proofs as programs.
-    ProofTerm,
-
-    /// The meaning functor — DisCoCat F: Grammar → Semantics.
-    /// Strong monoidal: preserves composition.
-    MeaningFunctor,
-
-    // === Streaming / incremental (Di Lavore & de Felice 2022) ===
-    /// A partial result in the pipeline — not yet complete.
-    /// Comonadic: carries context of what came before.
-    PartialResult,
-
-    /// The stream of partial results over time.
-    /// Monoidal stream: composition of incremental steps.
-    Stream,
-}
-
-define_ontology! {
-    /// Parse ⊣ Generate — the language pipeline adjunction.
-    pub PipelineOntology for PipelineCategory {
-        concepts: PipelineConcept,
-        relation: PipelineRelation,
-
-        being: Process,
-        source: "de Groote (2001); Lambek (1958); Coecke et al. (2010); Levelt (1989); Di Lavore & de Felice (2022)",
-
-        is_a: PipelineTaxonomy [
-            // Unit and Counit are structural parts of the adjunction
-            (Unit, Parse),
-            (Counit, Generate),
-            // ProofTerm is a SyntacticStructure
-            (ProofTerm, SyntacticStructure),
-            // PartialResult is part of a Stream
-            (PartialResult, Stream),
-        ],
-
-        has_a: PipelineMereology [
-            // Parse has stages: SurfaceForm → SyntacticStructure → SemanticRepresentation
-            (Parse, SurfaceForm),
-            (Parse, SyntacticStructure),
-            (Parse, SemanticRepresentation),
-            // Generate has stages in reverse
-            (Generate, SemanticRepresentation),
-            (Generate, SyntacticStructure),
-            (Generate, SurfaceForm),
-            // The lexicon homomorphism is shared
-            (Parse, LexiconHomomorphism),
-            (Generate, LexiconHomomorphism),
-            // The meaning functor connects grammar to semantics
-            (Parse, MeaningFunctor),
-            // Stream contains partial results
-            (Stream, PartialResult),
-        ],
-
-        causes: PipelineCausation for PipelineConcept [
-            // Parse direction: surface causes syntactic, syntactic causes semantic
-            // (Generation is the REVERSE adjoint, not a separate causal chain)
-            (SurfaceForm, SyntacticStructure),
-            (SyntacticStructure, SemanticRepresentation),
-            // LexiconHomomorphism enables proof construction
-            (LexiconHomomorphism, ProofTerm),
-        ],
-
-        opposes: PipelineOpposition [
-            // Parse ⊣ Generate — the adjunction itself
-            (Parse, Generate),
-            // Surface vs Meaning — the two endpoints
-            (SurfaceForm, SemanticRepresentation),
-        ],
-    }
+    opposes: [
+        // Parse ⊣ Generate — the adjunction itself
+        (Parse, Generate),
+        // Surface vs Meaning — the two endpoints
+        (SurfaceForm, SemanticRepresentation),
+    ],
 }
 
 /// Whether a concept is a pipeline stage vs structural/streaming.

--- a/crates/domains/src/cognitive/linguistics/pragmatics/discourse/ontology.rs
+++ b/crates/domains/src/cognitive/linguistics/pragmatics/discourse/ontology.rs
@@ -1,129 +1,72 @@
-// Discourse Coherence — RST + SDRT.
-//
-// Rhetorical relations are MORPHISMS (typed edges), not objects.
-// An Elaboration is a relationship between a Nucleus and its Satellite —
-// it doesn't exist independently. This follows Mann & Thompson (1988)
-// and Asher & Lascarides (2003): relations have specific semantic
-// conditions and aren't arbitrary connections.
-//
-// Concepts (objects): TextSpan, Nucleus, Satellite, DiscourseSegment,
-//   DiscourseStructure, Topic.
-// Relations (morphism kinds): Elaboration, Sequence, Cause, Condition,
-//   Purpose, Background, Justify, Restatement, Concession, Contrast,
-//   Narration, Explanation, Parallel, Continuation.
-//
-// Source: Mann & Thompson (1988); Asher & Lascarides (2003); Hobbs (1979)
+//! Discourse Coherence — RST + SDRT.
+//!
+//! Rhetorical relations are MORPHISMS (typed edges), not objects.
+//! An Elaboration is a relationship between a Nucleus and its Satellite —
+//! it doesn't exist independently. This follows Mann & Thompson (1988)
+//! and Asher & Lascarides (2003): relations have specific semantic
+//! conditions and aren't arbitrary connections.
+//!
+//! Concepts (objects): TextSpan, Nucleus, Satellite, DiscourseSegment,
+//!   DiscourseStructure, Topic.
+//! Relations (morphism kinds): Elaboration, Sequence, Cause, Condition,
+//!   Purpose, Background, Justify, Restatement, Concession, Contrast,
+//!   Narration, Explanation, Parallel, Continuation.
+//!
+//! Source: Mann & Thompson (1988); Asher & Lascarides (2003); Hobbs (1979)
 
-use pr4xis::category::{Category, Entity};
-use pr4xis::define_ontology;
+use pr4xis::category::Category;
 use pr4xis::ontology::{Axiom, Ontology, Quality};
 
-/// Structural concepts in discourse — what text IS.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Entity)]
-pub enum DiscourseConcept {
-    /// A minimal unit of text that participates in discourse structure.
-    TextSpan,
-    /// The more central part of a nucleus-satellite pair.
-    Nucleus,
-    /// The supporting part — depends on the nucleus for interpretation.
-    Satellite,
-    /// An elementary discourse unit (SDRT).
-    DiscourseSegment,
-    /// A complex discourse structure built from segments + relations.
-    DiscourseStructure,
-    /// What the discourse is about.
-    Topic,
-}
+pr4xis::ontology! {
+    name: "Discourse",
+    source: "Mann & Thompson (1988); Asher & Lascarides (2003); Hobbs (1979)",
+    being: AbstractObject,
 
-define_ontology! {
-    /// Discourse Coherence — RST + SDRT with typed rhetorical relations.
-    pub DiscourseOntology for DiscourseCategory {
-        concepts: DiscourseConcept,
-        relation: DiscourseRelation,
-        kind: DiscourseRelationKind,
-        kinds: [
-            // === Subject-matter relations (RST, informational) ===
-            /// Adding detail to the nucleus.
-            Elaboration,
-            /// Temporal or logical sequence.
-            Sequence,
-            /// Causal connection.
-            Cause,
-            /// A condition under which the nucleus holds.
-            Condition,
-            /// The goal behind an action.
-            Purpose,
-            /// Setting the context.
-            Background,
+    concepts: [TextSpan, Nucleus, Satellite, DiscourseSegment, DiscourseStructure, Topic],
 
-            // === Presentational relations (RST, affect attitude) ===
-            /// Making the nucleus more believable.
-            Justify,
-            /// Restating in different words.
-            Restatement,
-            /// Acknowledging incompatibility then overriding.
-            Concession,
-            /// Highlighting difference.
-            Contrast,
+    labels: {
+        TextSpan: ("en", "Text span", "A minimal unit of text that participates in discourse structure."),
+        Nucleus: ("en", "Nucleus", "The more central part of a nucleus-satellite pair (RST)."),
+        Satellite: ("en", "Satellite", "The supporting part — depends on the nucleus for interpretation."),
+        DiscourseSegment: ("en", "Discourse segment", "An elementary discourse unit (SDRT)."),
+        DiscourseStructure: ("en", "Discourse structure", "A complex discourse structure built from segments + relations."),
+        Topic: ("en", "Topic", "What the discourse is about."),
+    },
 
-            // === SDRT-specific relations ===
-            /// Temporal progression (Asher & Lascarides).
-            Narration,
-            /// Causal explanation of a previous event.
-            Explanation,
-            /// Similar content in parallel structure.
-            Parallel,
-            /// Continuing without new rhetorical structure.
-            Continuation,
+    edges: [
+        // Nucleus-Satellite relations (RST core)
+        (Nucleus, Satellite, Elaboration),
+        (Nucleus, Satellite, Justify),
+        (Nucleus, Satellite, Restatement),
+        (Nucleus, Satellite, Concession),
+        (Nucleus, Satellite, Background),
+        (Nucleus, Satellite, Condition),
+        (Nucleus, Satellite, Purpose),
+        // Multinuclear relations (both spans are nuclei)
+        (Nucleus, Nucleus, Sequence),
+        (Nucleus, Nucleus, Contrast),
+        (Nucleus, Nucleus, Parallel),
+        (Nucleus, Nucleus, Continuation),
+        // Causal relations (SDRT)
+        (DiscourseSegment, DiscourseSegment, Cause),
+        (DiscourseSegment, DiscourseSegment, Explanation),
+        (DiscourseSegment, DiscourseSegment, Narration),
+        // Structural containment
+        (DiscourseStructure, DiscourseSegment, Contains),
+        (DiscourseStructure, Nucleus, Contains),
+        (DiscourseStructure, Satellite, Contains),
+        (DiscourseStructure, Topic, Contains),
+    ],
 
-            // === Structural relations ===
-            /// Structure contains segments.
-            Contains,
-        ],
-        edges: [
-            // Nucleus-Satellite relations (RST core)
-            (Nucleus, Satellite, Elaboration),
-            (Nucleus, Satellite, Justify),
-            (Nucleus, Satellite, Restatement),
-            (Nucleus, Satellite, Concession),
-            (Nucleus, Satellite, Background),
-            (Nucleus, Satellite, Condition),
-            (Nucleus, Satellite, Purpose),
+    is_a: [
+        (Nucleus, TextSpan),
+        (Satellite, TextSpan),
+        (DiscourseSegment, TextSpan),
+    ],
 
-            // Multinuclear relations (both spans are nuclei)
-            (Nucleus, Nucleus, Sequence),
-            (Nucleus, Nucleus, Contrast),
-            (Nucleus, Nucleus, Parallel),
-            (Nucleus, Nucleus, Continuation),
-
-            // Causal relations (SDRT)
-            (DiscourseSegment, DiscourseSegment, Cause),
-            (DiscourseSegment, DiscourseSegment, Explanation),
-            (DiscourseSegment, DiscourseSegment, Narration),
-
-            // Structural containment
-            (DiscourseStructure, DiscourseSegment, Contains),
-            (DiscourseStructure, Nucleus, Contains),
-            (DiscourseStructure, Satellite, Contains),
-            (DiscourseStructure, Topic, Contains),
-        ],
-        composed: [
-            (DiscourseStructure, TextSpan),
-        ],
-
-        being: AbstractObject,
-        source: "Mann & Thompson (1988); Asher & Lascarides (2003); Hobbs (1979)",
-
-        is_a: DiscourseTaxonomy [
-            (Nucleus, TextSpan),
-            (Satellite, TextSpan),
-            (DiscourseSegment, TextSpan),
-        ],
-
-        opposes: DiscourseOpposition [
-            (Nucleus, Satellite),
-        ],
-    }
+    opposes: [
+        (Nucleus, Satellite),
+    ],
 }
 
 /// Whether a concept is structural vs a text unit.

--- a/crates/domains/src/cognitive/linguistics/pragmatics/fragment/ontology.rs
+++ b/crates/domains/src/cognitive/linguistics/pragmatics/fragment/ontology.rs
@@ -1,73 +1,65 @@
-// Fragment Resolution — non-sentential utterances in dialogue.
-//
-// Most dialogue utterances are not full sentences. "Yes", "the red one",
-// "tomorrow?", "John" — these fragments are interpretable only in context.
-// This ontology models how fragments are resolved to full propositions
-// using the QUD (Question Under Discussion) and dialogue context.
-//
-// Source: Fernandez & Ginzburg (2002, 2006); Ginzburg "The Interactive Stance" (2012);
-//         Schlangen (2003); Purver et al. (2006)
+//! Fragment Resolution — non-sentential utterances in dialogue.
+//!
+//! Most dialogue utterances are not full sentences. "Yes", "the red one",
+//! "tomorrow?", "John" — these fragments are interpretable only in context.
+//! This ontology models how fragments are resolved to full propositions
+//! using the QUD (Question Under Discussion) and dialogue context.
+//!
+//! Source: Fernandez & Ginzburg (2002, 2006); Ginzburg "The Interactive Stance" (2012);
+//!         Schlangen (2003); Purver et al. (2006)
 
-use pr4xis::category::Entity;
-use pr4xis::define_ontology;
 use pr4xis::ontology::{Axiom, Ontology, Quality};
 
-/// Concepts in the Fragment Resolution ontology.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Entity)]
-pub enum FragmentConcept {
-    /// A non-sentential utterance — syntactically incomplete.
-    Fragment,
-    /// The resolved full proposition derived from fragment + context.
-    ResolvedContent,
-    /// The Question Under Discussion that licenses the fragment.
-    QUD,
-    /// The dialogue context providing resolution material.
-    DialogueContext,
+pr4xis::ontology! {
+    name: "Fragment",
+    source: "Fernandez & Ginzburg (2002, 2006); Ginzburg (2012); Schlangen (2003)",
+    being: AbstractObject,
 
-    // === Fragment types (Fernandez & Ginzburg 2002) ===
-    /// Short answer to a question: "John" → "John left".
-    ShortAnswer,
-    /// Acknowledgment/confirmation: "Yes" / "OK".
-    Affirmation,
-    /// Rejection: "No" / "Not really".
-    Rejection,
-    /// Sluice — bare wh-word: "Who?" / "Where?".
-    Sluice,
-    /// Clarification ellipsis: "John?" (did you say John?).
-    ClarificationEllipsis,
-    /// Propositional fragment completing a prior partial: "tomorrow".
-    Completion,
-    /// Correction of a prior utterance: "no, TUESDAY".
-    Correction,
-    /// Plain acknowledgment token: "uh-huh", "right".
-    AcknowledgmentToken,
-}
+    concepts: [
+        Fragment,
+        ResolvedContent,
+        QUD,
+        DialogueContext,
+        ShortAnswer,
+        Affirmation,
+        Rejection,
+        Sluice,
+        ClarificationEllipsis,
+        Completion,
+        Correction,
+        AcknowledgmentToken,
+    ],
 
-define_ontology! {
-    /// Fragment Resolution — interpreting non-sentential utterances.
-    pub FragmentOntology for FragmentCategory {
-        concepts: FragmentConcept,
-        relation: FragmentRelation,
+    labels: {
+        Fragment: ("en", "Fragment", "A non-sentential utterance — syntactically incomplete."),
+        ResolvedContent: ("en", "Resolved content", "The resolved full proposition derived from fragment + context."),
+        QUD: ("en", "Question Under Discussion", "The QUD that licenses the fragment."),
+        DialogueContext: ("en", "Dialogue context", "The dialogue context providing resolution material."),
+        ShortAnswer: ("en", "Short answer", "Short answer to a question: 'John' → 'John left'."),
+        Affirmation: ("en", "Affirmation", "Acknowledgment/confirmation: 'Yes' / 'OK'."),
+        Rejection: ("en", "Rejection", "Rejection: 'No' / 'Not really'."),
+        Sluice: ("en", "Sluice", "Bare wh-word: 'Who?' / 'Where?'."),
+        ClarificationEllipsis: ("en", "Clarification ellipsis", "'John?' (did you say John?)."),
+        Completion: ("en", "Completion", "Propositional fragment completing a prior partial: 'tomorrow'."),
+        Correction: ("en", "Correction", "Correction of a prior utterance: 'no, TUESDAY'."),
+        AcknowledgmentToken: ("en", "Acknowledgment token", "Plain acknowledgment token: 'uh-huh', 'right'."),
+    },
 
-        being: AbstractObject,
-        source: "Fernandez & Ginzburg (2002, 2006); Ginzburg (2012); Schlangen (2003)",
+    is_a: [
+        (ShortAnswer, Fragment),
+        (Affirmation, Fragment),
+        (Rejection, Fragment),
+        (Sluice, Fragment),
+        (ClarificationEllipsis, Fragment),
+        (Completion, Fragment),
+        (Correction, Fragment),
+        (AcknowledgmentToken, Fragment),
+    ],
 
-        is_a: FragmentTaxonomy [
-            (ShortAnswer, Fragment),
-            (Affirmation, Fragment),
-            (Rejection, Fragment),
-            (Sluice, Fragment),
-            (ClarificationEllipsis, Fragment),
-            (Completion, Fragment),
-            (Correction, Fragment),
-            (AcknowledgmentToken, Fragment),
-        ],
-
-        opposes: FragmentOpposition [
-            (Affirmation, Rejection),
-            (Fragment, ResolvedContent),
-        ],
-    }
+    opposes: [
+        (Affirmation, Rejection),
+        (Fragment, ResolvedContent),
+    ],
 }
 
 /// Whether a concept is a fragment type vs structural.

--- a/crates/domains/src/cognitive/linguistics/pragmatics/generation.rs
+++ b/crates/domains/src/cognitive/linguistics/pragmatics/generation.rs
@@ -1,122 +1,62 @@
-use pr4xis::category::Entity;
-use pr4xis::define_ontology;
+//! Speech production ontology — the generation pipeline.
+//!
+//! This is the RIGHT ADJOINT of the parsing pipeline.
+//! Parse: Text → Syntax → Semantics (left adjoint, F)
+//! Generate: Semantics → Syntax → Text (right adjoint, G)
+//! Together: Parse ⊣ Generate (adjunction)
+//!
+//! The pipeline follows Levelt's speech production model (1989):
+//!   Conceptualizer → PreverbalMessage → Formulator → SurfaceForm
+//!
+//! Enriched by:
+//! - Reiter & Dale (2000): content determination → document planning → microplanning → realization
+//! - Appelt (1985): speech acts as plan operators with preconditions and effects
+//! - Pogodalla (2000): generation in Lambek calculus = proof search with semantic constraint fixed
+//! - de Groote (2001): ACG generation = beta-reduction of lexicon homomorphism (trivial!)
+//! - McKeown (1985): rhetorical schemata for content organization
 
-// Speech production ontology — the generation pipeline.
-//
-// This is the RIGHT ADJOINT of the parsing pipeline.
-// Parse: Text → Syntax → Semantics (left adjoint, F)
-// Generate: Semantics → Syntax → Text (right adjoint, G)
-// Together: Parse ⊣ Generate (adjunction)
-//
-// The pipeline follows Levelt's speech production model (1989):
-//   Conceptualizer → PreverbalMessage → Formulator → SurfaceForm
-//
-// Enriched by:
-// - Reiter & Dale (2000): content determination → document planning → microplanning → realization
-// - Appelt (1985): speech acts as plan operators with preconditions and effects
-// - Pogodalla (2000): generation in Lambek calculus = proof search with semantic constraint fixed
-// - de Groote (2001): ACG generation = beta-reduction of lexicon homomorphism (trivial!)
-// - McKeown (1985): rhetorical schemata for content organization
-//
-// The key theorem (Pogodalla/de Groote): the SAME grammar does both parsing and
-// generation. Generation is the easy direction (beta-reduce). Parsing is the hard
-// direction (find pre-image). Our Lambek grammar already has everything needed.
+pr4xis::ontology! {
+    name: "Production",
+    source: "Levelt (1989); de Groote (2001); Reiter & Dale (2000); Appelt (1985); McKeown (1985)",
+    being: Process,
 
-/// Concepts in the speech production pipeline.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Entity)]
-pub enum ProductionConcept {
-    /// What the system wants to achieve by speaking.
-    /// Appelt (1985): a goal in the hearer's mental state.
-    CommunicativeGoal,
+    concepts: [
+        CommunicativeGoal,
+        PreverbalMessage,
+        SentencePlan,
+        SurfaceForm,
+        Monitor,
+        Message,
+        DocumentPlan,
+        LexicalChoice,
+    ],
 
-    /// The pre-linguistic representation of what to say.
-    /// Levelt (1989): output of the Conceptualizer.
-    /// Contains: speech act type, propositional content, topic/focus, mood.
-    PreverbalMessage,
+    labels: {
+        CommunicativeGoal: ("en", "Communicative goal", "What the system wants to achieve by speaking. Appelt (1985): a goal in the hearer's mental state."),
+        PreverbalMessage: ("en", "Preverbal message", "The pre-linguistic representation of what to say. Levelt (1989): output of the Conceptualizer."),
+        SentencePlan: ("en", "Sentence plan", "The grammatical structure being built. Levelt (1989): output of the Formulator's grammatical encoder."),
+        SurfaceForm: ("en", "Surface form", "The final realized utterance. de Groote (2001): L(abstract_term) = beta-reduce = surface string."),
+        Monitor: ("en", "Monitor", "The self-monitoring loop — parse back and compare to intention. Levelt (1989): inner speech loop."),
+        Message: ("en", "Message", "A fact selected from the knowledge base for expression. Reiter & Dale (2000): the atomic unit of communicable content."),
+        DocumentPlan: ("en", "Document plan", "The rhetorical structure organizing multiple messages. Mann & Thompson RST (1988); McKeown (1985) schemata."),
+        LexicalChoice: ("en", "Lexical choice", "A word selected from the lexicon to express a concept. Levelt (1989): lemma retrieval."),
+    },
 
-    /// The grammatical structure being built.
-    /// Levelt (1989): output of the Formulator's grammatical encoder.
-    /// = Vec<(word, LambekType)> — a typed sequence ready for realization.
-    SentencePlan,
-
-    /// The final surface string — the realized utterance.
-    /// de Groote (2001): L(abstract_term) = beta-reduce = surface string.
-    SurfaceForm,
-
-    /// The self-monitoring loop — parse back and compare to intention.
-    /// Levelt (1989): the speech comprehension system applied to own output.
-    /// = Metacognition applied to generation.
-    Monitor,
-
-    /// A fact selected from the knowledge base for expression.
-    /// Reiter & Dale (2000): the atomic unit of communicable content.
-    Message,
-
-    /// The rhetorical structure organizing multiple messages.
-    /// Mann & Thompson RST (1988): nucleus/satellite tree.
-    /// McKeown (1985): rhetorical schemata.
-    DocumentPlan,
-
-    /// A word selected from the lexicon to express a concept.
-    /// Levelt (1989): lemma retrieval from mental lexicon.
-    LexicalChoice,
-}
-
-define_ontology! {
-    /// Speech Production — the Levelt pipeline (1989) with NLG extensions.
-    pub ProductionOntology for ProductionCategory {
-        concepts: ProductionConcept,
-        relation: ProductionRelation,
-        kind: ProductionRelationKind,
-        kinds: [
-            /// CommunicativeGoal conceptualized into PreverbalMessage (Levelt macro+micro planning).
-            Conceptualizes,
-            /// PreverbalMessage formulated into SentencePlan (Levelt grammatical encoding).
-            Formulates,
-            /// SentencePlan realized as SurfaceForm (de Groote ACG beta-reduction).
-            Realizes,
-            /// Monitor checks SurfaceForm against PreverbalMessage (Levelt inner speech loop).
-            Monitors,
-            /// CommunicativeGoal selects Messages from knowledge base (Reiter-Dale content det.).
-            Selects,
-            /// Messages organized into DocumentPlan (RST / McKeown schemata).
-            Organizes,
-            /// DocumentPlan elaborated into PreverbalMessage (Levelt micro-planning per clause).
-            Elaborates,
-            /// SentencePlan uses LexicalChoice (Levelt lemma access).
-            UsesLexicon,
-        ],
-        edges: [
-            // The Levelt pipeline: Goal → PreverbalMessage → SentencePlan → SurfaceForm
-            (CommunicativeGoal, PreverbalMessage, Conceptualizes),
-            (PreverbalMessage, SentencePlan, Formulates),
-            (SentencePlan, SurfaceForm, Realizes),
-            // Monitor loop: SurfaceForm → Monitor → PreverbalMessage (repair)
-            (Monitor, SurfaceForm, Monitors),
-            (Monitor, PreverbalMessage, Monitors),
-            // Content determination: Goal → Messages → DocumentPlan → PreverbalMessage
-            (CommunicativeGoal, Message, Selects),
-            (Message, DocumentPlan, Organizes),
-            (DocumentPlan, PreverbalMessage, Elaborates),
-            // Lexical choice: SentencePlan uses LexicalChoice
-            (SentencePlan, LexicalChoice, UsesLexicon),
-        ],
-        composed: [
-            // Goal → SurfaceForm (full pipeline)
-            (CommunicativeGoal, SurfaceForm),
-            // Goal → SentencePlan (through PreverbalMessage)
-            (CommunicativeGoal, SentencePlan),
-            // Goal → DocumentPlan (through Messages)
-            (CommunicativeGoal, DocumentPlan),
-            // PreverbalMessage → SurfaceForm (formulate then realize)
-            (PreverbalMessage, SurfaceForm),
-            // DocumentPlan → SurfaceForm (through PreverbalMessage)
-            (DocumentPlan, SurfaceForm),
-        ],
-
-        being: Process,
-        source: "Levelt (1989); de Groote (2001)",
-    }
+    edges: [
+        // The Levelt pipeline: Goal → PreverbalMessage → SentencePlan → SurfaceForm
+        (CommunicativeGoal, PreverbalMessage, Conceptualizes),
+        (PreverbalMessage, SentencePlan, Formulates),
+        (SentencePlan, SurfaceForm, Realizes),
+        // Monitor loop: SurfaceForm → Monitor → PreverbalMessage (repair)
+        (Monitor, SurfaceForm, Monitors),
+        (Monitor, PreverbalMessage, Monitors),
+        // Content determination: Goal → Messages → DocumentPlan → PreverbalMessage
+        (CommunicativeGoal, Message, Selects),
+        (Message, DocumentPlan, Organizes),
+        (DocumentPlan, PreverbalMessage, Elaborates),
+        // Lexical choice: SentencePlan uses LexicalChoice
+        (SentencePlan, LexicalChoice, UsesLexicon),
+    ],
 }
 
 #[cfg(test)]
@@ -151,7 +91,6 @@ mod tests {
 
     #[test]
     fn levelt_pipeline_exists() {
-        // Goal → PreverbalMessage → SentencePlan → SurfaceForm
         let m = ProductionCategory::morphisms();
         assert!(
             m.iter()
@@ -172,7 +111,6 @@ mod tests {
 
     #[test]
     fn full_pipeline_composes() {
-        // Goal → PreverbalMessage → SentencePlan composes
         let conceptualize = ProductionRelation {
             from: ProductionConcept::CommunicativeGoal,
             to: ProductionConcept::PreverbalMessage,
@@ -190,7 +128,6 @@ mod tests {
 
     #[test]
     fn goal_reaches_surface_form() {
-        // The full composed path should exist
         assert!(
             ProductionCategory::morphisms()
                 .iter()
@@ -202,7 +139,6 @@ mod tests {
 
     #[test]
     fn monitor_exists() {
-        // Monitor checks both SurfaceForm and PreverbalMessage
         let m = ProductionCategory::morphisms();
         assert!(m.iter().any(|r| r.from == ProductionConcept::Monitor
             && r.to == ProductionConcept::SurfaceForm
@@ -214,7 +150,6 @@ mod tests {
 
     #[test]
     fn content_determination_path() {
-        // Goal → Message → DocumentPlan → PreverbalMessage
         let m = ProductionCategory::morphisms();
         assert!(
             m.iter()

--- a/crates/domains/src/cognitive/linguistics/pragmatics/grounding/ontology.rs
+++ b/crates/domains/src/cognitive/linguistics/pragmatics/grounding/ontology.rs
@@ -1,132 +1,107 @@
-// Conversation Grounding — how participants establish mutual understanding.
-//
-// Grounding is the process by which conversational participants ensure
-// their contributions are understood. Every utterance must be grounded
-// before the conversation can advance — this is what distinguishes
-// dialogue from monologue.
-//
-// Clark & Schaefer (1989): contributions have two phases — presentation
-// and acceptance. The contribution is grounded when accepted.
-//
-// Clark "Using Language" (1996): grounding is a joint activity with
-// grounding criteria (evidence of understanding) that vary by medium.
-//
-// Traum (1994): computational grounding acts — acknowledge, continue,
-// initiate, repair, request clarification.
-//
-// Ginzburg "The Interactive Stance" (2012) KoS: information states,
-// dialogue gameboards, QUD (Questions Under Discussion) stack.
+//! Conversation Grounding — how participants establish mutual understanding.
+//!
+//! Grounding is the process by which conversational participants ensure
+//! their contributions are understood. Every utterance must be grounded
+//! before the conversation can advance — this is what distinguishes
+//! dialogue from monologue.
+//!
+//! Clark & Schaefer (1989): contributions have two phases — presentation
+//! and acceptance. The contribution is grounded when accepted.
+//!
+//! Clark "Using Language" (1996): grounding is a joint activity with
+//! grounding criteria (evidence of understanding) that vary by medium.
+//!
+//! Traum (1994): computational grounding acts — acknowledge, continue,
+//! initiate, repair, request clarification.
+//!
+//! Ginzburg "The Interactive Stance" (2012) KoS: information states,
+//! dialogue gameboards, QUD (Questions Under Discussion) stack.
 
-use pr4xis::category::Entity;
-use pr4xis::define_ontology;
 use pr4xis::ontology::{Axiom, Ontology, Quality};
 
-/// Concepts in the Conversation Grounding ontology.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Entity)]
-pub enum GroundingConcept {
-    // === Clark & Schaefer (1989) contribution model ===
-    /// Shared knowledge/beliefs between participants (Stalnaker 2002).
-    CommonGround,
-    /// The process of establishing mutual understanding.
-    Grounding,
-    /// An act that advances or maintains the grounding process.
-    GroundingAct,
-    /// Phase 1: speaker presents new content.
-    Presentation,
-    /// Phase 2: addressee signals understanding.
-    Acceptance,
-    /// A unit of discourse that has been jointly accepted.
-    Contribution,
+pr4xis::ontology! {
+    name: "Grounding",
+    source: "Clark & Schaefer (1989); Clark (1996); Traum (1994); Ginzburg (2012)",
+    being: Process,
 
-    // === Traum (1994) grounding acts ===
-    /// Explicit signal of understanding (nod, "uh-huh", paraphrase).
-    Acknowledgment,
-    /// Implicit grounding by continuing the conversation.
-    Continuation,
-    /// Starting a new contribution.
-    Initiation,
-    /// Third-party or self-repair of a misunderstanding.
-    Repair,
-    /// Requesting clarification of a previous utterance.
-    ClarificationRequest,
+    concepts: [
+        CommonGround,
+        Grounding,
+        GroundingAct,
+        Presentation,
+        Acceptance,
+        Contribution,
+        Acknowledgment,
+        Continuation,
+        Initiation,
+        Repair,
+        ClarificationRequest,
+        GroundingCriterion,
+        Evidence,
+        InfoState,
+        DialogueGameBoard,
+        LatestMove,
+        Pending,
+        MaxQUD,
+        Commitment,
+    ],
 
-    // === Clark (1996) grounding criteria ===
-    /// The standard of evidence required for grounding.
-    GroundingCriterion,
-    /// Evidence that the addressee understood (verbal, gestural, etc.).
-    Evidence,
+    labels: {
+        CommonGround: ("en", "Common ground", "Shared knowledge/beliefs between participants (Stalnaker 2002)."),
+        Grounding: ("en", "Grounding", "The process of establishing mutual understanding."),
+        GroundingAct: ("en", "Grounding act", "An act that advances or maintains the grounding process."),
+        Presentation: ("en", "Presentation", "Phase 1: speaker presents new content."),
+        Acceptance: ("en", "Acceptance", "Phase 2: addressee signals understanding."),
+        Contribution: ("en", "Contribution", "A unit of discourse that has been jointly accepted."),
+        Acknowledgment: ("en", "Acknowledgment", "Explicit signal of understanding (nod, 'uh-huh', paraphrase)."),
+        Continuation: ("en", "Continuation", "Implicit grounding by continuing the conversation."),
+        Initiation: ("en", "Initiation", "Starting a new contribution."),
+        Repair: ("en", "Repair", "Third-party or self-repair of a misunderstanding."),
+        ClarificationRequest: ("en", "Clarification request", "Requesting clarification of a previous utterance."),
+        GroundingCriterion: ("en", "Grounding criterion", "The standard of evidence required for grounding."),
+        Evidence: ("en", "Evidence", "Evidence that the addressee understood (verbal, gestural, etc.)."),
+        InfoState: ("en", "Info state", "The participant's private + shared information state."),
+        DialogueGameBoard: ("en", "Dialogue game board", "The public record of the dialogue state (QUD, moves, commitments)."),
+        LatestMove: ("en", "Latest move", "The most recent move in the dialogue."),
+        Pending: ("en", "Pending", "Content awaiting grounding (not yet integrated into common ground)."),
+        MaxQUD: ("en", "Max QUD", "The current Question Under Discussion driving the dialogue."),
+        Commitment: ("en", "Commitment", "A participant's commitment to a proposition."),
+    },
 
-    // === Ginzburg (2012) KoS framework ===
-    /// The participant's private + shared information state.
-    InfoState,
-    /// The public record of the dialogue state (QUD, moves, commitments).
-    DialogueGameBoard,
-    /// The most recent move in the dialogue.
-    LatestMove,
-    /// Content awaiting grounding (not yet integrated into common ground).
-    Pending,
-    /// The current Question Under Discussion driving the dialogue.
-    MaxQUD,
-    /// A participant's commitment to a proposition.
-    Commitment,
-}
+    is_a: [
+        (Acknowledgment, GroundingAct),
+        (Continuation, GroundingAct),
+        (Initiation, GroundingAct),
+        (Repair, GroundingAct),
+        (ClarificationRequest, GroundingAct),
+        (Presentation, Grounding),
+        (Acceptance, Grounding),
+        (GroundingCriterion, Grounding),
+        (Evidence, Grounding),
+    ],
 
-define_ontology! {
-    /// Conversation Grounding — mutual understanding in dialogue.
-    pub GroundingOntology for GroundingCategory {
-        concepts: GroundingConcept,
-        relation: GroundingRelation,
+    has_a: [
+        (CommonGround, Contribution),
+        (CommonGround, Commitment),
+        (InfoState, DialogueGameBoard),
+        (DialogueGameBoard, LatestMove),
+        (DialogueGameBoard, Pending),
+        (DialogueGameBoard, MaxQUD),
+    ],
 
-        being: Process,
-        source: "Clark & Schaefer (1989); Clark (1996); Traum (1994); Ginzburg (2012)",
+    causes: [
+        (Presentation, Acceptance),
+        (Presentation, Repair),
+        (ClarificationRequest, Repair),
+        (Acceptance, Contribution),
+        (GroundingAct, InfoState),
+    ],
 
-        is_a: GroundingTaxonomy [
-            // Grounding acts are specializations
-            (Acknowledgment, GroundingAct),
-            (Continuation, GroundingAct),
-            (Initiation, GroundingAct),
-            (Repair, GroundingAct),
-            (ClarificationRequest, GroundingAct),
-            // Presentation and Acceptance are phases of Grounding
-            (Presentation, Grounding),
-            (Acceptance, Grounding),
-            // Grounding criterion and evidence relate to the process
-            (GroundingCriterion, Grounding),
-            (Evidence, Grounding),
-        ],
-
-        has_a: GroundingMereology [
-            // Common ground is composed of grounded contributions
-            (CommonGround, Contribution),
-            (CommonGround, Commitment),
-            // InfoState has a dialogue gameboard
-            (InfoState, DialogueGameBoard),
-            // Dialogue gameboard has its components
-            (DialogueGameBoard, LatestMove),
-            (DialogueGameBoard, Pending),
-            (DialogueGameBoard, MaxQUD),
-        ],
-
-        causes: GroundingCausation for GroundingConcept [
-            // Presentation causes Acceptance (or Repair)
-            (Presentation, Acceptance),
-            (Presentation, Repair),
-            (ClarificationRequest, Repair),
-            // Acceptance causes update to CommonGround
-            (Acceptance, Contribution),
-            // Grounding act causes update to InfoState
-            (GroundingAct, InfoState),
-        ],
-
-        opposes: GroundingOpposition [
-            // Presentation vs Acceptance: speaker vs addressee phase
-            (Presentation, Acceptance),
-            // Acceptance vs Repair: understanding vs misunderstanding
-            (Acceptance, Repair),
-            // Pending vs Contribution: ungrounded vs grounded
-            (Pending, Contribution),
-        ],
-    }
+    opposes: [
+        (Presentation, Acceptance),
+        (Acceptance, Repair),
+        (Pending, Contribution),
+    ],
 }
 
 /// Whether a concept is from the Clark/Traum model vs Ginzburg KoS.

--- a/crates/domains/src/cognitive/linguistics/pragmatics/nlg.rs
+++ b/crates/domains/src/cognitive/linguistics/pragmatics/nlg.rs
@@ -1,141 +1,85 @@
-use pr4xis::category::Entity;
-use pr4xis::define_ontology;
+//! Natural Language Generation pipeline ontology.
+//!
+//! The Reiter & Dale (2000) four-stage pipeline, driven by metacognition
+//! (what do I know?) and the Levelt production model.
+//!
+//! The pipeline:
+//!   ContentDetermination → DocumentPlanning → Microplanning → Realization
+//!
+//! Each stage is a functor: transforms one representation into the next.
+//! Content determination is driven by the epistemics ontology (KK/KU/UK/UU).
+//! Document planning organizes using RST (rhetorical structure theory).
+//! Microplanning selects words and referring expressions.
+//! Realization produces surface text through the SVO grammar.
+//!
+//! References:
+//! - Reiter & Dale, "Building Natural Language Generation Systems" (2000)
+//! - Levelt, "Speaking: From Intention to Articulation" (1989)
+//! - Mann & Thompson, "Rhetorical Structure Theory" (1988) — RST
+//! - Appelt, "Planning English Sentences" (1985) — speech act planning
+//! - McKeown, "Text Generation" (1985) — rhetorical schemata
 
-// Natural Language Generation pipeline ontology.
-//
-// The Reiter & Dale (2000) four-stage pipeline, driven by
-// metacognition (what do I know?) and the Levelt production model.
-//
-// The pipeline:
-//   ContentDetermination → DocumentPlanning → Microplanning → Realization
-//
-// Each stage is a functor: transforms one representation into the next.
-// Content determination is driven by the epistemics ontology (KK/KU/UK/UU).
-// Document planning organizes using RST (rhetorical structure theory).
-// Microplanning selects words and referring expressions.
-// Realization produces surface text through the SVO grammar.
-//
-// References:
-// - Reiter & Dale, "Building Natural Language Generation Systems" (2000)
-// - Levelt, "Speaking: From Intention to Articulation" (1989)
-// - Mann & Thompson, "Rhetorical Structure Theory" (1988) — RST
-// - Appelt, "Planning English Sentences" (1985) — speech act planning
-// - McKeown, "Text Generation" (1985) — rhetorical schemata
+pr4xis::ontology! {
+    name: "Nlg",
+    source: "Reiter & Dale (2000); Levelt (1989); Mann & Thompson (1988); Appelt (1985)",
+    being: AbstractObject,
 
-/// Concepts in the NLG pipeline.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Entity)]
-pub enum NlgConcept {
-    /// The communicative goal — what the system wants to achieve.
-    /// Appelt (1985): a goal in the hearer's mental state.
-    /// Driven by the epistemic state from metacognition.
-    CommunicativeGoal,
+    concepts: [
+        CommunicativeGoal,
+        ContentDetermination,
+        Message,
+        DocumentPlanning,
+        RhetoricalRelation,
+        Microplanning,
+        ReferringExpression,
+        Realization,
+        SurfaceText,
+        KnowledgeGathering,
+        Monitor,
+    ],
 
-    /// Content determination: gather relevant knowledge from ontologies.
-    /// Reiter & Dale (2000), Stage 1.
-    /// Metacognition: traverse associations, find relationships.
-    ContentDetermination,
+    labels: {
+        CommunicativeGoal: ("en", "Communicative goal", "Appelt (1985): a goal in the hearer's mental state. Driven by the epistemic state from metacognition."),
+        ContentDetermination: ("en", "Content determination", "Reiter & Dale Stage 1: gather relevant knowledge from ontologies."),
+        Message: ("en", "Message", "A fact selected from the knowledge base for expression. The atomic unit of communicable content."),
+        DocumentPlanning: ("en", "Document planning", "Reiter & Dale Stage 2: organize messages using rhetorical structure. Mann & Thompson RST (1988): nucleus/satellite tree."),
+        RhetoricalRelation: ("en", "Rhetorical relation", "RST: elaboration, evidence, contrast, sequence, etc."),
+        Microplanning: ("en", "Microplanning", "Reiter & Dale Stage 3: select words, build referring expressions. Includes lexicalization, aggregation, REG."),
+        ReferringExpression: ("en", "Referring expression", "Dale & Reiter (1995) incremental algorithm for RE generation."),
+        Realization: ("en", "Realization", "Reiter & Dale Stage 4: produce actual text through grammar. de Groote (2001): beta-reduction in Lambek grammar."),
+        SurfaceText: ("en", "Surface text", "Levelt (1989): the articulated utterance — the output."),
+        KnowledgeGathering: ("en", "Knowledge gathering", "A structured collection of ontological facts gathered during content determination."),
+        Monitor: ("en", "Monitor", "Levelt (1989): the inner speech loop. Parse back the generated text and compare to intent."),
+    },
 
-    /// A fact selected from the knowledge base for expression.
-    /// Reiter & Dale (2000): the atomic unit of communicable content.
-    Message,
-
-    /// Document planning: organize messages using rhetorical structure.
-    /// Reiter & Dale (2000), Stage 2.
-    /// Mann & Thompson RST (1988): nucleus/satellite tree.
-    DocumentPlanning,
-
-    /// A rhetorical relation organizing multiple messages.
-    /// RST: elaboration, evidence, contrast, sequence, etc.
-    RhetoricalRelation,
-
-    /// Microplanning: select words, build referring expressions.
-    /// Reiter & Dale (2000), Stage 3.
-    /// Includes: lexicalization, aggregation, referring expression generation.
-    Microplanning,
-
-    /// A referring expression for an entity (definite, indefinite, pronoun).
-    /// Dale & Reiter (1995): incremental algorithm for RE generation.
-    ReferringExpression,
-
-    /// Surface realization: produce the actual text through grammar.
-    /// Reiter & Dale (2000), Stage 4.
-    /// de Groote (2001): beta-reduction in the Lambek grammar.
-    Realization,
-
-    /// The final surface text — the output.
-    /// Levelt (1989): the articulated utterance.
-    SurfaceText,
-
-    /// The knowledge gathered during content determination.
-    /// A structured collection of ontological facts.
-    KnowledgeGathering,
-
-    /// Self-monitoring: parse back the generated text and compare to intent.
-    /// Levelt (1989): the inner speech loop.
-    Monitor,
-}
-
-define_ontology! {
-    /// NLG Pipeline — four-stage generation (Reiter & Dale 2000).
-    pub NlgOntology for NlgCategory {
-        concepts: NlgConcept,
-        relation: NlgRelation,
-        kind: NlgRelationKind,
-        kinds: [
-            /// CommunicativeGoal drives ContentDetermination.
-            Drives,
-            /// ContentDetermination gathers KnowledgeGathering.
-            Gathers,
-            /// ContentDetermination selects Messages.
-            Selects,
-            /// DocumentPlanning organizes Messages using RhetoricalRelation.
-            Organizes,
-            /// Microplanning produces ReferringExpressions from Messages.
-            Produces,
-            /// Realization generates SurfaceText from the plan.
-            Generates,
-            /// Monitor checks SurfaceText against CommunicativeGoal.
-            Checks,
-            /// Pipeline stages: each precedes the next.
-            Precedes,
-        ],
-        edges: [
-            // CommunicativeGoal drives ContentDetermination
-            (CommunicativeGoal, ContentDetermination, Drives),
-            // ContentDetermination gathers knowledge and selects messages
-            (ContentDetermination, KnowledgeGathering, Gathers),
-            (ContentDetermination, Message, Selects),
-            // DocumentPlanning organizes using RhetoricalRelation
-            (DocumentPlanning, Message, Organizes),
-            (DocumentPlanning, RhetoricalRelation, Organizes),
-            // Microplanning produces ReferringExpressions
-            (Microplanning, ReferringExpression, Produces),
-            // Realization generates SurfaceText
-            (Realization, SurfaceText, Generates),
-            // Monitor checks SurfaceText against CommunicativeGoal
-            (Monitor, SurfaceText, Checks),
-            (Monitor, CommunicativeGoal, Checks),
-            // Pipeline: CD → DP → MP → R
-            (ContentDetermination, DocumentPlanning, Precedes),
-            (DocumentPlanning, Microplanning, Precedes),
-            (Microplanning, Realization, Precedes),
-        ],
-        composed: [
-            // Composed: Goal → SurfaceText (full pipeline)
-            (CommunicativeGoal, SurfaceText),
-            (ContentDetermination, SurfaceText),
-            (ContentDetermination, Realization),
-        ],
-
-        being: AbstractObject,
-        source: "Reiter & Dale (2000)",
-    }
+    edges: [
+        // CommunicativeGoal drives ContentDetermination
+        (CommunicativeGoal, ContentDetermination, Drives),
+        // ContentDetermination gathers knowledge and selects messages
+        (ContentDetermination, KnowledgeGathering, Gathers),
+        (ContentDetermination, Message, Selects),
+        // DocumentPlanning organizes using RhetoricalRelation
+        (DocumentPlanning, Message, Organizes),
+        (DocumentPlanning, RhetoricalRelation, Organizes),
+        // Microplanning produces ReferringExpressions
+        (Microplanning, ReferringExpression, Produces),
+        // Realization generates SurfaceText
+        (Realization, SurfaceText, Generates),
+        // Monitor checks SurfaceText against CommunicativeGoal
+        (Monitor, SurfaceText, Checks),
+        (Monitor, CommunicativeGoal, Checks),
+        // Pipeline: CD → DP → MP → R
+        (ContentDetermination, DocumentPlanning, Precedes),
+        (DocumentPlanning, Microplanning, Precedes),
+        (Microplanning, Realization, Precedes),
+    ],
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use pr4xis::category::Category;
+    use pr4xis::category::Entity;
     use pr4xis::category::validate::check_category_laws;
 
     #[test]
@@ -147,8 +91,6 @@ mod tests {
     fn has_eleven_concepts() {
         assert_eq!(NlgConcept::variants().len(), 11);
     }
-
-    // --- Reiter & Dale (2000): four-stage pipeline ---
 
     #[test]
     fn pipeline_order() {
@@ -164,8 +106,6 @@ mod tests {
             && r.kind == NlgRelationKind::Precedes));
     }
 
-    // --- Appelt (1985): goal drives content ---
-
     #[test]
     fn goal_drives_content_determination() {
         let m = NlgCategory::morphisms();
@@ -174,16 +114,12 @@ mod tests {
             && r.kind == NlgRelationKind::Drives));
     }
 
-    // --- Full pipeline: Goal → SurfaceText ---
-
     #[test]
     fn goal_reaches_surface_text() {
         let m = NlgCategory::morphisms();
         assert!(m.iter().any(|r| r.from == NlgConcept::CommunicativeGoal
             && r.to == NlgConcept::SurfaceText));
     }
-
-    // --- Realization generates SurfaceText ---
 
     #[test]
     fn realization_generates_text() {
@@ -192,8 +128,6 @@ mod tests {
             && r.to == NlgConcept::SurfaceText
             && r.kind == NlgRelationKind::Generates));
     }
-
-    // --- Levelt (1989): Monitor loop ---
 
     #[test]
     fn monitor_checks_output_against_goal() {
@@ -208,8 +142,6 @@ mod tests {
         );
     }
 
-    // --- Content determination gathers knowledge ---
-
     #[test]
     fn content_gathers_knowledge() {
         let m = NlgCategory::morphisms();
@@ -217,8 +149,6 @@ mod tests {
             && r.to == NlgConcept::KnowledgeGathering
             && r.kind == NlgRelationKind::Gathers));
     }
-
-    // --- RST: DocumentPlanning uses RhetoricalRelations ---
 
     #[test]
     fn document_planning_uses_rst() {

--- a/crates/domains/src/cognitive/linguistics/pragmatics/planning/ontology.rs
+++ b/crates/domains/src/cognitive/linguistics/pragmatics/planning/ontology.rs
@@ -1,131 +1,88 @@
-// Speech Act Planning — plan-based theory of speech acts.
-//
-// Speech acts are operators with epistemic preconditions and effects
-// on the hearer's mental state. Planning selects which speech acts to
-// perform based on communicative goals and the current epistemic state.
-//
-// Cohen & Perrault (1979): speech acts as STRIPS-like plan operators.
-// Appelt (1985): KAMP planner — intensional logic of knowledge and action.
-// Stalnaker (2002): assertion updates the Common Ground.
-// Bratman (1987): BDI — Belief + Desire + Intention → Plan.
-// Jakobson (1960): phatic function — social ritual, not information.
-//
-// This ontology bridges Epistemics → Response:
-//   Epistemics (what I know) → Planning (what to say) → Response (how to say it)
-//
-// Source: Cohen & Perrault (1979); Appelt (1985);
-//         Stalnaker (2002); Bratman (1987); Jakobson (1960)
+//! Speech Act Planning — plan-based theory of speech acts.
+//!
+//! Speech acts are operators with epistemic preconditions and effects
+//! on the hearer's mental state. Planning selects which speech acts to
+//! perform based on communicative goals and the current epistemic state.
+//!
+//! Cohen & Perrault (1979): speech acts as STRIPS-like plan operators.
+//! Appelt (1985): KAMP planner — intensional logic of knowledge and action.
+//! Stalnaker (2002): assertion updates the Common Ground.
+//! Bratman (1987): BDI — Belief + Desire + Intention → Plan.
+//! Jakobson (1960): phatic function — social ritual, not information.
+//!
+//! This ontology bridges Epistemics → Response:
+//!   Epistemics (what I know) → Planning (what to say) → Response (how to say it)
+//!
+//! Source: Cohen & Perrault (1979); Appelt (1985);
+//!         Stalnaker (2002); Bratman (1987); Jakobson (1960)
 
-use pr4xis::category::{Category, Entity};
-use pr4xis::define_ontology;
+use pr4xis::category::Category;
 use pr4xis::ontology::{Axiom, Ontology, Quality};
 
-/// Concepts in the Speech Act Planning ontology.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Entity)]
-pub enum PlanningConcept {
-    // === BDI architecture (Bratman 1987) ===
-    /// What the speaker believes about the world and the hearer.
-    /// Maps from Epistemics: KnownKnown, KnownUnknown, etc.
-    Belief,
-    /// What the speaker wants to achieve in the hearer's mind.
-    /// "I want the hearer to know that dogs are mammals."
-    Desire,
-    /// Commitment to a specific plan of speech acts.
-    Intention,
+pr4xis::ontology! {
+    name: "Planning",
+    source: "Cohen & Perrault (1979); Appelt (1985); Stalnaker (2002); Bratman (1987); Jakobson (1960)",
+    being: Process,
 
-    // === Plan-based speech acts (Cohen & Perrault 1979) ===
-    /// A speech act as a plan operator: preconditions + effects.
-    /// Precondition: speaker believes p. Effect: hearer believes p.
-    SpeechActOperator,
-    /// What must hold for the speech act to be appropriate.
-    /// Epistemic: speaker knows p. Social: speaker has authority.
-    Precondition,
-    /// What changes after the speech act is performed.
-    /// Epistemic: hearer now believes p. Social: commitment created.
-    Effect,
-    /// A sequence of speech acts achieving a communicative goal.
-    Plan,
+    concepts: [
+        // BDI architecture (Bratman 1987)
+        Belief,
+        Desire,
+        Intention,
+        // Plan-based speech acts (Cohen & Perrault 1979)
+        SpeechActOperator,
+        Precondition,
+        Effect,
+        Plan,
+        // Common Ground (Stalnaker 2002)
+        CommonGround,
+        CommonGroundUpdate,
+        // Communicative functions (Jakobson 1960)
+        CommunicativeGoal,
+        InformativeGoal,
+        PhaticGoal,
+        DirectiveGoal,
+        ExpressiveGoal,
+    ],
 
-    // === Common Ground (Stalnaker 2002) ===
-    /// The set of mutually accepted propositions.
-    CommonGround,
-    /// How an assertion changes the common ground.
-    /// Assertion: removes worlds where p is false.
-    CommonGroundUpdate,
+    labels: {
+        Belief: ("en", "Belief", "What the speaker believes about the world and the hearer. Maps from Epistemics."),
+        Desire: ("en", "Desire", "What the speaker wants to achieve in the hearer's mind."),
+        Intention: ("en", "Intention", "Commitment to a specific plan of speech acts."),
+        SpeechActOperator: ("en", "Speech act operator", "A speech act as a plan operator: preconditions + effects (Cohen & Perrault 1979)."),
+        Precondition: ("en", "Precondition", "What must hold for the speech act to be appropriate."),
+        Effect: ("en", "Effect", "What changes after the speech act is performed."),
+        Plan: ("en", "Plan", "A sequence of speech acts achieving a communicative goal."),
+        CommonGround: ("en", "Common ground", "The set of mutually accepted propositions (Stalnaker 2002)."),
+        CommonGroundUpdate: ("en", "Common ground update", "How an assertion changes the common ground."),
+        CommunicativeGoal: ("en", "Communicative goal", "The goal the utterance serves (Jakobson function)."),
+        InformativeGoal: ("en", "Informative goal", "Transfer knowledge (referential function)."),
+        PhaticGoal: ("en", "Phatic goal", "Maintain social contact. 'How are you?' — not seeking information."),
+        DirectiveGoal: ("en", "Directive goal", "Get hearer to do something (conative function)."),
+        ExpressiveGoal: ("en", "Expressive goal", "Express speaker's attitude (emotive function)."),
+    },
 
-    // === Communicative functions (Jakobson 1960) ===
-    /// The communicative goal — what function the utterance serves.
-    CommunicativeGoal,
-    /// Informative: transfer knowledge (referential function).
-    InformativeGoal,
-    /// Phatic: maintain social contact (phatic function).
-    /// "How are you?" — not seeking information.
-    PhaticGoal,
-    /// Directive: get hearer to do something (conative function).
-    DirectiveGoal,
-    /// Expressive: express speaker's attitude (emotive function).
-    ExpressiveGoal,
-}
-
-define_ontology! {
-    /// Speech Act Planning — BDI + plan-based speech acts.
-    pub PlanningOntology for PlanningCategory {
-        concepts: PlanningConcept,
-        relation: PlanningRelation,
-        kind: PlanningRelationKind,
-        kinds: [
-            /// BDI: belief + desire produce intention.
-            Produces,
-            /// Planning: intention selects plan.
-            Selects,
-            /// Planning: plan consists of operators.
-            ConsistsOf,
-            /// Operator: has precondition.
-            HasPrecondition,
-            /// Operator: has effect.
-            HasEffect,
-            /// Stalnaker: speech act updates common ground.
-            Updates,
-            /// Goal: specialization.
-            Specializes,
-        ],
-        edges: [
-            // BDI: Belief + Desire → Intention → Plan
-            (Belief, Intention, Produces),
-            (Desire, Intention, Produces),
-            (Intention, Plan, Selects),
-            // Plan consists of SpeechActOperators
-            (Plan, SpeechActOperator, ConsistsOf),
-            // Operator has Precondition and Effect
-            (SpeechActOperator, Precondition, HasPrecondition),
-            (SpeechActOperator, Effect, HasEffect),
-            // Effect updates CommonGround
-            (Effect, CommonGroundUpdate, Updates),
-            (CommonGroundUpdate, CommonGround, Updates),
-            // Goal specializations (Jakobson functions)
-            (InformativeGoal, CommunicativeGoal, Specializes),
-            (PhaticGoal, CommunicativeGoal, Specializes),
-            (DirectiveGoal, CommunicativeGoal, Specializes),
-            (ExpressiveGoal, CommunicativeGoal, Specializes),
-            // Goal drives Desire
-            (CommunicativeGoal, Desire, Produces),
-        ],
-        composed: [
-            // BDI chain: Belief → Plan
-            (Belief, Plan),
-            (Desire, Plan),
-            // Goal → Plan (through Desire → Intention)
-            (CommunicativeGoal, Plan),
-            (CommunicativeGoal, Intention),
-            // Plan → CommonGround (through Operator → Effect → Update)
-            (Plan, CommonGroundUpdate),
-            (Plan, CommonGround),
-            (SpeechActOperator, CommonGround),
-        ],
-
-        being: Process,
-        source: "Cohen & Perrault (1979); Appelt (1985); Stalnaker (2002); Bratman (1987); Jakobson (1960)",
-    }
+    edges: [
+        // BDI: Belief + Desire → Intention → Plan
+        (Belief, Intention, Produces),
+        (Desire, Intention, Produces),
+        (Intention, Plan, Selects),
+        // Plan consists of SpeechActOperators
+        (Plan, SpeechActOperator, ConsistsOf),
+        // Operator has Precondition and Effect
+        (SpeechActOperator, Precondition, HasPrecondition),
+        (SpeechActOperator, Effect, HasEffect),
+        // Effect updates CommonGround
+        (Effect, CommonGroundUpdate, Updates),
+        (CommonGroundUpdate, CommonGround, Updates),
+        // Goal specializations (Jakobson functions)
+        (InformativeGoal, CommunicativeGoal, Specializes),
+        (PhaticGoal, CommunicativeGoal, Specializes),
+        (DirectiveGoal, CommunicativeGoal, Specializes),
+        (ExpressiveGoal, CommunicativeGoal, Specializes),
+        // Goal drives Desire
+        (CommunicativeGoal, Desire, Produces),
+    ],
 }
 
 /// Whether a concept is BDI-structural vs goal-type vs planning.

--- a/crates/domains/src/cognitive/linguistics/pragmatics/reference.rs
+++ b/crates/domains/src/cognitive/linguistics/pragmatics/reference.rs
@@ -1,56 +1,76 @@
+//! Discourse Reference Ontology — how language tracks entities across utterances.
+//!
+//! Two foundational theories compose here:
+//!
+//! DRT (Discourse Representation Theory) — Kamp (1981), Kamp & Reyle (1993):
+//!   Meaning is not static truth conditions but DYNAMIC UPDATE to a discourse model.
+//!   Indefinites ("a dog") introduce new discourse referents.
+//!   Pronouns ("it") resolve to existing accessible referents.
+//!   Accessibility is structural: determined by DRS nesting.
+//!
+//! Centering Theory — Grosz, Joshi, Weinstein (1995):
+//!   Local discourse coherence is tracked by salience ranking.
+//!   Cf (forward-looking centers): entities in current utterance, ranked by grammar.
+//!   Cb (backward-looking center): most salient entity from previous utterance.
+//!   Transitions: Continue > Retain > Smooth Shift > Rough Shift.
+//!
+//! Together: DRT says what CAN be resolved; Centering says what SHOULD be resolved.
+//!
+//! References:
+//! - Kamp, A Theory of Truth and Semantic Representation (1981)
+//! - Kamp & Reyle, From Discourse to Logic (1993)
+//! - Grosz, Joshi, Weinstein, Centering (Computational Linguistics, 1995)
+//! - Van der Sandt, Presupposition Projection as Anaphora Resolution (1992)
+//! - Heim, The Semantics of Definite and Indefinite Noun Phrases (1982)
+
 use pr4xis::category::Entity;
-use pr4xis::define_ontology;
 
-// Discourse Reference Ontology — how language tracks entities across utterances.
-//
-// Two foundational theories compose here:
-//
-// DRT (Discourse Representation Theory) — Kamp (1981), Kamp & Reyle (1993):
-//   Meaning is not static truth conditions but DYNAMIC UPDATE to a discourse model.
-//   Indefinites ("a dog") introduce new discourse referents.
-//   Pronouns ("it") resolve to existing accessible referents.
-//   Accessibility is structural: determined by DRS nesting.
-//
-// Centering Theory — Grosz, Joshi, Weinstein (1995):
-//   Local discourse coherence is tracked by salience ranking.
-//   Cf (forward-looking centers): entities in current utterance, ranked by grammar.
-//   Cb (backward-looking center): most salient entity from previous utterance.
-//   Transitions: Continue > Retain > Smooth Shift > Rough Shift.
-//
-// Together: DRT says what CAN be resolved; Centering says what SHOULD be resolved.
-//
-// References:
-// - Kamp, A Theory of Truth and Semantic Representation (1981)
-// - Kamp & Reyle, From Discourse to Logic (1993)
-// - Grosz, Joshi, Weinstein, Centering (Computational Linguistics, 1995)
-// - Van der Sandt, Presupposition Projection as Anaphora Resolution (1992)
-// - Heim, The Semantics of Definite and Indefinite Noun Phrases (1982)
+pr4xis::ontology! {
+    name: "Reference",
+    source: "Kamp (1981); Grosz, Joshi & Weinstein (1995)",
+    being: AbstractObject,
 
-/// Core concepts of discourse reference.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Entity)]
-pub enum ReferenceConcept {
-    /// A discourse referent — an abstract placeholder for an entity
-    /// introduced into the discourse model. NOT the real-world entity;
-    /// a mediating representation that accumulates conditions.
-    Referent,
-    /// A Discourse Representation Structure — the discourse model at a point.
-    /// Contains a universe of referents and conditions on them.
-    DRS,
-    /// A condition on referents within a DRS: predicates, relations, nested DRSs.
-    Condition,
-    /// The structural context determining which referents are visible.
-    /// DRS nesting defines accessibility (Kamp & Reyle 1993).
-    Accessibility,
-    /// The salience state of an utterance (Grosz, Joshi, Weinstein 1995).
-    /// Contains Cf (forward-looking centers), Cp (preferred), Cb (backward-looking).
-    CenteringState,
-    /// The coherence relationship between adjacent utterances.
-    /// Continue, Retain, Smooth Shift, Rough Shift.
-    Transition,
-    /// A linguistic expression requiring resolution: pronouns, definites, demonstratives.
-    AnaphoricExpression,
-    /// The resolved link between an anaphor and its antecedent referent.
-    Binding,
+    concepts: [
+        Referent,
+        DRS,
+        Condition,
+        Accessibility,
+        CenteringState,
+        Transition,
+        AnaphoricExpression,
+        Binding,
+    ],
+
+    labels: {
+        Referent: ("en", "Discourse referent", "Abstract placeholder for an entity introduced into the discourse model."),
+        DRS: ("en", "Discourse Representation Structure", "The discourse model at a point. Universe of referents + conditions."),
+        Condition: ("en", "Condition", "A condition on referents within a DRS: predicates, relations, nested DRSs."),
+        Accessibility: ("en", "Accessibility", "Structural context determining which referents are visible (Kamp & Reyle 1993)."),
+        CenteringState: ("en", "Centering state", "Cf (forward-looking), Cp (preferred), Cb (backward-looking) (Grosz et al. 1995)."),
+        Transition: ("en", "Centering transition", "Continue / Retain / Smooth Shift / Rough Shift — coherence relationship."),
+        AnaphoricExpression: ("en", "Anaphoric expression", "Linguistic expression requiring resolution: pronouns, definites, demonstratives."),
+        Binding: ("en", "Binding", "The resolved link between an anaphor and its antecedent referent."),
+    },
+
+    edges: [
+        // DRT structure
+        (DRS, Referent, Contains),
+        (Condition, Referent, Constrains),
+        (DRS, DRS, Subordinates),
+        (Accessibility, DRS, Accessible),
+        // Introduction and resolution
+        (Referent, DRS, Introduces),
+        (AnaphoricExpression, Referent, Resolves),
+        // Binding
+        (Binding, AnaphoricExpression, Binds),
+        (Binding, Referent, Binds),
+        // Centering
+        (CenteringState, Referent, Ranks),
+        (CenteringState, CenteringState, Links),
+        (Transition, CenteringState, Links),
+        // Update: utterance processing extends DRS
+        (DRS, Condition, Updates),
+    ],
 }
 
 /// Centering transition types — how topic/salience shifts between utterances.
@@ -65,64 +85,6 @@ pub enum CenteringTransition {
     SmoothShift,
     /// New topic, not yet clearly established. Cb changes, Cb ≠ Cp.
     RoughShift,
-}
-
-define_ontology! {
-    /// Discourse Reference — DRT + Centering (Kamp 1981; Grosz et al. 1995).
-    pub ReferenceOntology for ReferenceCategory {
-        concepts: ReferenceConcept,
-        relation: ReferenceRelation,
-        kind: ReferenceRelationKind,
-        kinds: [
-            /// NP introduces a new discourse referent into the DRS.
-            Introduces,
-            /// Anaphor resolves to an existing referent.
-            Resolves,
-            /// Condition constrains what a referent can denote.
-            Constrains,
-            /// DRS contains referents in its universe.
-            Contains,
-            /// DRS nesting: sub-DRS for negation, conditionals, quantifiers.
-            Subordinates,
-            /// Referents in source DRS are visible from target DRS.
-            Accessible,
-            /// Processing an utterance extends the DRS.
-            Updates,
-            /// Centering state ranks referents by salience.
-            Ranks,
-            /// Centering links adjacent utterance states.
-            Links,
-            /// Binding connects anaphor to resolved referent.
-            Binds,
-        ],
-        edges: [
-            // DRT structure
-            (DRS, Referent, Contains),
-            (Condition, Referent, Constrains),
-            (DRS, DRS, Subordinates),
-            (Accessibility, DRS, Accessible),
-            // Introduction and resolution
-            (Referent, DRS, Introduces),
-            (AnaphoricExpression, Referent, Resolves),
-            // Binding
-            (Binding, AnaphoricExpression, Binds),
-            (Binding, Referent, Binds),
-            // Centering
-            (CenteringState, Referent, Ranks),
-            (CenteringState, CenteringState, Links),
-            (Transition, CenteringState, Links),
-            // Update: utterance processing extends DRS
-            (DRS, Condition, Updates),
-        ],
-        composed: [
-            (AnaphoricExpression, DRS),
-            (DRS, Condition),
-            (Accessibility, Referent),
-        ],
-
-        being: AbstractObject,
-        source: "Kamp (1981); Grosz, Joshi & Weinstein (1995)",
-    }
 }
 
 #[cfg(test)]
@@ -180,7 +142,6 @@ mod tests {
 
     #[test]
     fn accessibility_reaches_referents() {
-        // Accessibility → DRS → Referent (transitive through composition)
         let morphisms = ReferenceCategory::morphisms();
         assert!(
             morphisms

--- a/crates/domains/src/cognitive/linguistics/pragmatics/response.rs
+++ b/crates/domains/src/cognitive/linguistics/pragmatics/response.rs
@@ -1,97 +1,59 @@
-use pr4xis::category::Entity;
-use pr4xis::define_ontology;
+//! Response Generation ontology — the right adjoint of parsing.
+//!
+//! Parsing: Text → Syntax → Semantics (left adjoint, F)
+//! Generation: Semantics → Syntax → Text (right adjoint, G)
+//! Together: Parse ⊣ Generate (adjunction)
+//!
+//! The unit η: Id → G∘F means: parse then generate ≈ paraphrase.
+//! The counit ε: F∘G → Id means: generate then parse ≈ comprehension check.
+//! G∘F ≠ Id: paraphrase loses information (many texts → one meaning).
+//! F∘G ≠ Id: a meaning can be expressed many ways.
+//!
+//! This ontology defines the concepts for generating responses from
+//! ontological states. It composes:
+//! - Metacognition (what happened: gap, repair, clarification)
+//! - Epistemics (what the system knows: KK, KU, UK, UU)
+//! - SelfModel (what the system IS: components, capabilities)
+//! - Speech acts (what kind of response: assertion, question)
+//!
+//! The response is NOT a hardcoded string. It is composed from
+//! ontological concepts that are then realized through the Language.
+//!
+//! References:
+//! - Reiter & Dale, "Building Natural Language Generation Systems" (2000)
+//! - White, "Efficient Realization of Coordinate Structures in CCG" (2006)
+//! - Lambek & Scott, "Introduction to Higher Order Categorical Logic" (1986)
 
-// Response Generation ontology — the right adjoint of parsing.
-//
-// Parsing: Text → Syntax → Semantics (left adjoint, F)
-// Generation: Semantics → Syntax → Text (right adjoint, G)
-// Together: Parse ⊣ Generate (adjunction)
-//
-// The unit η: Id → G∘F means: parse then generate ≈ paraphrase.
-// The counit ε: F∘G → Id means: generate then parse ≈ comprehension check.
-// G∘F ≠ Id: paraphrase loses information (many texts → one meaning).
-// F∘G ≠ Id: a meaning can be expressed many ways.
-//
-// This ontology defines the concepts for generating responses from
-// ontological states. It composes:
-// - Metacognition (what happened: gap, repair, clarification)
-// - Epistemics (what the system knows: KK, KU, UK, UU)
-// - SelfModel (what the system IS: components, capabilities)
-// - Speech acts (what kind of response: assertion, question)
-//
-// The response is NOT a hardcoded string. It is composed from
-// ontological concepts that are then realized through the Language.
-//
-// References:
-// - Reiter & Dale, "Building Natural Language Generation Systems" (2000)
-// - White, "Efficient Realization of Coordinate Structures in CCG" (2006)
-// - Lambek & Scott, "Introduction to Higher Order Categorical Logic" (1986)
+pr4xis::ontology! {
+    name: "Response",
+    source: "Reiter & Dale (2000); Lambek & Scott (1986)",
+    being: Process,
 
-/// Concepts in response generation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Entity)]
-pub enum ResponseConcept {
-    /// The communicative intent — what the system wants to express.
-    /// Determined by metacognition (gap → clarify, repair → suggest).
-    Intent,
-    /// The epistemic frame — the system's knowledge state about this exchange.
-    /// From epistemics: KnownKnown, KnownUnknown, UnknownKnown, UnknownUnknown.
-    EpistemicFrame,
-    /// The content — the actual information to convey.
-    /// From self-model, knowledge base, or query results.
-    Content,
-    /// The speech act type — assertion, question, directive, etc.
-    /// From speech_act.rs.
-    SpeechActType,
-    /// The surface form — the linguistic realization.
-    /// The right adjoint maps intent → text through the Language.
-    SurfaceForm,
-    /// The context — what was said before, what the user asked.
-    /// From dialogue state.
-    Context,
-}
+    concepts: [Intent, EpistemicFrame, Content, SpeechActType, SurfaceForm, Context],
 
-define_ontology! {
-    /// Response Generation — the right adjoint of parsing (Reiter & Dale 2000).
-    pub ResponseOntology for ResponseCategory {
-        concepts: ResponseConcept,
-        relation: ResponseRelation,
-        kind: ResponseRelationKind,
-        kinds: [
-            /// Metacognition determines Intent.
-            Determines,
-            /// Epistemics frames the Content.
-            Frames,
-            /// Intent selects SpeechActType.
-            Selects,
-            /// Content realizes as SurfaceForm (the generation step).
-            Realizes,
-            /// Context constrains Intent.
-            Constrains,
-            /// SpeechActType shapes SurfaceForm.
-            Shapes,
-        ],
-        edges: [
-            // Metacognition → Intent (gap/repair/clarification determines what to say)
-            (Context, Intent, Constrains),
-            // Epistemics frames Content (KK→assert, KU→ask, UK→suggest, UU→admit)
-            (EpistemicFrame, Content, Frames),
-            // Intent selects SpeechActType (clarification→question, assertion→statement)
-            (Intent, SpeechActType, Selects),
-            // Content realizes as SurfaceForm (the generation functor)
-            (Content, SurfaceForm, Realizes),
-            // SpeechActType shapes SurfaceForm (question → interrogative form)
-            (SpeechActType, SurfaceForm, Shapes),
-        ],
-        composed: [
-            (Context, SpeechActType),
-            (Context, SurfaceForm),
-            (Intent, SurfaceForm),
-            (EpistemicFrame, SurfaceForm),
-        ],
+    labels: {
+        Intent: ("en", "Intent", "The communicative intent — what the system wants to express. Determined by metacognition."),
+        EpistemicFrame: ("en", "Epistemic frame", "The system's knowledge state about this exchange (KK/KU/UK/UU)."),
+        Content: ("en", "Content", "The actual information to convey. From self-model, knowledge base, or query results."),
+        SpeechActType: ("en", "Speech act type", "Assertion, question, directive, etc. From speech_act.rs."),
+        SurfaceForm: ("en", "Surface form", "The linguistic realization. The right adjoint maps intent → text through the Language."),
+        Context: ("en", "Context", "What was said before, what the user asked. From dialogue state."),
+    },
 
-        being: Process,
-        source: "Reiter & Dale (2000); Lambek & Scott (1986)",
-    }
+    edges: [
+        // Context constrains Intent
+        (Context, Intent, Constrains),
+        // EpistemicFrame determines Intent (knowledge state → response intent)
+        (EpistemicFrame, Intent, Determines),
+        // Epistemics frames Content (KK→assert, KU→ask, UK→suggest, UU→admit)
+        (EpistemicFrame, Content, Frames),
+        // Intent selects SpeechActType (clarification→question, assertion→statement)
+        (Intent, SpeechActType, Selects),
+        // Content realizes as SurfaceForm (the generation functor)
+        (Content, SurfaceForm, Realizes),
+        // SpeechActType shapes SurfaceForm (question → interrogative form)
+        (SpeechActType, SurfaceForm, Shapes),
+    ],
 }
 
 // =========================================================================

--- a/crates/domains/src/cognitive/linguistics/pragmatics/response.rs
+++ b/crates/domains/src/cognitive/linguistics/pragmatics/response.rs
@@ -121,13 +121,15 @@ pub enum ResponseFrame {
 
 impl ResponseFrame {
     /// Map from epistemic state to response frame.
-    pub fn from_epistemic(state: &crate::cognitive::cognition::epistemics::EpistemicState) -> Self {
-        use crate::cognitive::cognition::epistemics::EpistemicState;
+    pub fn from_epistemic(
+        state: &crate::cognitive::cognition::epistemics::EpistemicConcept,
+    ) -> Self {
+        use crate::cognitive::cognition::epistemics::EpistemicConcept;
         match state {
-            EpistemicState::KnownKnown => Self::AssertKnowledge,
-            EpistemicState::KnownUnknown => Self::AcknowledgeGap,
-            EpistemicState::UnknownKnown => Self::SuggestInterpretation,
-            EpistemicState::UnknownUnknown => Self::AdmitLimitation,
+            EpistemicConcept::KnownKnown => Self::AssertKnowledge,
+            EpistemicConcept::KnownUnknown => Self::AcknowledgeGap,
+            EpistemicConcept::UnknownKnown => Self::SuggestInterpretation,
+            EpistemicConcept::UnknownUnknown => Self::AdmitLimitation,
         }
     }
 }
@@ -186,21 +188,21 @@ mod tests {
 
     #[test]
     fn epistemic_frames_map_correctly() {
-        use crate::cognitive::cognition::epistemics::EpistemicState;
+        use crate::cognitive::cognition::epistemics::EpistemicConcept;
         assert_eq!(
-            ResponseFrame::from_epistemic(&EpistemicState::KnownKnown),
+            ResponseFrame::from_epistemic(&EpistemicConcept::KnownKnown),
             ResponseFrame::AssertKnowledge
         );
         assert_eq!(
-            ResponseFrame::from_epistemic(&EpistemicState::KnownUnknown),
+            ResponseFrame::from_epistemic(&EpistemicConcept::KnownUnknown),
             ResponseFrame::AcknowledgeGap
         );
         assert_eq!(
-            ResponseFrame::from_epistemic(&EpistemicState::UnknownKnown),
+            ResponseFrame::from_epistemic(&EpistemicConcept::UnknownKnown),
             ResponseFrame::SuggestInterpretation
         );
         assert_eq!(
-            ResponseFrame::from_epistemic(&EpistemicState::UnknownUnknown),
+            ResponseFrame::from_epistemic(&EpistemicConcept::UnknownUnknown),
             ResponseFrame::AdmitLimitation
         );
     }

--- a/crates/domains/src/cognitive/linguistics/text/ontology.rs
+++ b/crates/domains/src/cognitive/linguistics/text/ontology.rs
@@ -1,72 +1,65 @@
-// Text Occurrence — where linguistic units live in text.
-//
-// Bridges NIF (text position), Lemon (lexicon), OLiA (annotation),
-// and Lambek (grammar) into a unified model of typed tokens.
-//
-// A Word is NOT a string. It's a text occurrence at a position in a
-// Context, connected to a LexicalEntry in a Lexicon (via Lemon),
-// carrying a grammatical type (via Lambek), and annotated with
-// linguistic features (via OLiA).
-//
-// Source: Hellmann et al. NIF (2013); Chiarcos & Sukhareva OLiA (2015);
-//         Coecke, Sadrzadeh & Clark DisCoCat (2010)
+//! Text Occurrence — where linguistic units live in text.
+//!
+//! Bridges NIF (text position), Lemon (lexicon), OLiA (annotation),
+//! and Lambek (grammar) into a unified model of typed tokens.
+//!
+//! A Word is NOT a string. It's a text occurrence at a position in a
+//! Context, connected to a LexicalEntry in a Lexicon (via Lemon),
+//! carrying a grammatical type (via Lambek), and annotated with
+//! linguistic features (via OLiA).
+//!
+//! Source: Hellmann et al. NIF (2013); Chiarcos & Sukhareva OLiA (2015);
+//!         Coecke, Sadrzadeh & Clark DisCoCat (2010)
 
-use pr4xis::category::Entity;
-use pr4xis::define_ontology;
 use pr4xis::ontology::{Axiom, Ontology, Quality};
 
-/// Concepts in the Text Occurrence ontology.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Entity)]
-pub enum TextConcept {
-    // === NIF structural concepts (Hellmann 2013) ===
-    /// nif:Context — the reference text containing all occurrences.
-    Context,
-    /// nif:Word — a token occurrence at a position in Context.
-    Word,
-    /// nif:Sentence — a sequence of Words forming a grammatical unit.
-    Sentence,
-    /// nif:Phrase — a contiguous span of Words (NP, VP, etc.).
-    Phrase,
-    /// A position range in the Context (beginIndex, endIndex).
-    Span,
+pr4xis::ontology! {
+    name: "Text",
+    source: "Hellmann NIF (2013); Chiarcos OLiA (2015); Coecke DisCoCat (2010)",
+    being: AbstractObject,
 
-    // === Bridging concepts (functors to other ontologies) ===
-    /// The lexicon entry this Word maps to (Lemon functor target).
-    LexiconReference,
-    /// The grammatical type assigned (Lambek functor target).
-    GrammaticalType,
-    /// The ontology concept referenced through meaning (DisCoCat target).
-    MeaningReference,
-    /// Linguistic annotation — POS, morphology, dependency (OLiA).
-    Annotation,
-}
+    concepts: [
+        // NIF structural concepts (Hellmann 2013)
+        Context,
+        Word,
+        Sentence,
+        Phrase,
+        Span,
+        // Bridging concepts (functors to other ontologies)
+        LexiconReference,
+        GrammaticalType,
+        MeaningReference,
+        Annotation,
+    ],
 
-define_ontology! {
-    /// Text Occurrence — typed tokens in context.
-    pub TextOntology for TextCategory {
-        concepts: TextConcept,
-        relation: TextRelation,
+    labels: {
+        Context: ("en", "Context", "nif:Context — the reference text containing all occurrences."),
+        Word: ("en", "Word", "nif:Word — a token occurrence at a position in Context."),
+        Sentence: ("en", "Sentence", "nif:Sentence — a sequence of Words forming a grammatical unit."),
+        Phrase: ("en", "Phrase", "nif:Phrase — a contiguous span of Words (NP, VP, etc.)."),
+        Span: ("en", "Span", "A position range in the Context (beginIndex, endIndex)."),
+        LexiconReference: ("en", "Lexicon reference", "The lexicon entry this Word maps to (Lemon functor target)."),
+        GrammaticalType: ("en", "Grammatical type", "The grammatical type assigned (Lambek functor target)."),
+        MeaningReference: ("en", "Meaning reference", "The ontology concept referenced through meaning (DisCoCat target)."),
+        Annotation: ("en", "Annotation", "Linguistic annotation — POS, morphology, dependency (OLiA)."),
+    },
 
-        being: AbstractObject,
-        source: "Hellmann NIF (2013); Chiarcos OLiA (2015); Coecke DisCoCat (2010)",
+    is_a: [
+        (Word, Span),
+        (Sentence, Span),
+        (Phrase, Span),
+    ],
 
-        is_a: TextTaxonomy [
-            (Word, Span),
-            (Sentence, Span),
-            (Phrase, Span),
-        ],
-
-        has_a: TextMereology [
-            (Context, Sentence),
-            (Sentence, Word),
-            (Phrase, Word),
-            (Word, Span),
-            (Word, LexiconReference),
-            (Word, GrammaticalType),
-            (Word, MeaningReference),
-            (Word, Annotation),
-        ],
-    }
+    has_a: [
+        (Context, Sentence),
+        (Sentence, Word),
+        (Phrase, Word),
+        (Word, Span),
+        (Word, LexiconReference),
+        (Word, GrammaticalType),
+        (Word, MeaningReference),
+        (Word, Annotation),
+    ],
 }
 
 /// Whether a concept is NIF-structural vs a bridging reference.

--- a/crates/domains/src/formal/information/diagnostics/metacognition_functor.rs
+++ b/crates/domains/src/formal/information/diagnostics/metacognition_functor.rs
@@ -27,39 +27,39 @@ impl Functor for DiagnosticsToMetacognition {
     type Source = DiagnosticCategory;
     type Target = MetaCognitionCategory;
 
-    fn map_object(obj: &DiagnosticConcept) -> MetaConcept {
+    fn map_object(obj: &DiagnosticConcept) -> MetaCognitionConcept {
         match obj {
-            DiagnosticConcept::Symptom => MetaConcept::Gap,
-            DiagnosticConcept::Hypothesis => MetaConcept::Evaluation,
-            DiagnosticConcept::Test => MetaConcept::Control,
-            DiagnosticConcept::Evidence => MetaConcept::Monitoring,
-            DiagnosticConcept::Diagnosis => MetaConcept::EpistemicAssessment,
-            DiagnosticConcept::Residual => MetaConcept::Trace,
-            DiagnosticConcept::FaultMode => MetaConcept::Gap,
-            DiagnosticConcept::Severity => MetaConcept::Evaluation,
-            DiagnosticConcept::Remedy => MetaConcept::Repair,
-            DiagnosticConcept::TraceContext => MetaConcept::Trace,
+            DiagnosticConcept::Symptom => MetaCognitionConcept::Gap,
+            DiagnosticConcept::Hypothesis => MetaCognitionConcept::Evaluation,
+            DiagnosticConcept::Test => MetaCognitionConcept::Control,
+            DiagnosticConcept::Evidence => MetaCognitionConcept::Monitoring,
+            DiagnosticConcept::Diagnosis => MetaCognitionConcept::EpistemicAssessment,
+            DiagnosticConcept::Residual => MetaCognitionConcept::Trace,
+            DiagnosticConcept::FaultMode => MetaCognitionConcept::Gap,
+            DiagnosticConcept::Severity => MetaCognitionConcept::Evaluation,
+            DiagnosticConcept::Remedy => MetaCognitionConcept::Repair,
+            DiagnosticConcept::TraceContext => MetaCognitionConcept::Trace,
         }
     }
 
-    fn map_morphism(m: &DiagnosticRelation) -> MetaRelation {
+    fn map_morphism(m: &DiagnosticRelation) -> MetaCognitionRelation {
         let from = Self::map_object(&m.from);
         let to = Self::map_object(&m.to);
         let kind = match m.kind {
-            DiagnosticRelationKind::Identity => MetaRelationKind::Identity,
-            DiagnosticRelationKind::Triggers => MetaRelationKind::Detects,
-            DiagnosticRelationKind::Generates => MetaRelationKind::Detects,
-            DiagnosticRelationKind::Requires => MetaRelationKind::Decides,
-            DiagnosticRelationKind::Produces => MetaRelationKind::Observes,
-            DiagnosticRelationKind::Updates => MetaRelationKind::Observes,
-            DiagnosticRelationKind::Confirms => MetaRelationKind::Assesses,
-            DiagnosticRelationKind::Identifies => MetaRelationKind::Detects,
-            DiagnosticRelationKind::HasSeverity => MetaRelationKind::Assesses,
-            DiagnosticRelationKind::Prescribes => MetaRelationKind::Triggers,
-            DiagnosticRelationKind::Contextualizes => MetaRelationKind::Observes,
-            DiagnosticRelationKind::Composed => MetaRelationKind::Composed,
+            DiagnosticRelationKind::Identity => MetaCognitionRelationKind::Identity,
+            DiagnosticRelationKind::Triggers => MetaCognitionRelationKind::Detects,
+            DiagnosticRelationKind::Generates => MetaCognitionRelationKind::Detects,
+            DiagnosticRelationKind::Requires => MetaCognitionRelationKind::Decides,
+            DiagnosticRelationKind::Produces => MetaCognitionRelationKind::Observes,
+            DiagnosticRelationKind::Updates => MetaCognitionRelationKind::Observes,
+            DiagnosticRelationKind::Confirms => MetaCognitionRelationKind::Assesses,
+            DiagnosticRelationKind::Identifies => MetaCognitionRelationKind::Detects,
+            DiagnosticRelationKind::HasSeverity => MetaCognitionRelationKind::Assesses,
+            DiagnosticRelationKind::Prescribes => MetaCognitionRelationKind::Triggers,
+            DiagnosticRelationKind::Contextualizes => MetaCognitionRelationKind::Observes,
+            DiagnosticRelationKind::Composed => MetaCognitionRelationKind::Composed,
         };
-        MetaRelation { from, to, kind }
+        MetaCognitionRelation { from, to, kind }
     }
 }
 
@@ -77,7 +77,7 @@ mod tests {
     fn symptom_is_gap() {
         assert_eq!(
             DiagnosticsToMetacognition::map_object(&DiagnosticConcept::Symptom),
-            MetaConcept::Gap
+            MetaCognitionConcept::Gap
         );
     }
 
@@ -85,7 +85,7 @@ mod tests {
     fn remedy_is_repair() {
         assert_eq!(
             DiagnosticsToMetacognition::map_object(&DiagnosticConcept::Remedy),
-            MetaConcept::Repair
+            MetaCognitionConcept::Repair
         );
     }
 
@@ -93,7 +93,7 @@ mod tests {
     fn diagnosis_is_epistemic_assessment() {
         assert_eq!(
             DiagnosticsToMetacognition::map_object(&DiagnosticConcept::Diagnosis),
-            MetaConcept::EpistemicAssessment
+            MetaCognitionConcept::EpistemicAssessment
         );
     }
 }

--- a/crates/domains/src/formal/information/diagnostics/trace_impls.rs
+++ b/crates/domains/src/formal/information/diagnostics/trace_impls.rs
@@ -108,7 +108,7 @@ impl Traceable for InterpretResult<'_> {
 
 /// Traceable for epistemic classification.
 pub struct EpistemicResult {
-    pub state: crate::cognitive::cognition::epistemics::EpistemicState,
+    pub state: crate::cognitive::cognition::epistemics::EpistemicConcept,
     pub known_words: Vec<String>,
     pub unknown_words: Vec<String>,
 }

--- a/crates/domains/src/formal/information/dialogue/ontology.rs
+++ b/crates/domains/src/formal/information/dialogue/ontology.rs
@@ -1,162 +1,83 @@
-use pr4xis::category::Entity;
-use pr4xis::define_ontology;
+//! Dialogue ontology — the science of conversation.
+//!
+//! A dialogue IS:
+//! - An event-driven system (utterances are events)
+//! - Concurrent (two+ agents, turn-taking)
+//! - A system (feedback: listen → understand → respond)
+//! - Linguistic (uses grammar, semantics, pragmatics)
+//!
+//! References:
+//! - Austin, How to Do Things with Words (1962) — speech acts
+//! - Searle, Speech Acts (1969) — illocutionary force
+//! - Jurafsky & Martin, Speech and Language Processing — dialogue acts
+//! - Traum, A Computational Theory of Grounding (1994)
+//! - Ginzburg, The Interactive Stance (2012) — KoS, QUD
+//! - Clark, Using Language (1996) — grounding, common ground
+//! - Stalnaker, Common Ground (2002) — context set, assertion
+//! - Levelt, Speaking (1989) — speech production model
+//! - Grice, Logic and Conversation (1975) — cooperative principle
+
 use pr4xis::ontology::{Ontology, Quality};
 
-// Dialogue ontology — the science of conversation.
-//
-// A dialogue IS:
-// - An event-driven system (utterances are events)
-// - Concurrent (two+ agents, turn-taking)
-// - A system (feedback: listen → understand → respond)
-// - Linguistic (uses grammar, semantics, pragmatics)
-//
-// References:
-// - Austin, How to Do Things with Words (1962) — speech acts
-// - Searle, Speech Acts (1969) — illocutionary force
-// - Jurafsky & Martin, Speech and Language Processing — dialogue acts
-// - Traum, A Computational Theory of Grounding (1994)
-// - Ginzburg, The Interactive Stance (2012) — KoS, QUD
-// - Clark, Using Language (1996) — grounding, common ground
-// - Stalnaker, Common Ground (2002) — context set, assertion
-// - Levelt, Speaking (1989) — speech production model
-// - Grice, Logic and Conversation (1975) — cooperative principle
+pr4xis::ontology! {
+    name: "Dialogue",
+    source: "Austin (1962); Traum (1994); Clark (1996); Ginzburg (2012); Stalnaker (2002); Levelt (1989)",
+    being: Process,
 
-/// Core concepts of a dialogue system.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Entity)]
-pub enum DialogueConcept {
-    /// A single utterance from a participant.
-    Utterance,
-    /// The speaker/listener — an agent in the conversation.
-    Participant,
-    /// What the speaker intends to achieve with an utterance.
-    /// Inform, question, request, confirm, deny, etc.
-    DialogueAct,
-    /// The shared knowledge between participants at a point in time.
-    /// What's been said, what's understood, what's expected.
-    DialogueState,
-    /// The topic currently being discussed.
-    Topic,
-    /// The conversational context — everything said so far.
-    History,
-    /// Understanding an utterance — parsing, meaning extraction, intent recognition.
-    Understanding,
-    /// Generating a response — selecting content, constructing utterance.
-    Generation,
-    /// The mechanism controlling who speaks when.
-    TurnManagement,
-    /// A successful exchange — both parties understand each other.
-    /// Traum (1994): Initiate → Acknowledge → Ground.
-    Grounding,
+    concepts: [
+        Utterance,
+        Participant,
+        DialogueAct,
+        DialogueState,
+        Topic,
+        History,
+        Understanding,
+        Generation,
+        TurnManagement,
+        Grounding,
+        QUD,
+        CommonGround,
+        Intention,
+        GroundingAct,
+        Repair,
+    ],
 
-    // === New concepts from literature ===
-    /// Questions Under Discussion — the stack that drives interpretation.
-    /// Ginzburg (2012): QUD is a priority queue of open questions.
-    /// Every utterance either raises a question or resolves one.
-    QUD,
-    /// Shared beliefs between participants (Stalnaker 2002).
-    /// The context set — propositions both participants accept as true.
-    /// Assertion = proposal to add to common ground.
-    CommonGround,
-    /// What the speaker wants to achieve BEFORE formulating words.
-    /// Levelt (1989): the preverbal message from the Conceptualizer.
-    /// Contains: topic, focus, mood, speech act type, propositional content.
-    Intention,
-    /// The act of establishing mutual understanding.
-    /// Traum (1994): Initiate, Continue, Acknowledge, Repair, ReqRepair.
-    /// Clark (1996): presentation + acceptance.
-    GroundingAct,
-    /// When understanding fails and needs correction.
-    /// Schegloff et al. (1977): self-repair, other-repair, other-initiated self-repair.
-    Repair,
-}
+    labels: {
+        Utterance: ("en", "Utterance", "A single utterance from a participant."),
+        Participant: ("en", "Participant", "The speaker/listener — an agent in the conversation."),
+        DialogueAct: ("en", "Dialogue act", "What the speaker intends to achieve with an utterance (inform, question, request, confirm, deny)."),
+        DialogueState: ("en", "Dialogue state", "The shared knowledge between participants at a point in time."),
+        Topic: ("en", "Topic", "The topic currently being discussed."),
+        History: ("en", "History", "The conversational context — everything said so far."),
+        Understanding: ("en", "Understanding", "Parsing, meaning extraction, intent recognition."),
+        Generation: ("en", "Generation", "Selecting content, constructing utterance."),
+        TurnManagement: ("en", "Turn management", "The mechanism controlling who speaks when."),
+        Grounding: ("en", "Grounding", "A successful exchange — both parties understand each other. Traum (1994): Initiate → Acknowledge → Ground."),
+        QUD: ("en", "Question Under Discussion", "Ginzburg (2012): priority queue of open questions. Every utterance raises or resolves one."),
+        CommonGround: ("en", "Common ground", "Stalnaker (2002): propositions both participants accept as true. Assertion = proposal to add to common ground."),
+        Intention: ("en", "Intention", "Levelt (1989): the preverbal message from the Conceptualizer. Contains topic, focus, mood, speech act type, propositional content."),
+        GroundingAct: ("en", "Grounding act", "Traum (1994): Initiate, Continue, Acknowledge, Repair, ReqRepair. Clark (1996): presentation + acceptance."),
+        Repair: ("en", "Repair", "Schegloff et al. (1977): self-repair, other-repair, other-initiated self-repair."),
+    },
 
-define_ontology! {
-    pub DialogueOntology for DialogueCategory {
-        concepts: DialogueConcept,
-        relation: DialogueRelation,
-        kind: DialogueRelationKind,
-        kinds: [
-            /// Participant produces Utterance.
-            Produces,
-            /// Utterance expresses DialogueAct.
-            Expresses,
-            /// Utterance updates DialogueState.
-            Updates,
-            /// Utterance appended to History.
-            AppendedTo,
-            /// Understanding interprets Utterance.
-            Interprets,
-            /// Generation creates Utterance.
-            Creates,
-            /// TurnManagement controls Participant.
-            Controls,
-            /// Grounding arises from shared Understanding.
-            ArisesFrom,
-            /// DialogueAct addresses Topic.
-            Addresses,
-            /// Utterance raises/resolves QUD (Ginzburg).
-            RaisesOrResolves,
-            /// Understanding updates CommonGround (Stalnaker).
-            EstablishesIn,
-            /// Intention drives Generation (Levelt).
-            Drives,
-            /// GroundingAct achieves Grounding (Traum).
-            Achieves,
-            /// Repair restores Understanding (Schegloff).
-            Restores,
-            /// Intention formed from DialogueState + QUD (what to say next).
-            FormedFrom,
-        ],
-        edges: [
-            // Participant produces Utterance
-            (Participant, Utterance, Produces),
-            // Utterance expresses DialogueAct
-            (Utterance, DialogueAct, Expresses),
-            // Utterance updates DialogueState
-            (Utterance, DialogueState, Updates),
-            // Utterance appended to History
-            (Utterance, History, AppendedTo),
-            // Understanding interprets Utterance
-            (Understanding, Utterance, Interprets),
-            // Generation creates Utterance
-            (Generation, Utterance, Creates),
-            // TurnManagement controls Participant
-            (TurnManagement, Participant, Controls),
-            // Grounding arises from Understanding
-            (Understanding, Grounding, ArisesFrom),
-            // DialogueAct addresses Topic
-            (DialogueAct, Topic, Addresses),
-            // QUD: utterances raise or resolve questions (Ginzburg 2012)
-            (Utterance, QUD, RaisesOrResolves),
-            // Understanding establishes facts in CommonGround (Stalnaker 2002)
-            (Understanding, CommonGround, EstablishesIn),
-            // Intention drives Generation (Levelt 1989)
-            (Intention, Generation, Drives),
-            // GroundingAct achieves Grounding (Traum 1994)
-            (GroundingAct, Grounding, Achieves),
-            // Repair restores Understanding (Schegloff 1977)
-            (Repair, Understanding, Restores),
-            // Intention formed from DialogueState + QUD
-            (DialogueState, Intention, FormedFrom),
-            (QUD, Intention, FormedFrom),
-        ],
-        composed: [
-            (Participant, DialogueAct),
-            (Participant, DialogueState),
-            (Participant, History),
-            (TurnManagement, Utterance),
-            (Understanding, DialogueAct),
-            (Generation, DialogueAct),
-            // Intention → Utterance (through Generation)
-            (Intention, Utterance),
-            // DialogueState → Generation (through Intention)
-            (DialogueState, Generation),
-            // Repair → Grounding (through Understanding → GroundingAct)
-            (Repair, Grounding),
-        ],
-        being: Process,
-        source: "Austin (1962); Traum (1994); Clark (1996)",
-    }
+    edges: [
+        (Participant, Utterance, Produces),
+        (Utterance, DialogueAct, Expresses),
+        (Utterance, DialogueState, Updates),
+        (Utterance, History, AppendedTo),
+        (Understanding, Utterance, Interprets),
+        (Generation, Utterance, Creates),
+        (TurnManagement, Participant, Controls),
+        (Understanding, Grounding, ArisesFrom),
+        (DialogueAct, Topic, Addresses),
+        (Utterance, QUD, RaisesOrResolves),
+        (Understanding, CommonGround, EstablishesIn),
+        (Intention, Generation, Drives),
+        (GroundingAct, Grounding, Achieves),
+        (Repair, Understanding, Restores),
+        (DialogueState, Intention, FormedFrom),
+        (QUD, Intention, FormedFrom),
+    ],
 }
 
 /// Whether a dialogue concept is agent-facing (produced/consumed by participants).


### PR DESCRIPTION
## Summary

Batch 2 of the #113 migration. Focuses on the **dialogue/pragmatics/cognition cluster** — the critical-path ontologies for #117's chat pipeline composition.

### Migrated (7 ontologies)

| File | Concepts | Notable |
|---|---|---|
| \`cognitive/cognition/distinction.rs\` | Void, Mark, Boundary, MarkedSpace, UnmarkedSpace, ReEntry | Spencer-Brown Laws of Form |
| \`cognitive/cognition/epistemics.rs\` | KnownKnown, KnownUnknown, UnknownKnown, UnknownUnknown | Rumsfeld matrix + cybernetics transitions |
| \`cognitive/cognition/metacognition.rs\` | ObjectLevel, MetaLevel, Monitoring, Evaluation, Control, Trace, Gap, Repair, Clarification, EpistemicAssessment | Added \`Orchestrates\` edges so transitive closure reaches leaves (replaces ad-hoc \`composed:\` list) |
| \`cognitive/linguistics/pragmatics/fragment/ontology.rs\` | 12 concepts (Fragment, ResolvedContent, QUD, DialogueContext, + 8 fragment types) | Fernandez & Ginzburg 2002 |
| \`cognitive/linguistics/pragmatics/nlg.rs\` | 11 concepts (CommunicativeGoal → Realization → SurfaceText) | Reiter & Dale 2000 pipeline + Levelt Monitor + Appelt goal |
| \`cognitive/linguistics/pipeline/ontology.rs\` | 12 concepts (Parse, Generate, Unit, Counit, stages, streaming) | **de Groote ACG 2001 adjunction**, DisCoCat, Di Lavore streams |
| \`formal/information/dialogue/ontology.rs\` | 15 concepts (Utterance, Participant, DialogueAct, QUD, CommonGround, Intention, Grounding, Repair) | Austin, Searle, Traum, Clark, Ginzburg, Stalnaker, Levelt |

### Pattern highlights

- All migrations use \`pub use X as Y\` re-exports (not type aliases) for backward compat — type aliases don't support glob imports in match arms.
- **metacognition**: dropped the ad-hoc \`composed:\` list, added explicit \`Orchestrates\` edges from MetaLevel to sub-processes. Transitive closure via Floyd-Warshall now covers MetaLevel → Clarification correctly.
- **dialogue, nlg, pipeline**: composed lists were redundant with edge closure; just removed.

### Test plan

- [x] \`cargo test -p pr4xis-domains\` — 4594 passed (same as master baseline)
- [x] \`devenv ci\` — all 5 checks green
- [ ] Copilot review

Refs: #113 (7/188 → 29/188 total migrated), #117 (unblocks chat pipeline composition)