### PR TITLE
fix(#62): address 11 copilot comments on consolidated Heim PR #143

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The mathematical foundation runs from G. Spencer-Brown's *Laws of Form* (1969) t
 cargo test -p pr4xis-domains -- syntrometry
 ```
 
-runs the whole suite — the primary `Syntrometry → Pr4xisSubstrate` functor (object-level equivalence; 0% loss), the `Distinction → Syntrometry` embedding (Spencer-Brown → Heim), and cross-functors into `MetaOntology`, `Staging` (Futamura), `Algebra` (Goguen/Zimmermann), and `C1` (Dehaene GWT). Heim anticipated each of these constructions.
+runs the whole suite — the primary `Syntrometry → Pr4xisSubstrate` functor (14 of 18 concepts round-trip as fixed points; four intentional collapses whose richer semantics lives in the dedicated Dialectics and Kripke ontologies), the `Distinction → Syntrometry` embedding (Spencer-Brown → Heim), and cross-functors into `MetaOntology`, `Staging` (Futamura), `Algebra` (Goguen/Zimmermann), `Dialectics` (Hegel/Aristotle/Marx/Adorno/Priest), `Kripke` (possible-worlds semantics), and `C1` (Dehaene GWT).
 
 ## The problem
 

--- a/crates/domains/docs/report.html
+++ b/crates/domains/docs/report.html
@@ -139,7 +139,7 @@ const D = {
   "meta": {
     "generator": "vogix-ontology",
     "dataset": "all (base16 + base24 + vogix16)",
-    "generated": "2026-04-17T14:38:14Z"
+    "generated": "2026-04-17T22:38:23Z"
   },
   "summary": {
     "total": 464,

--- a/crates/domains/docs/report.json
+++ b/crates/domains/docs/report.json
@@ -2,7 +2,7 @@
   "meta": {
     "generator": "vogix-ontology",
     "dataset": "all",
-    "generated": "2026-04-17T14:38:14Z"
+    "generated": "2026-04-17T22:38:23Z"
   },
   "summary": {
     "total": 464,

--- a/crates/domains/proptest-regressions/cognitive/cognition/tests.txt
+++ b/crates/domains/proptest-regressions/cognitive/cognition/tests.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 59dfad87614ef5481db4f462bf94d52854283dd2a93e4efe1032a136efa2ea4e # shrinks to _dummy = 0

--- a/crates/domains/proptest-regressions/formal/meta/syntrometry/proptests.txt
+++ b/crates/domains/proptest-regressions/formal/meta/syntrometry/proptests.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 05b6d53a4e33eefbe3ada1f915288512ddc791522f06ebfa5e1faa54e005f918 # shrinks to c = SequencePermutation

--- a/crates/domains/src/formal/meta/gap_analysis.rs
+++ b/crates/domains/src/formal/meta/gap_analysis.rs
@@ -798,14 +798,9 @@ mod tests {
     // Syntrometry → MetaOntology cross-functor collapse (Phase 4)
     // -----------------------------------------------------------------------
 
-    /// Count how many distinct `MetaEntity` values the 14 syntrometric
-    /// concepts land at under the cross-functor. Expected: 12 out of 14 land
-    /// uniquely; SyntrixLevel/Syntrix both go to CategoryStructure and
-    /// Synkolator/Korporator both go to Functor — the two intentional
-    /// collapses documented in meta_ontology_functor.rs.
-    /// Phase 5: Syntrometry → Staging collapses Heim's finer grain into
-    /// Futamura's coarser vocabulary. Expected 6+ collapses (many concepts
-    /// land at Program).
+    /// Syntrometry → Staging collapses Heim's finer grain into Futamura's
+    /// coarser vocabulary. Expected 6+ collapses (many concepts land at
+    /// Program).
     #[test]
     fn test_syntrometry_to_staging_collapse_is_measured() {
         use crate::formal::meta::staging::ontology::StageConcept;
@@ -860,8 +855,12 @@ mod tests {
         assert!(collapse < total, "functor is not trivial");
     }
 
+    /// Syntrometry → MetaOntology intentionally collapses 6 of 18 concepts
+    /// — pairs that share a diagnostic role collapse to the same `MetaEntity`
+    /// bucket (e.g., Synkolator/Korporator/permutations → Functor;
+    /// Koordination/Reflexivity → NaturalTransformation).
     #[test]
-    fn test_syntrometry_to_meta_ontology_collapse_is_two() {
+    fn test_syntrometry_to_meta_ontology_collapse_is_six() {
         use crate::formal::meta::ontology_diagnostics::ontology::MetaEntity;
         use crate::formal::meta::syntrometry::meta_ontology_functor::SyntrometryToMetaOntology;
         use crate::formal::meta::syntrometry::ontology::SyntrometryConcept;

--- a/crates/domains/src/formal/meta/syntrometry/README.md
+++ b/crates/domains/src/formal/meta/syntrometry/README.md
@@ -35,7 +35,7 @@ cargo test -p pr4xis-domains -- formal::meta::syntrometry
 | Refined sub-kinds (3) | `SubProductCategory`, `SubGradedObject`, `SubObject` |
 | Natural transformation (1) | `SubNaturalTransformation` |
 
-## Lineage mappings (seven verified functors)
+## Lineage mappings (eight verified functors)
 
 ### Primary: `Syntrometry → Pr4xisSubstrate`
 
@@ -66,7 +66,7 @@ Gap analysis: **4 intentional unit collapses out of 18, 0% counit loss** — ver
 
 ### Cross-functors into existing pr4xis ontologies
 
-Each of the six cross-functors below passes `check_functor_laws` and carries its own collapse profile, demonstrating that Heim's vocabulary aligns with pr4xis's meta-ontology, composition, staging, cognitive, logical, and modal layers:
+Each of the seven cross-functors below passes `check_functor_laws` and carries its own collapse profile, demonstrating that Heim's vocabulary aligns with pr4xis's meta-ontology, composition, staging, cognitive, logical, and modal layers. The last row — `Distinction → Syntrometry` — runs in the historical direction (Spencer-Brown 1969 → Heim, embedding the earlier distinction calculus into the richer syntrometric vocabulary):
 
 | Functor | Target | Headline mapping |
 |---|---|---|

--- a/crates/domains/src/formal/meta/syntrometry/README.md
+++ b/crates/domains/src/formal/meta/syntrometry/README.md
@@ -14,7 +14,7 @@ cargo test -p pr4xis-domains -- formal::meta::syntrometry
 
 ## Entities
 
-### Syntrometry (14)
+### Syntrometry (18)
 
 | Family | Entities |
 |---|---|
@@ -22,6 +22,9 @@ cargo test -p pr4xis-domains -- formal::meta::syntrometry
 | Syntrometric structures (4) | `Syntrix`, `SyntrixLevel`, `Synkolator`, `Korporator` |
 | Mereology (1) | `Part` |
 | Teleological / hierarchical (4) | `Telecenter`, `Maxime`, `Transzendenzstufe`, `Metroplex` |
+| Permutation operators (2) | `SequencePermutation` (C), `OrientationPermutation` (c) |
+| Multi-aspect (1) | `Aspektivsystem` |
+| Self-observation (1) | `Reflexivity` (ρ) |
 
 ### Pr4xis-substrate (14)
 
@@ -32,11 +35,11 @@ cargo test -p pr4xis-domains -- formal::meta::syntrometry
 | Refined sub-kinds (3) | `SubProductCategory`, `SubGradedObject`, `SubObject` |
 | Natural transformation (1) | `SubNaturalTransformation` |
 
-## Lineage mappings (six verified functors)
+## Lineage mappings (seven verified functors)
 
 ### Primary: `Syntrometry → Pr4xisSubstrate`
 
-13 of 14 concepts round-trip cleanly. `Dialektik` intentionally collapses to `SubCategory` because opposition-structure is carried by the dedicated [Dialectics](../../logic/dialectics/) ontology (Aristotle / Hegel / Marx / Adorno / Priest), not by the core substrate. Reach it via the `SyntrometryToDialectics` cross-functor.
+14 of 18 concepts round-trip cleanly. Four concepts — `Dialektik`, `SequencePermutation`, `OrientationPermutation`, `Aspektivsystem` — intentionally collapse to a substrate parent because their richer semantics lives in dedicated cross-functor targets (Dialectics, Kripke).
 
 | Syntrometry | Pr4xis substrate |
 |---|---|
@@ -46,24 +49,29 @@ cargo test -p pr4xis-domains -- formal::meta::syntrometry
 | `Koordination`  | `SubMorphism` |
 | `Aspekt`        | `SubProductCategory` |
 | `Syntrix`       | `SubCategory` |
-| `SyntrixLevel`  | `SubLeveledEntity` |
+| `SyntrixLevel`  | `SubGradedObject` |
 | `Synkolator`    | `SubEndofunctor` |
 | `Korporator`    | `SubFunctor` |
-| `Part`          | `SubMereologicalMorphism` |
+| `Part`          | `SubObject` |
 | `Telecenter`    | `SubEigenform` |
 | `Maxime`        | `SubIntention` |
 | `Transzendenzstufe` | `SubStagingLevel` |
 | `Metroplex`     | `SubSystemOfSystems` |
+| `SequencePermutation` | `SubEndofunctor` (collapses with Synkolator) |
+| `OrientationPermutation` | `SubEndofunctor` (collapses) |
+| `Aspektivsystem` | `SubOntology` (collapses — handled by Kripke cross-functor) |
+| `Reflexivity`   | `SubNaturalTransformation` |
 
-Gap analysis: **~7% unit loss (1/14 — Dialektik), 0% counit loss** — verified by `test_syntrometry_substrate_dialektik_collapses`. The one collapse is intentional and preserved at full resolution by the Dialectics cross-functor.
+Gap analysis: **4 intentional unit collapses out of 18, 0% counit loss** — verified by `test_syntrometry_substrate_intentional_collapses`. Each collapsed concept is preserved at full resolution by a dedicated cross-functor.
 
 ### Cross-functors into existing pr4xis ontologies
 
-Each of the five cross-functors below passes `check_functor_laws` and carries its own collapse profile, demonstrating that Heim's vocabulary aligns with pr4xis's meta-ontology, composition, staging, and cognitive layers:
+Each of the six cross-functors below passes `check_functor_laws` and carries its own collapse profile, demonstrating that Heim's vocabulary aligns with pr4xis's meta-ontology, composition, staging, cognitive, logical, and modal layers:
 
 | Functor | Target | Headline mapping |
 |---|---|---|
 | `Syntrometry → Dialectics` | `formal::logic::dialectics` (Hegel / Aristotle / Priest) | `Dialektik` ↦ `DialecticalMoment`, `Synkolator` ↦ `Sublation`, `Telecenter` ↦ `Synthesis` |
+| `Syntrometry → Kripke` | `formal::logic::kripke` (Kripke 1959/63) | `Aspekt` ↦ `KripkeFrame`, `Aspektivsystem` ↦ `AccessibilityRelation`, `Reflexivity` ↦ `Reflexive` |
 | `Syntrometry → MetaOntology` | `formal::meta::ontology_diagnostics` | `Synkolator` / `Korporator` ↦ `Functor`, `Maxime` ↦ `PropertyTest` |
 | `Syntrometry → Staging` | `formal::meta::staging` (Futamura 1971) | `Transzendenzstufe` ↦ `Interpreter`, `Metroplex` ↦ `CompilerGenerator` |
 | `Syntrometry → Algebra` | `formal::meta::algebra` (Goguen / Zimmermann) | `Korporator` ↦ `Mapping`, `Aspekt` ↦ `Product`, `Telecenter` ↦ `Pushout` |

--- a/crates/domains/src/formal/meta/syntrometry/meta_ontology_functor.rs
+++ b/crates/domains/src/formal/meta/syntrometry/meta_ontology_functor.rs
@@ -25,10 +25,20 @@
 //! | `Transzendenzstufe` | `IntermediateDomain` | A grade between two abstract levels |
 //! | `Metroplex`     | `Structure`          | The top-level abstract container |
 //!
-//! The collapses (SyntrixLevel → CategoryStructure, Korporator → Functor)
-//! are honest: pr4xis's meta-ontology deliberately doesn't distinguish
-//! endofunctor-on-a-Syntrix from a general functor at that level of
-//! abstraction. Those distinctions live in Pr4xisSubstrate (Phases 1-3).
+//! The functor has six intentional collapses out of 18 concepts — pairs
+//! that share a diagnostic role land at the same `MetaEntity` bucket:
+//!
+//! - `Synkolator` / `Korporator` / `SequencePermutation` /
+//!   `OrientationPermutation` → `Functor`
+//! - `Syntrix` / `SyntrixLevel` → `CategoryStructure`
+//! - `Predicate` / `Aspektivsystem` → `DomainOntology`
+//! - `Koordination` / `Reflexivity` → `NaturalTransformation`
+//!
+//! These are honest: pr4xis's meta-ontology deliberately doesn't
+//! distinguish endofunctor-on-a-Syntrix from a general functor at that
+//! level of abstraction. The finer distinctions live in Pr4xisSubstrate
+//! (where e.g. `SubEndofunctor` ⊂ `SubFunctor`) and in the dedicated
+//! Dialectics / Kripke ontologies.
 
 use pr4xis::category::{Category, Functor};
 

--- a/crates/domains/src/formal/meta/syntrometry/ontology.rs
+++ b/crates/domains/src/formal/meta/syntrometry/ontology.rs
@@ -161,10 +161,11 @@ pr4xis::ontology! {
         // Transzendenzstufe is a structural index into a Metroplex — each
         // level corresponds to a grade of Syntrix within the hierarchy.
         (Transzendenzstufe, Syntrix, Grades),
-        // A Telecenter can be realised as a fixed point of a Synkolator
-        // (Eigenform X = F(X)) — this is the categorical content that
-        // justifies the pr4xis mapping to Eigenform / colimit.
-        (Synkolator, Telecenter, FixedPointOf),
+        // A Telecenter is a fixed-point of a Synkolator (Eigenform
+        // X = F(X)) — this is the categorical content that justifies
+        // the pr4xis mapping to Eigenform / colimit. Reads as
+        // "Telecenter is a FixedPointOf Synkolator".
+        (Telecenter, Synkolator, FixedPointOf),
     ],
 }
 
@@ -270,7 +271,7 @@ impl Axiom for SyntrixIsLeveled {
     }
 }
 
-///a Metroplex mereologically contains Syntrices organised
+/// A Metroplex mereologically contains Syntrices organised
 /// by Transzendenzstufen. Both parts must be present.
 pub struct MetroplexContainsSyntrixAndLevels;
 
@@ -285,7 +286,7 @@ impl Axiom for MetroplexContainsSyntrixAndLevels {
     }
 }
 
-///every Maxime ConvergesToward a Telecenter. The pair
+/// Every Maxime ConvergesToward a Telecenter. The pair
 /// (Maxime, Telecenter) must exist with the ConvergesToward kind —
 /// otherwise the teleological selection claim of Maximentelezentrik
 /// is unencoded.
@@ -304,20 +305,23 @@ impl Axiom for MaximeConvergesTowardTelecenter {
     }
 }
 
-///a Telecenter is a fixed-point of a Synkolator — the
-/// categorical content of the eigenform / goal-attractor mapping.
+/// A Telecenter is a fixed-point of a Synkolator — the categorical
+/// content of the eigenform / goal-attractor mapping. Encoded as
+/// `(Telecenter, Synkolator, FixedPointOf)` so `(from, to, kind)`
+/// reads "Telecenter is a FixedPointOf Synkolator", preserving the
+/// intended subject/object roles.
 pub struct TelecenterIsSynkolatorFixedPoint;
 
 impl Axiom for TelecenterIsSynkolatorFixedPoint {
     fn description(&self) -> &str {
-        "Synkolator carries a FixedPointOf edge into Telecenter (eigenform X=F(X))"
+        "Telecenter is a FixedPointOf Synkolator (eigenform X=F(X))"
     }
     fn holds(&self) -> bool {
         use SyntrometryConcept as S;
         use SyntrometryRelationKind as K;
         SyntrometryCategory::morphisms()
             .iter()
-            .any(|r| r.from == S::Synkolator && r.to == S::Telecenter && r.kind == K::FixedPointOf)
+            .any(|r| r.from == S::Telecenter && r.to == S::Synkolator && r.kind == K::FixedPointOf)
     }
 }
 

--- a/crates/wasm/Cargo.lock
+++ b/crates/wasm/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pr4xis"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "linkme",
  "paste",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "pr4xis-chat"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "pr4xis",
  "pr4xis-domains",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "pr4xis-domains"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/docs/research/novelty.md
+++ b/docs/research/novelty.md
@@ -42,9 +42,9 @@ After subtracting the prior art, the things we believe pr4xis contributes — pe
 
 5. **The explicit codegen / async / mmap functor equivalence.** Three different mechanisms for delivering ontology data into the runtime, all proven equivalent as functors from the same source. This is a small-but-load-bearing piece of infrastructure that lets the same ontology run as a static binary, an asynchronously loaded resource, or a memory-mapped file without semantic drift.
 
-## The Heim lineage — machine-verified across seven functors
+## The Heim lineage — machine-verified across eight functors
 
-The most prominent lineage claim in the project is the structural alignment with the **modernized syntrometric logic tradition** (Heim 1980, reformulated categorically in 2025). Per the project's core principle — every claim must be machine-checkable — this is operationalised as seven tested theorems (one primary lineage functor + six cross-functors) spanning the substrate, meta-ontology layer, composition layer, and cognitive layer.
+The most prominent lineage claim in the project is the structural alignment with the **modernized syntrometric logic tradition** (Heim 1980, reformulated categorically in 2025). Per the project's core principle — every claim must be machine-checkable — this is operationalised as eight tested theorems (one primary lineage functor + seven cross-functors, including the historical-direction `Distinction → Syntrometry` embedding) spanning the substrate, meta-ontology layer, composition layer, cognitive layer, and modal/dialectical logic layers.
 
 ### Verify
 

--- a/docs/research/novelty.md
+++ b/docs/research/novelty.md
@@ -42,9 +42,9 @@ After subtracting the prior art, the things we believe pr4xis contributes — pe
 
 5. **The explicit codegen / async / mmap functor equivalence.** Three different mechanisms for delivering ontology data into the runtime, all proven equivalent as functors from the same source. This is a small-but-load-bearing piece of infrastructure that lets the same ontology run as a static binary, an asynchronously loaded resource, or a memory-mapped file without semantic drift.
 
-## The Heim lineage — machine-verified across six functors
+## The Heim lineage — machine-verified across seven functors
 
-The most prominent lineage claim in the project is the structural alignment with the **modernized syntrometric logic tradition** (Heim 1980, reformulated categorically in 2025). Per the project's core principle — every claim must be machine-checkable — this is operationalised as six tested theorems spanning the substrate, the meta-ontology layer, the composition layer, and the cognitive layer.
+The most prominent lineage claim in the project is the structural alignment with the **modernized syntrometric logic tradition** (Heim 1980, reformulated categorically in 2025). Per the project's core principle — every claim must be machine-checkable — this is operationalised as seven tested theorems (one primary lineage functor + six cross-functors) spanning the substrate, meta-ontology layer, composition layer, and cognitive layer.
 
 ### Verify
 
@@ -54,15 +54,15 @@ cargo test -p pr4xis-domains -- syntrometry
 
 ### What the test proves
 
-Heim's syntrometric primitives — `Predicate`, `Predikatrix`, `Dialektik`, `Koordination`, `Aspekt`, `Syntrix`, `SyntrixLevel`, `Synkolator`, `Korporator`, `Part` — are encoded as a pr4xis ontology at [`crates/domains/src/formal/meta/syntrometry/`](../../crates/domains/src/formal/meta/syntrometry/). A `Functor: Syntrometry → Pr4xisSubstrate` carries each Heim concept to its pr4xis-core counterpart. `check_functor_laws` verifies identity preservation + composition preservation exhaustively over every morphism. The structural alignment is no longer argued — it is proven.
+Heim's 18 syntrometric primitives — distinction primitives (`Predicate`, `Predikatrix`, `Dialektik`, `Koordination`, `Aspekt`), structures (`Syntrix`, `SyntrixLevel`, `Synkolator`, `Korporator`), mereology (`Part`), teleological/hierarchical (`Telecenter`, `Maxime`, `Transzendenzstufe`, `Metroplex`), permutation operators (`SequencePermutation` C, `OrientationPermutation` c), multi-aspect (`Aspektivsystem`), self-observation (`Reflexivity` ρ) — are encoded as a pr4xis ontology at [`crates/domains/src/formal/meta/syntrometry/`](../../crates/domains/src/formal/meta/syntrometry/). A `Functor: Syntrometry → Pr4xisSubstrate` carries each Heim concept to its pr4xis-core counterpart. `check_functor_laws` verifies identity preservation + composition preservation exhaustively over every morphism. The structural alignment is no longer argued — it is proven.
 
 ### Measured information-loss profile
 
-The [gap analysis](../../crates/domains/src/formal/meta/gap_analysis.rs) on the primary lineage functor reports **0% unit loss and 0% counit loss** — every Heim concept has a unique pr4xis-substrate target and every substrate primitive has a unique Heim representative. Object-level equivalence.
+The [gap analysis](../../crates/domains/src/formal/meta/gap_analysis.rs) on the primary lineage functor reports **4 intentional unit collapses out of 18 concepts** (Dialektik, SequencePermutation, OrientationPermutation, Aspektivsystem) and **0% counit loss** (the substrate is closed under the round-trip). The four collapses are honest: each of these concepts has a richer dedicated home — `Dialektik` → the Dialectics ontology, `Aspektivsystem` → the Kripke ontology, the permutations → endomorphism-class at the substrate level. Full precision is preserved by the corresponding cross-functors below.
 
-### Cross-functors to existing pr4xis ontologies
+### Cross-functors to existing and new pr4xis ontologies
 
-The primary lineage is the Heim ↔ Pr4xisSubstrate bijection above. Beyond that, five further functors demonstrate that Heim's vocabulary aligns with ontologies pr4xis already had for other reasons:
+The primary lineage maps Heim into pr4xis's categorical substrate; cross-functors preserve richer structure by routing into dedicated ontologies:
 
 - **`Syntrometry → MetaOntology`** (ontology_diagnostics) — Heim's categorical primitives match the meta-ontology vocabulary pr4xis uses to diagnose gaps across ontology pairs.
 - **`Syntrometry → Staging`** (Futamura 1971) — Transzendenzstufen ↦ Futamura projection levels.


### PR DESCRIPTION
Addresses the 11 Copilot comments left on #143 after the squash-merge landed (the comments appeared after I merged — apologies, should have waited longer).

## Fixes

1, 7 — Syntrometry README: concept count corrected (14 → 18); listed all 7 families; mapping table updated with correct `SubGradedObject` / `SubObject` names; added `SyntrometryToKripke` to cross-functor table; cross-functor count 6 → 7.

1, 11 — README.md + novelty.md: corrected "0% unit loss / object-level equivalence" claim. The primary lineage functor has 4 intentional collapses out of 18 concepts (Dialektik, SequencePermutation, OrientationPermutation, Aspektivsystem); counit loss is 0%. The richer semantics of the collapsed concepts lives in dedicated Dialectics and Kripke cross-functors.

4, 8 — `gap_analysis.rs`: renamed `test_syntrometry_to_meta_ontology_collapse_is_two` → `_is_six` to match the asserted value; rewrote stale doc comments that referenced 14 concepts and 2 collapses.

5 — `ontology.rs`: fixed malformed rustdoc (`///a`, `///every` → `/// A`, `/// Every`) on three domain axiom documentation lines.

6 — `novelty.md`: "six functors" → "seven functors" in the section heading and explanation.

9 — `meta_ontology_functor.rs`: rewrote the collapse documentation to list the actual 6 collapses (Synkolator/Korporator/permutations → Functor; Syntrix/SyntrixLevel → CategoryStructure; Predicate/Aspektivsystem → DomainOntology; Koordination/Reflexivity → NaturalTransformation) rather than the stale "2 collapses" claim.

10 — `ontology.rs`: flipped edge direction `(Synkolator, Telecenter, FixedPointOf)` → `(Telecenter, Synkolator, FixedPointOf)` so the `(from, to, kind)` triple reads "Telecenter is a FixedPointOf Synkolator", preserving the subject/object roles Heim's eigenform interpretation requires. Updated the `TelecenterIsSynkolatorFixedPoint` axiom check and description to match.

## Test plan

- [x] `cargo test -p pr4xis-domains -- syntrometry dialectics kripke` — 63 tests pass
- [x] `cargo test --workspace` — all pass
- [x] `devenv ci` — 5/5 checks green