### PR TITLE
feat(#62): Heim Phase 4 — cross-functor Syntrometry → MetaOntology

### DIFF
--- a/crates/domains/src/formal/meta/gap_analysis.rs
+++ b/crates/domains/src/formal/meta/gap_analysis.rs
@@ -794,6 +794,43 @@ mod tests {
     // Syntrometry-Substrate gap analysis (#62)
     // -----------------------------------------------------------------------
 
+    // -----------------------------------------------------------------------
+    // Syntrometry → MetaOntology cross-functor collapse (Phase 4)
+    // -----------------------------------------------------------------------
+
+    /// Count how many distinct `MetaEntity` values the 14 syntrometric
+    /// concepts land at under the cross-functor. Expected: 12 out of 14 land
+    /// uniquely; SyntrixLevel/Syntrix both go to CategoryStructure and
+    /// Synkolator/Korporator both go to Functor — the two intentional
+    /// collapses documented in meta_ontology_functor.rs.
+    #[test]
+    fn test_syntrometry_to_meta_ontology_collapse_is_two() {
+        use crate::formal::meta::ontology_diagnostics::ontology::MetaEntity;
+        use crate::formal::meta::syntrometry::meta_ontology_functor::SyntrometryToMetaOntology;
+        use crate::formal::meta::syntrometry::ontology::SyntrometryConcept;
+        use pr4xis::category::{Entity, Functor};
+        use std::collections::HashSet;
+
+        let mapped: HashSet<MetaEntity> = SyntrometryConcept::variants()
+            .into_iter()
+            .map(|c| SyntrometryToMetaOntology::map_object(&c))
+            .collect();
+        let total = SyntrometryConcept::variants().len();
+        let unique = mapped.len();
+        let collapse = total - unique;
+        assert_eq!(
+            collapse, 2,
+            "expected exactly 2 intentional collapses (Syntrix/SyntrixLevel both → CategoryStructure; Synkolator/Korporator both → Functor); got {}",
+            collapse
+        );
+        eprintln!(
+            "\nSyntrometry → MetaOntology collapse: {}/{} ({:.1}%)",
+            collapse,
+            total,
+            collapse as f64 / total as f64 * 100.0
+        );
+    }
+
     #[test]
     fn test_syntrometry_substrate_is_object_equivalence() {
         let report = analyze_syntrometry_substrate();

--- a/crates/domains/src/formal/meta/syntrometry/README.md
+++ b/crates/domains/src/formal/meta/syntrometry/README.md
@@ -1,4 +1,4 @@
-# Syntrometry — Heim's syntrometric logic (Phases 1 + 2)
+# Syntrometry — Heim's syntrometric logic (Phases 1–4)
 
 Encodes the core of Burkhard Heim's *Syntrometrische Maximentelezentrik* — the logical/philosophical foundation underneath Heim theory — as a pr4xis ontology, and verifies the long-standing claim that "pr4xis instantiates Heim's syntrometric structure" by a Functor whose laws are checked at test time.
 
@@ -84,16 +84,34 @@ Bijection: every Heim concept has a unique substrate target; every substrate pri
 | `MaximeConvergesTowardTelecenter` | Heim Telezentrik | Maxime carries `ConvergesToward` edge into Telecenter |
 | `TelecenterIsSynkolatorFixedPoint` | Heim Telezentrik × Mac Lane | Synkolator carries `FixedPointOf` edge into Telecenter (eigenform) |
 
-## Phase 3 (future)
+## Phase 4 — cross-functors to existing pr4xis ontologies
 
-Reducing the 28.6% unit loss by enriching the substrate with the four missing distinctions:
+Phase 4 demonstrates that Heim's syntrometric vocabulary aligns not only with the Pr4xisSubstrate mirror but with existing workspace meta-ontologies. The first cross-functor is:
 
-- `SubOppositionCategory` to receive `Dialektik` without collapse
-- `SubProductCategory` to receive `Aspekt` without collapse
-- `SubLeveledEntity` / `SubGradedObject` to receive `SyntrixLevel` without collapse
-- `SubMereologicalMorphism` to receive `Part` without collapse
+### `Syntrometry → MetaOntology`
 
-Each would be a judgement call — the collapse is honest information compression, and adding sub-kinds only pays off if downstream ontologies need them.
+Maps each of the 14 Syntrometry concepts to a `formal::meta::ontology_diagnostics::MetaEntity`:
+
+| Syntrometry | MetaEntity |
+|---|---|
+| `Predicate`     | `DomainOntology` |
+| `Predikatrix`   | `TaxonomyStructure` |
+| `Dialektik`     | `CausalStructure` |
+| `Koordination`  | `NaturalTransformation` |
+| `Aspekt`        | `QualityStructure` |
+| `Syntrix`, `SyntrixLevel` | `CategoryStructure` (intentional collapse) |
+| `Synkolator`, `Korporator` | `Functor` (intentional collapse) |
+| `Part`          | `UnitMorphism` |
+| `Telecenter`    | `CanonicalRepresentative` |
+| `Maxime`        | `PropertyTest` |
+| `Transzendenzstufe` | `IntermediateDomain` |
+| `Metroplex`     | `Structure` |
+
+Collapse rate: 2/14 (14.3%). The two collapses are deliberate — pr4xis's meta-ontology doesn't distinguish `SyntrixLevel` from `Syntrix` or `Synkolator` from `Korporator` at that level of abstraction. Verified by `meta_ontology_functor_laws_pass` + proptest sweeps.
+
+### Future cross-functors
+
+Additional targets remain open as follow-ups: `Syntrometry → Algebra` (Korporator ↦ Mapping, Aspekt ↦ Product), `Syntrometry → Staging` (Transzendenzstufe ↦ Futamura-projection levels). Each would satisfy the functor laws by construction (kinded source → dense target) and add its own collapse profile.
 
 ## Files
 

--- a/crates/domains/src/formal/meta/syntrometry/meta_ontology_functor.rs
+++ b/crates/domains/src/formal/meta/syntrometry/meta_ontology_functor.rs
@@ -1,0 +1,90 @@
+//! Cross-functor: Syntrometry → OntologyDiagnostics::MetaOntology.
+//!
+//! Phase 4 of the Heim-pr4xis lineage work. Demonstrates that Heim's
+//! syntrometric vocabulary and pr4xis's meta-ontology vocabulary describe
+//! the same primitives using different words — an explicit structural
+//! alignment between the two, proven by a strict Functor whose laws check
+//! at test time.
+//!
+//! # The mapping
+//!
+//! | Syntrometry | MetaEntity | Why |
+//! |---|---|---|
+//! | `Predicate`     | `DomainOntology`     | The atomic unit of a domain vocabulary |
+//! | `Predikatrix`   | `TaxonomyStructure`  | A structured set of predicates = taxonomy |
+//! | `Dialektik`     | `CausalStructure`    | Binary opposition ≈ minimal causal structure |
+//! | `Koordination`  | `NaturalTransformation` | Ordering between parallel operators |
+//! | `Aspekt`        | `QualityStructure`   | Subjective view = quality slice |
+//! | `Syntrix`       | `CategoryStructure`  | §2.2 — Syntrix IS a category |
+//! | `SyntrixLevel`  | `CategoryStructure`  | A level is a sub-category (collapse — intentional) |
+//! | `Synkolator`    | `Functor`            | Endofunctor on a Syntrix |
+//! | `Korporator`    | `Functor`            | General functor (collapse) |
+//! | `Part`          | `UnitMorphism`       | Mereology embeds into the morphism structure |
+//! | `Telecenter`    | `CanonicalRepresentative` | The round-trip attractor |
+//! | `Maxime`        | `PropertyTest`       | Extremal selection = invariant check |
+//! | `Transzendenzstufe` | `IntermediateDomain` | A grade between two abstract levels |
+//! | `Metroplex`     | `Structure`          | The top-level abstract container |
+//!
+//! The collapses (SyntrixLevel → CategoryStructure, Korporator → Functor)
+//! are honest: pr4xis's meta-ontology deliberately doesn't distinguish
+//! endofunctor-on-a-Syntrix from a general functor at that level of
+//! abstraction. Those distinctions live in Pr4xisSubstrate (Phases 1-3).
+
+use pr4xis::category::{Category, Functor};
+
+use super::ontology::{SyntrometryCategory, SyntrometryConcept, SyntrometryRelation};
+use crate::formal::meta::ontology_diagnostics::ontology::{MetaCategory, MetaEntity, MetaRelation};
+
+fn map_concept(c: &SyntrometryConcept) -> MetaEntity {
+    use MetaEntity as M;
+    use SyntrometryConcept as S;
+    match c {
+        S::Predicate => M::DomainOntology,
+        S::Predikatrix => M::TaxonomyStructure,
+        S::Dialektik => M::CausalStructure,
+        S::Koordination => M::NaturalTransformation,
+        S::Aspekt => M::QualityStructure,
+        S::Syntrix | S::SyntrixLevel => M::CategoryStructure,
+        S::Synkolator | S::Korporator => M::Functor,
+        S::Part => M::UnitMorphism,
+        S::Telecenter => M::CanonicalRepresentative,
+        S::Maxime => M::PropertyTest,
+        S::Transzendenzstufe => M::IntermediateDomain,
+        S::Metroplex => M::Structure,
+    }
+}
+
+/// Cross-domain functor: Syntrometry → MetaOntology.
+pub struct SyntrometryToMetaOntology;
+
+impl Functor for SyntrometryToMetaOntology {
+    type Source = SyntrometryCategory;
+    type Target = MetaCategory;
+
+    fn map_object(obj: &SyntrometryConcept) -> MetaEntity {
+        map_concept(obj)
+    }
+
+    fn map_morphism(m: &SyntrometryRelation) -> MetaRelation {
+        let from = map_concept(&m.from);
+        let to = map_concept(&m.to);
+        if from == to {
+            MetaCategory::identity(&from)
+        } else {
+            MetaRelation { from, to }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pr4xis::category::validate::check_functor_laws;
+
+    /// The Phase 4 headline test: Heim's vocabulary aligns with pr4xis's
+    /// own meta-ontology vocabulary via a strict Functor.
+    #[test]
+    fn meta_ontology_functor_laws_pass() {
+        check_functor_laws::<SyntrometryToMetaOntology>().unwrap();
+    }
+}

--- a/crates/domains/src/formal/meta/syntrometry/mod.rs
+++ b/crates/domains/src/formal/meta/syntrometry/mod.rs
@@ -14,6 +14,7 @@
 
 pub mod adjunction;
 pub mod lineage_functor;
+pub mod meta_ontology_functor;
 pub mod ontology;
 #[cfg(test)]
 mod proptests;

--- a/crates/domains/src/formal/meta/syntrometry/proptests.rs
+++ b/crates/domains/src/formal/meta/syntrometry/proptests.rs
@@ -153,6 +153,32 @@ proptest! {
     // Morphism closure
     // -----------------------------------------------------------------------
 
+    // -----------------------------------------------------------------------
+    // Phase 4 cross-functor invariants
+    // -----------------------------------------------------------------------
+
+    /// For every concept sampled, the cross-functor to MetaOntology produces
+    /// a valid MetaEntity target.
+    #[test]
+    fn meta_ontology_functor_maps_into_target(c in arb_syntrometry_concept()) {
+        use super::meta_ontology_functor::SyntrometryToMetaOntology;
+        use crate::formal::meta::ontology_diagnostics::ontology::MetaEntity;
+        let mapped = SyntrometryToMetaOntology::map_object(&c);
+        prop_assert!(MetaEntity::variants().contains(&mapped));
+    }
+
+    /// Cross-functor preserves identity for any sampled concept.
+    #[test]
+    fn meta_ontology_functor_preserves_identity(c in arb_syntrometry_concept()) {
+        use super::meta_ontology_functor::SyntrometryToMetaOntology;
+        use crate::formal::meta::ontology_diagnostics::ontology::MetaCategory;
+        let id_c = SyntrometryCategory::identity(&c);
+        let f_id = SyntrometryToMetaOntology::map_morphism(&id_c);
+        let id_fc =
+            MetaCategory::identity(&SyntrometryToMetaOntology::map_object(&c));
+        prop_assert_eq!(f_id, id_fc);
+    }
+
     /// Every kind of Syntrometry morphism (Identity, every declared edge
     /// kind, Composed) shows up in `morphisms()`. Without this the
     /// category's closure claim would be empty.


### PR DESCRIPTION
Stacks on #137. Demonstrates Heim's vocabulary aligns with existing pr4xis meta-ontology (ontology_diagnostics::MetaEntity) via a strict Functor that passes check_functor_laws. Collapse rate: 2/14 (14.3%) — intentional (Syntrix/SyntrixLevel → CategoryStructure; Synkolator/Korporator → Functor). 32 tests pass (up from 28).