### PR TITLE
feat!: document substrate API surface — release-please marker for #170

### DIFF
--- a/crates/pr4xis/src/lib.rs
+++ b/crates/pr4xis/src/lib.rs
@@ -1,3 +1,31 @@
+//! # pr4xis — Axiomatic Intelligence
+//!
+//! Substrate crate for the pr4xis runtime. Defines the core traits that
+//! every domain ontology composes against:
+//!
+//! - [`category::Arrow`] — directed structure between concepts, carrying
+//!   a relation-kind tag and per-instance provenance.
+//!   Grounded in Mac Lane (1971) *Categories for the Working Mathematician*
+//!   Ch. I §1 and Awodey (2010) *Category Theory* 2nd ed.
+//! - [`category::Concept`] — closed-world enum of named objects in a
+//!   category. Grounded in Guarino (2009) *What is an Ontology?*
+//! - [`logic::Axiom`] — verifiable claim returning a typed
+//!   [`logic::proof::Verdict`] (`Ok` = `Proof` witness, `Err` =
+//!   `Counterexample` refutation, per Martin-Löf 1984). Required
+//!   companion: [`logic::Axiom::citation`] — every axiom traces to
+//!   published literature.
+//! - [`ontology::Ontology`] — `type Cat`, `type Qual`, and `fn axioms()`.
+//!   Structural axioms come from
+//!   [`ontology::reasoning::structural_axioms_for`] (the catalog).
+//!
+//! Authoring shortcut: the [`ontology!`] proc macro takes a declarative
+//! shape (`name`, `source`, `concepts`, `labels`, `is_a:` / `has_a:` /
+//! `causes:` / `opposes:` sugar clauses, optional inline `axioms:` block)
+//! and emits the full impl chain at compile time.
+//!
+//! See `docs/understand/architecture.md` for the layered design and
+//! `docs/learn/get-started.md` for a guided walk-through.
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;


### PR DESCRIPTION
## Summary

PR #171's `feat!:` marker only touched `.github/workflows/ci.yml`. release-please runs per-crate-path scans (see `.release-please-config.json`) and reported `No user facing commits found since eb7cd87...` for every tracked crate — so it didn't open a release PR, and Deploy Pages + Publish to crates.io stayed dormant.

This PR puts a `feat!:` commit on a path release-please actually tracks: `crates/pr4xis/`. The added content is real top-level module documentation for the substrate traits (`Arrow`, `Concept`, `Axiom`, `Verdict`, `Ontology`, `ontology!` macro) with literature citations (Mac Lane CWM, Awodey 2010, Guarino 2009, Martin-Löf 1984).

With the `cargo-workspace` plugin already configured, the breaking-change bump cascades across `pr4xis-domains`, `pr4xis-chat`, `pr4xis-cli`, `pr4xis-examples` on the release PR release-please will produce after this merges.

The breaking surface comes from #170 (recap):
- `Axiom`: `description/holds` → `verify/citation` (#167)
- `Relationship` → `Arrow` (Mac Lane/Awodey, #155)
- `Entity` → `Concept` (Guarino 2009, #154)
- `define_ontology!` removed; `ontology!` proc macro canonical
- `being:` clause removed (#165, DOLCE out of core)
- Per-def traits removed (#168)
- `Composed` variant removed from auto-generated `*RelationKind` (#166)
- `Ontology::{structural_axioms, domain_axioms}` → `axioms()`
- `PreconditionResult` deleted; Engine returns `Verdict`
- `describe` / `is_terminal` removed from `Action`/`Situation`/`Precondition`
- `register_axiom!` requires citation

## Test plan

- [x] `cargo check -p pr4xis` clean
- [ ] On merge, release-please opens a `release: <version>` PR
- [ ] Merging that release PR triggers Deploy Pages + Publish to crates.io