### PR TITLE
feat(#124): Endofunctor trait — first-class C → C functor

### DIFF
--- a/crates/domains/src/natural/geodesy/ontology.rs
+++ b/crates/domains/src/natural/geodesy/ontology.rs
@@ -1,4 +1,4 @@
-use pr4xis::category::{Category, Entity, Functor};
+use pr4xis::category::{Category, Endofunctor, Entity, Functor};
 use pr4xis::define_ontology;
 use pr4xis::ontology::{Axiom, Ontology, Quality};
 
@@ -84,6 +84,10 @@ impl Functor for NedToEnuFunctor {
             to: Self::map_object(&m.to),
         }
     }
+}
+
+impl Endofunctor for NedToEnuFunctor {
+    type Category = GeodesyCategory;
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/domains/src/natural/geodesy/tests.rs
+++ b/crates/domains/src/natural/geodesy/tests.rs
@@ -1,4 +1,4 @@
-use pr4xis::category::validate::{check_category_laws, check_functor_laws};
+use pr4xis::category::validate::{check_category_laws, check_endofunctor_laws};
 use pr4xis::ontology::{Axiom, Ontology};
 
 use crate::natural::geodesy::ontology::*;
@@ -9,8 +9,8 @@ fn geodesy_category_laws() {
 }
 
 #[test]
-fn ned_to_enu_functor_laws() {
-    check_functor_laws::<NedToEnuFunctor>().unwrap();
+fn ned_to_enu_endofunctor_laws() {
+    check_endofunctor_laws::<NedToEnuFunctor>().unwrap();
 }
 
 #[test]

--- a/crates/pr4xis/src/category/endofunctor.rs
+++ b/crates/pr4xis/src/category/endofunctor.rs
@@ -1,0 +1,44 @@
+use super::category::Category;
+use super::functor::Functor;
+
+/// An endofunctor is a functor whose source and target categories coincide: F: C → C.
+///
+/// Mac Lane (1971), *Categories for the Working Mathematician*, Ch. II §1.
+///
+/// # Why it matters
+///
+/// Endofunctors are the foundation of monads, comonads, fixed points, and every
+/// self-referential construction in category theory. A monad is "just" an endofunctor
+/// with η (unit) and μ (multiplication) natural transformations satisfying coherence
+/// laws (Mac Lane Ch. VI §1; Wadler, *Monads for Functional Programming*, 1992).
+///
+/// Declaring a functor as `Endofunctor` makes the C → C identity first-class, rather
+/// than implicit in `type Source = type Target`. Downstream code can require an
+/// endofunctor at the type level (e.g., monad definitions, involutions, fixed-point
+/// operators) without inspecting associated types.
+///
+/// # Laws
+///
+/// Endofunctors inherit the [`Functor`] laws (identity and composition preservation).
+/// There are no additional laws — but
+/// [`crate::category::validate::check_endofunctor_laws`] specialises those checks to a
+/// single carrier category, which makes involution and fixed-point mistakes easier to
+/// localise.
+///
+/// # Implementing
+///
+/// An `Endofunctor` impl is an explicit claim: "this functor's source and target are
+/// the same category." The compiler enforces it via the `Source = Self::Category` and
+/// `Target = Self::Category` constraints on the associated type.
+///
+/// ```ignore
+/// impl Endofunctor for MyInvolution {
+///     type Category = MyCategory;
+/// }
+/// ```
+pub trait Endofunctor:
+    Functor<Source = <Self as Endofunctor>::Category, Target = <Self as Endofunctor>::Category>
+{
+    /// The single category this endofunctor operates within.
+    type Category: Category;
+}

--- a/crates/pr4xis/src/category/mod.rs
+++ b/crates/pr4xis/src/category/mod.rs
@@ -6,6 +6,7 @@ pub mod applicative;
 #[allow(clippy::module_inception)]
 pub mod category;
 pub mod comonad;
+pub mod endofunctor;
 pub mod entity;
 pub mod free;
 pub mod functor;
@@ -32,6 +33,7 @@ pub use algebra::{Algebra, Coalgebra};
 pub use applicative::Ap;
 pub use category::Category;
 pub use comonad::{Cofree, Focused};
+pub use endofunctor::Endofunctor;
 pub use entity::Entity;
 pub use free::Chain;
 pub use functor::Functor;

--- a/crates/pr4xis/src/category/validate.rs
+++ b/crates/pr4xis/src/category/validate.rs
@@ -1,4 +1,5 @@
 use super::category::Category;
+use super::endofunctor::Endofunctor;
 use super::entity::Entity;
 use super::functor::Functor;
 use super::relationship::Relationship;
@@ -151,4 +152,18 @@ where
     }
 
     Ok(())
+}
+
+/// Verify endofunctor laws: the functor laws specialised to a single carrier category.
+///
+/// Mac Lane (1971), Ch. II §1: an endofunctor F: C → C is just a functor whose source
+/// and target coincide, so the laws are identical to [`check_functor_laws`]. The
+/// specialisation exists because endofunctors typically express involutions or
+/// fixed-point structure; failures here almost always localise to the single category's
+/// own morphisms rather than a cross-category mapping mismatch.
+pub fn check_endofunctor_laws<F: Endofunctor>() -> Result<(), String>
+where
+    <F::Category as Category>::Morphism: PartialEq,
+{
+    check_functor_laws::<F>()
 }


### PR DESCRIPTION
## Summary

- New `pr4xis::category::Endofunctor` trait refines `Functor` with `Source = Target = Self::Category` — makes the C → C identity first-class rather than implicit in associated types.
- New `check_endofunctor_laws` in `category::validate` — specialises the functor laws check to a single carrier category.
- Migrates `NedToEnuFunctor` (geodesy NED ↔ ENU involution) to declare `Endofunctor` — the first concrete instance.

Cites Mac Lane (1971), *Categories for the Working Mathematician*, Ch. II §1.

Foundation for declaring \`Writer<W, A>\` formally as a Monad (Endofunctor + η + μ, per Wadler 1992) and for #123 Resilience retry/backoff semantics that compose monadically.

Closes #124.

## Test plan

- [x] \`cargo test -p pr4xis --lib\` — 417 passed
- [x] \`cargo test -p pr4xis-domains -- geodesy\` — 20 passed incl. \`ned_to_enu_endofunctor_laws\`
- [x] \`cargo test --workspace\` — 5000+ passed
- [x] \`devenv ci\` — all 5 checks green (fmt, clippy, check, unit, wasm)