### PR TITLE
feat(#62): Heim Phase 3 — substrate enrichment, object-level equivalence

### DIFF
--- a/crates/domains/src/formal/meta/gap_analysis.rs
+++ b/crates/domains/src/formal/meta/gap_analysis.rs
@@ -795,36 +795,31 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn test_syntrometry_substrate_gaps_surface_missing_distinctions() {
+    fn test_syntrometry_substrate_is_object_equivalence() {
         let report = analyze_syntrometry_substrate();
-        // The substrate is at least as expressive as itself — every substrate
-        // primitive must round-trip back to itself under F∘G (the forward
-        // functor is surjective onto substrate concepts by construction).
+        // Phase 3 target: the lineage functor is an equivalence at the
+        // object level. Every syntrometric concept has a distinct substrate
+        // target and round-trips back to itself; every substrate primitive
+        // has a distinct syntrometric representative and round-trips back
+        // to itself.
         assert!(
             report.counit_gaps.is_empty(),
-            "counit should be identity on substrate (substrate is closed under forward map)"
+            "counit gaps should be empty (substrate is closed): {:?}",
+            report.counit_gaps
         );
-        // The unit surfaces real missing distinctions: at least SyntrixLevel,
-        // Part, Dialektik, and Aspekt all collapse.
         assert!(
-            !report.unit_gaps.is_empty(),
-            "unit must surface missing distinctions — pr4xis substrate is coarser than Heim's vocabulary"
+            report.unit_gaps.is_empty(),
+            "Phase 3 target is 0% unit loss; residual gaps: {:?}",
+            report.unit_gaps
         );
-
-        let loss = report.unit_loss_ratio();
-        assert!(
-            loss > 0.0 && loss < 1.0,
-            "loss ratio should be strictly between 0 and 1; got {}",
-            loss
-        );
+        assert_eq!(report.unit_loss_ratio(), 0.0);
+        assert_eq!(report.counit_loss_ratio(), 0.0);
         eprintln!(
-            "\nSyntrometry ⊣ Pr4xisSubstrate unit loss: {:.1}% ({} gap / {} preserved)",
-            loss * 100.0,
-            report.unit_gaps.len(),
-            report.unit_preserved.len()
+            "\nSyntrometry ⊣ Pr4xisSubstrate — equivalence achieved: {}/{} unit preserved, {}/{} counit preserved",
+            report.unit_preserved.len(),
+            report.unit_preserved.len() + report.unit_gaps.len(),
+            report.counit_preserved.len(),
+            report.counit_preserved.len() + report.counit_gaps.len(),
         );
-        for gap in &report.unit_gaps {
-            eprintln!("  {:?} collapses to {:?}", gap.original, gap.collapsed_to);
-        }
     }
 }

--- a/crates/domains/src/formal/meta/syntrometry/README.md
+++ b/crates/domains/src/formal/meta/syntrometry/README.md
@@ -16,16 +16,22 @@ The headline — "pr4xis instantiates Heim's syntrometric structure" — is veri
 
 ## Measured loss profile (gap analysis)
 
-`cargo test -p pr4xis-domains -- test_syntrometry_substrate_gaps_surface_missing_distinctions --nocapture`
+`cargo test -p pr4xis-domains -- test_syntrometry_substrate_is_object_equivalence --nocapture`
 
 | Direction | Loss | What collapses |
 |---|---|---|
-| **Unit** (Syntrometry → Substrate → Syntrometry) | **28.6%** (4/14) | `Dialektik → Syntrix`, `Aspekt → Syntrix`, `SyntrixLevel → Predicate`, `Part → Koordination` |
-| **Counit** (Substrate → Syntrometry → Substrate) | **0%** (0/10) | none — substrate is closed under the round-trip |
+| **Unit** (Syntrometry → Substrate → Syntrometry) | **0%** (0/14) | none — object-level equivalence |
+| **Counit** (Substrate → Syntrometry → Substrate) | **0%** (0/14) | none — substrate is closed under the round-trip |
 
-Phase 2's four new concepts (Telecenter/Maxime/Transzendenzstufe/Metroplex) all round-trip cleanly because Phase 2 added matching substrate targets (`SubEigenform`/`SubIntention`/`SubStagingLevel`/`SubSystemOfSystems`).
+Phase 3 closed the remaining 28.6% loss by adding four sub-kinds to `Pr4xisSubstrate` — `SubOppositionCategory`, `SubProductCategory`, `SubLeveledEntity`, `SubMereologicalMorphism` — so `Dialektik`, `Aspekt`, `SyntrixLevel`, and `Part` each land at a distinct substrate target. The lineage is now an **object-level equivalence**: every Heim concept has a unique pr4xis-substrate counterpart and every substrate primitive has a unique Heim representative.
 
-The four remaining unit collapses are the specific distinctions Heim's vocabulary carries that pr4xis's core substrate still does not. Phase 3 follow-up: either add `OppositionCategory`/`ProductCategory` sub-kinds to reduce collapse, or accept that these four are compression the substrate makes deliberately.
+Each phase's incremental progress, for the record:
+
+| Phase | Unit loss | Counit loss |
+|---|---|---|
+| 1 | 40% (4/10) | 0% (0/6) |
+| 2 | 28.6% (4/14) | 0% (0/10) |
+| 3 | **0% (0/14)** | **0% (0/14)** |
 
 ## Phase 1 entities (Phase 1 + Phase 2 = 14 Syntrometry + 10 Substrate)
 
@@ -38,31 +44,34 @@ The four remaining unit collapses are the specific distinctions Heim's vocabular
 | Mereology (1) | `Part` |
 | **Teleological / hierarchical (Phase 2) (4)** | `Telecenter`, `Maxime`, `Transzendenzstufe`, `Metroplex` |
 
-### Pr4xis-substrate (10)
+### Pr4xis-substrate (14)
 
 | Family | Entities |
 |---|---|
 | Core categorical primitives (6) | `SubEntity`, `SubMorphism`, `SubCategory`, `SubFunctor`, `SubEndofunctor`, `SubOntology` |
-| **Architectural primitives (Phase 2) (4)** | `SubEigenform`, `SubIntention`, `SubStagingLevel`, `SubSystemOfSystems` |
+| Architectural primitives (Phase 2) (4) | `SubEigenform`, `SubIntention`, `SubStagingLevel`, `SubSystemOfSystems` |
+| **Refined sub-kinds (Phase 3) (4)** | `SubOppositionCategory`, `SubProductCategory`, `SubLeveledEntity`, `SubMereologicalMorphism` |
 
-## The lineage mapping
+## The lineage mapping (object-level equivalence after Phase 3)
 
 | Syntrometry | Pr4xis substrate | Interpretation |
 |---|---|---|
 | `Predicate`     | `SubEntity` | atomic distinction = Entity variant |
 | `Predikatrix`   | `SubOntology` | predicate-system = small ontology |
-| `Dialektik`     | `SubCategory` | binary-opposition structure |
+| `Dialektik`     | `SubOppositionCategory` | binary-opposition structure (Phase 3) |
 | `Koordination`  | `SubMorphism` | ordering between predicates = morphism |
-| `Aspekt`        | `SubCategory` | product [D × K × P] = product category |
+| `Aspekt`        | `SubProductCategory` | product [D × K × P] = product category (Phase 3) |
 | `Syntrix`       | `SubCategory` | C_SL (§2.2 — Category of Leveled Structures) |
-| `SyntrixLevel`  | `SubEntity` | single level = object in the category |
+| `SyntrixLevel`  | `SubLeveledEntity` | grade-indexed entity (Phase 3) |
 | `Synkolator`    | `SubEndofunctor` | endofunctor on the Syntrix |
 | `Korporator`    | `SubFunctor` | structure-mapping functor |
-| `Part`          | `SubMorphism` | mereological relation = morphism |
-| **`Telecenter`** | **`SubEigenform`** | **goal-attractor = X=F(X) / CommunicativeGoal / Colimit** |
-| **`Maxime`**    | **`SubIntention`** | **extremal selection = BDI Intention / C1 Attention** |
-| **`Transzendenzstufe`** | **`SubStagingLevel`** | **transcendence-level = Staging grade / C1-vs-C2 split** |
-| **`Metroplex`** | **`SubSystemOfSystems`** | **hierarchical container = SoS composition (#94)** |
+| `Part`          | `SubMereologicalMorphism` | CEM-satisfying morphism (Phase 3) |
+| `Telecenter`    | `SubEigenform` | goal-attractor = X=F(X) (Phase 2) |
+| `Maxime`        | `SubIntention` | extremal selection = BDI Intention (Phase 2) |
+| `Transzendenzstufe` | `SubStagingLevel` | transcendence-level (Phase 2) |
+| `Metroplex`     | `SubSystemOfSystems` | hierarchical container (Phase 2) |
+
+Bijection: every Heim concept has a unique substrate target; every substrate primitive has a unique Heim representative. Verified by `test_syntrometry_substrate_is_object_equivalence`.
 
 ## Domain axioms (6)
 

--- a/crates/domains/src/formal/meta/syntrometry/adjunction.rs
+++ b/crates/domains/src/formal/meta/syntrometry/adjunction.rs
@@ -67,12 +67,13 @@ mod tests {
         }
     }
 
-    /// Some syntrometric concepts do NOT round-trip — those are the missing
-    /// distinctions the lineage adjunction surfaces. We assert the collapse
-    /// is non-empty without pinning specific concepts; gap analysis produces
-    /// the exact list with percentages.
+    /// Phase 3 target: the lineage is an equivalence at the object level.
+    /// Every syntrometric concept has a distinct substrate target and
+    /// round-trips back to itself. The remaining "adjunction" is trivial
+    /// in the Cat-sense but the *content* is the full Heim ↔ pr4xis
+    /// correspondence.
     #[test]
-    fn unit_surfaces_collapsed_concepts() {
+    fn unit_is_an_object_equivalence() {
         let collapses: Vec<_> = SyntrometryConcept::variants()
             .into_iter()
             .filter(|obj| {
@@ -81,18 +82,16 @@ mod tests {
             })
             .collect();
         assert!(
-            !collapses.is_empty(),
-            "the lineage adjunction is not an equivalence; at least one concept must collapse"
+            collapses.is_empty(),
+            "Phase 3 target is 0% unit loss; residual collapses: {:?}",
+            collapses
         );
     }
 
-    /// Concepts that *do* round-trip are the ones the substrate captures
-    /// natively. Expected: Predicate, Koordination, Syntrix, Korporator,
-    /// Synkolator, Predikatrix (the six that were the canonical
-    /// representatives in both directions).
+    /// All 14 syntrometric concepts are round-trip fixed points after
+    /// Phase 3's substrate enrichment.
     #[test]
-    fn unit_preserves_six_canonical_concepts() {
-        use SyntrometryConcept as S;
+    fn unit_preserves_all_concepts() {
         let preserved: Vec<_> = SyntrometryConcept::variants()
             .into_iter()
             .filter(|obj| {
@@ -100,20 +99,12 @@ mod tests {
                 source == rt
             })
             .collect();
-        let expected = [
-            S::Predicate,
-            S::Koordination,
-            S::Syntrix,
-            S::Korporator,
-            S::Synkolator,
-            S::Predikatrix,
-        ];
-        for c in &expected {
-            assert!(
-                preserved.contains(c),
-                "expected {:?} to be preserved by the lineage round-trip",
-                c
-            );
-        }
+        assert_eq!(
+            preserved.len(),
+            SyntrometryConcept::variants().len(),
+            "all {} concepts should be preserved; got {}",
+            SyntrometryConcept::variants().len(),
+            preserved.len()
+        );
     }
 }

--- a/crates/domains/src/formal/meta/syntrometry/lineage_functor.rs
+++ b/crates/domains/src/formal/meta/syntrometry/lineage_functor.rs
@@ -44,11 +44,12 @@ fn map_concept(c: &SyntrometryConcept) -> Pr4xisSubstrateConcept {
     use Pr4xisSubstrateConcept as P;
     use SyntrometryConcept as S;
     match c {
-        // Phase 1 mappings.
-        S::Predicate | S::SyntrixLevel => P::SubEntity,
+        // Phase 1 base mappings — each concept now lands at a distinct
+        // substrate primitive, no collapses.
+        S::Predicate => P::SubEntity,
         S::Predikatrix => P::SubOntology,
-        S::Dialektik | S::Aspekt | S::Syntrix => P::SubCategory,
-        S::Koordination | S::Part => P::SubMorphism,
+        S::Syntrix => P::SubCategory,
+        S::Koordination => P::SubMorphism,
         S::Synkolator => P::SubEndofunctor,
         S::Korporator => P::SubFunctor,
         // Phase 2 teleological / hierarchical mappings.
@@ -56,6 +57,12 @@ fn map_concept(c: &SyntrometryConcept) -> Pr4xisSubstrateConcept {
         S::Maxime => P::SubIntention,
         S::Transzendenzstufe => P::SubStagingLevel,
         S::Metroplex => P::SubSystemOfSystems,
+        // Phase 3 — formerly collapsed Phase 1 concepts land at their own
+        // refined substrate targets.
+        S::Dialektik => P::SubOppositionCategory,
+        S::Aspekt => P::SubProductCategory,
+        S::SyntrixLevel => P::SubLeveledEntity,
+        S::Part => P::SubMereologicalMorphism,
     }
 }
 

--- a/crates/domains/src/formal/meta/syntrometry/proptests.rs
+++ b/crates/domains/src/formal/meta/syntrometry/proptests.rs
@@ -109,23 +109,11 @@ proptest! {
         prop_assert!(SyntrometryConcept::variants().contains(&rt));
     }
 
-    /// The ten canonical concepts — Phase 1's six (Predicate, Koordination,
-    /// Syntrix, Korporator, Synkolator, Predikatrix) plus Phase 2's four
-    /// (Telecenter, Maxime, Transzendenzstufe, Metroplex) — are fixed
-    /// points of the round-trip. Sampling any one must reproduce it.
+    /// Phase 3 target: all 14 syntrometric concepts are round-trip fixed
+    /// points. Sampling any one reproduces it under G∘F. This is the
+    /// "object-level equivalence" form of the Heim ↔ pr4xis lineage.
     #[test]
-    fn canonical_concepts_are_round_trip_fixed_points(c in prop_oneof![
-        Just(SyntrometryConcept::Predicate),
-        Just(SyntrometryConcept::Koordination),
-        Just(SyntrometryConcept::Syntrix),
-        Just(SyntrometryConcept::Korporator),
-        Just(SyntrometryConcept::Synkolator),
-        Just(SyntrometryConcept::Predikatrix),
-        Just(SyntrometryConcept::Telecenter),
-        Just(SyntrometryConcept::Maxime),
-        Just(SyntrometryConcept::Transzendenzstufe),
-        Just(SyntrometryConcept::Metroplex),
-    ]) {
+    fn every_concept_is_round_trip_fixed_point(c in arb_syntrometry_concept()) {
         let (source, rt) = unit_pair(&c);
         prop_assert_eq!(source, rt);
     }

--- a/crates/domains/src/formal/meta/syntrometry/substrate.rs
+++ b/crates/domains/src/formal/meta/syntrometry/substrate.rs
@@ -29,6 +29,14 @@ pr4xis::ontology! {
         SubIntention,
         SubStagingLevel,
         SubSystemOfSystems,
+
+        // Phase 3 — sub-kinds of SubCategory / SubMorphism / SubEntity that
+        // receive the four remaining Phase 1 collapsed concepts cleanly.
+        // Landing these drops the unit loss from 28.6% to 0%.
+        SubOppositionCategory,
+        SubProductCategory,
+        SubLeveledEntity,
+        SubMereologicalMorphism,
     ],
 
     labels: {
@@ -43,12 +51,22 @@ pr4xis::ontology! {
         SubIntention: ("en", "Intention", "The BDI (Bratman 1987) commitment-to-plan + the C1 attention selection (Dehaene GWT). The extremal-selection primitive in the substrate."),
         SubStagingLevel: ("en", "StagingLevel", "A single grade of the Futamura-projection staging hierarchy / C1 vs C2 consciousness split. The transcendence-level primitive."),
         SubSystemOfSystems: ("en", "SystemOfSystems", "The hierarchical composition primitive — what system-of-systems ontologies formalise. Graded composition of sub-systems."),
+
+        SubOppositionCategory: ("en", "OppositionCategory", "A Category whose morphisms carry a binary-opposition structure — the refinement that distinguishes Dialektik from an unstructured Category."),
+        SubProductCategory: ("en", "ProductCategory", "A Category that is the product of two or more component categories (Mac Lane Ch. II §3). Receives Heim's Aspekt = [D × K × P]."),
+        SubLeveledEntity: ("en", "LeveledEntity", "An Entity that carries a grade/level index within a leveled-category tower. Receives Heim's SyntrixLevel."),
+        SubMereologicalMorphism: ("en", "MereologicalMorphism", "A Morphism that additionally satisfies CEM mereological axioms (Weak Supplementation etc.). Receives Heim's Part."),
     },
 
     is_a: [
         // True subsumption only: every Endofunctor is a Functor specialised
         // to Source = Target (Mac Lane Ch. II §1).
         (SubEndofunctor, SubFunctor),
+        // Phase 3 — sub-kinds of the core primitives.
+        (SubOppositionCategory, SubCategory),
+        (SubProductCategory, SubCategory),
+        (SubLeveledEntity, SubEntity),
+        (SubMereologicalMorphism, SubMorphism),
     ],
 }
 
@@ -77,6 +95,10 @@ impl Quality for SubstrateLocation {
                 "formal::meta::staging + cognitive::cognition::consciousness (C1/C2)"
             }
             P::SubSystemOfSystems => "system-of-systems composition (tracked as issue #94)",
+            P::SubOppositionCategory => "pr4xis::ontology::reasoning::opposition",
+            P::SubProductCategory => "pr4xis::category::monoidal::Product",
+            P::SubLeveledEntity => "formal::meta::staging (grade-indexed entities)",
+            P::SubMereologicalMorphism => "pr4xis::ontology::reasoning::mereology",
         })
     }
 }

--- a/crates/domains/src/formal/meta/syntrometry/substrate_functor.rs
+++ b/crates/domains/src/formal/meta/syntrometry/substrate_functor.rs
@@ -46,6 +46,12 @@ pub fn map_substrate(c: &Pr4xisSubstrateConcept) -> SyntrometryConcept {
         P::SubIntention => S::Maxime,
         P::SubStagingLevel => S::Transzendenzstufe,
         P::SubSystemOfSystems => S::Metroplex,
+        // Phase 3 reverse — each refined substrate primitive has a
+        // syntrometric counterpart, so every concept round-trips cleanly.
+        P::SubOppositionCategory => S::Dialektik,
+        P::SubProductCategory => S::Aspekt,
+        P::SubLeveledEntity => S::SyntrixLevel,
+        P::SubMereologicalMorphism => S::Part,
     }
 }
 

--- a/docs/research/novelty.md
+++ b/docs/research/novelty.md
@@ -56,16 +56,17 @@ cargo test -p pr4xis-domains -- formal::meta::syntrometry::lineage_functor::test
 
 Heim's syntrometric primitives — `Predicate`, `Predikatrix`, `Dialektik`, `Koordination`, `Aspekt`, `Syntrix`, `SyntrixLevel`, `Synkolator`, `Korporator`, `Part` — are encoded as a pr4xis ontology at [`crates/domains/src/formal/meta/syntrometry/`](../../crates/domains/src/formal/meta/syntrometry/). A `Functor: Syntrometry → Pr4xisSubstrate` carries each Heim concept to its pr4xis-core counterpart. `check_functor_laws` verifies identity preservation + composition preservation exhaustively over every morphism. The structural alignment is no longer argued — it is proven.
 
-### Measured information-loss profile
+### Measured information-loss profile (Phase 3 = object-level equivalence)
 
-The [gap analysis](../../crates/domains/src/formal/meta/gap_analysis.rs) reports the round-trip collapse (Phase 1 + Phase 2):
+The [gap analysis](../../crates/domains/src/formal/meta/gap_analysis.rs) reports the round-trip collapse:
 
-| Direction | Loss | Concepts that collapse |
-|---|---|---|
-| Unit (Syntrometry → Pr4xisSubstrate → Syntrometry) | **28.6%** (4/14) | `Dialektik → Syntrix`, `Aspekt → Syntrix`, `SyntrixLevel → Predicate`, `Part → Koordination` |
-| Counit (Pr4xisSubstrate → Syntrometry → Pr4xisSubstrate) | **0%** (0/10) | none (substrate is closed under the forward map) |
+| Phase | Unit loss | Counit loss | Notes |
+|---|---|---|---|
+| 1 | 40% (4/10) | 0% (0/6) | Syntrometric primitives only |
+| 2 | 28.6% (4/14) | 0% (0/10) | + teleological concepts |
+| **3** | **0% (0/14)** | **0% (0/14)** | **object-level equivalence** |
 
-Phase 2 added the teleological concepts (Telecenter, Maxime, Transzendenzstufe, Metroplex) with matching substrate targets, so all four round-trip cleanly. The four remaining unit collapses are the distinctions Heim carries that pr4xis's core substrate still does not — actionable Phase 3 targets.
+Phase 3 closed the final 28.6% gap by adding `SubOppositionCategory`, `SubProductCategory`, `SubLeveledEntity`, and `SubMereologicalMorphism` — refined sub-kinds of the substrate primitives that receive `Dialektik`, `Aspekt`, `SyntrixLevel`, and `Part` without collapsing. Every Heim concept now has a unique pr4xis-substrate target and every substrate primitive has a unique Heim representative.
 
 ### Phase 1 concept mapping
 

--- a/docs/understand/foundations.md
+++ b/docs/understand/foundations.md
@@ -20,7 +20,7 @@ The lineage claim is **verified, not asserted**. Heim's syntrometric primitives 
 cargo test -p pr4xis-domains -- formal::meta::syntrometry::lineage_functor::tests::lineage_functor_laws_pass
 ```
 
-The [gap analysis](../../crates/domains/src/formal/meta/gap_analysis.rs) measures **28.6% unit loss** on the round trip (Phase 1 + Phase 2) — four specific distinctions Heim's vocabulary carries that pr4xis's core substrate does not (`Dialektik`, `Aspekt`, `SyntrixLevel`, `Part`). Phase 2 added the teleological primitives (Telecenter/Maxime/Transzendenzstufe/Metroplex) with matching substrate targets, so those four round-trip cleanly; the remaining four are actionable Phase 3 targets.
+The [gap analysis](../../crates/domains/src/formal/meta/gap_analysis.rs) reports **0% unit loss** (object-level equivalence after Phase 3): every Heim concept has a unique pr4xis-substrate target and every substrate primitive has a unique Heim representative. Phase 3 closed the last 28.6% gap by adding `SubOppositionCategory`, `SubProductCategory`, `SubLeveledEntity`, and `SubMereologicalMorphism` — refined sub-kinds of `SubCategory` / `SubEntity` / `SubMorphism` that receive `Dialektik`, `Aspekt`, `SyntrixLevel`, and `Part` without collapsing.
 
 ## Modern Foundations (Section by Section)
 


### PR DESCRIPTION
Stacks on #136. Closes the 28.6% unit loss by adding 4 refined sub-kinds to Pr4xisSubstrate (SubOppositionCategory, SubProductCategory, SubLeveledEntity, SubMereologicalMorphism). Lineage is now an object-level equivalence: 0% unit loss, 0% counit loss. 28 tests pass.