### PR TITLE
feat!: re-label #170 API restructure + fix Pages WordNet codegen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
+      - name: Fetch WordNet (needed by wasm build.rs codegen step)
+        run: cargo run -p pr4xis-cli --release --quiet -- update
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build WASM


### PR DESCRIPTION
## Summary

Two purposes in one PR:

### 1. Provide the breaking-change marker that #170 should have carried

PR #170 landed a workspace-wide breaking API change but was labelled `refactor:`, which `release-please` does not treat as version-bumping. As a result, the merge did not produce a release PR and the Deploy Pages + Publish to crates.io jobs stayed dormant.

This PR's title (`feat!:`) is the Conventional-Commits breaking-change marker that release-please needs. On merge it will pick up the breaking change and emit a release PR.

The breaking surface from #170 (recap, this PR does NOT re-do that work):
- `Axiom` trait: `description/holds` → `verify/citation` (#167)
- `Relationship` trait → `Arrow` trait (Mac Lane CWM Ch. I §1, Awodey 2010; #155)
- `Entity` → `Concept` (Guarino 2009; #154)
- `define_ontology!` macro removed; `ontology!` proc macro canonical
- `being:` clause removed from `ontology!` (#165, DOLCE out of core)
- Per-def traits removed (`TaxonomyDef`/`MereologyDef`/…, #168)
- `Composed` variant removed from auto-generated `*RelationKind` (#166)
- `Ontology::{structural_axioms, domain_axioms}` → single `axioms()`
- `PreconditionResult` deleted; `Engine` returns `Verdict`
- `describe` / `is_terminal` removed from `Action` / `Situation` / `Precondition` traits
- `register_axiom!` requires citation

### 2. Fix the Deploy Pages job

The Deploy Pages job last failed (April 18) because the wasm crate's `build.rs` needs WordNet XML to produce `english_codegen.rs`, which `crates/wasm/src/lib.rs:9` unconditionally `include!()`s. The workflow ran `wasm-pack build` without first fetching WordNet, so `build.rs` returned early with an empty codegen, and the `include!` failed to resolve.

The fix mirrors `devenv.nix`'s `dev-test` step: run `pr4xis-cli update` before `wasm-pack build` to populate `crates/domains/data/wordnet/english-wordnet-2025.xml`.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (carried from #170)
- [ ] CI Deploy Pages job runs and succeeds on the release PR that release-please will produce after this merges