### PR TITLE
fix(ci): use monorepo per-package tag_name for .prx.gz release upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,10 +280,14 @@ jobs:
       needs.check.result == 'success'
     outputs:
       release_created: ${{ steps.release.outputs.release_created || steps.release.outputs.releases_created }}
-      # The created release's git tag (e.g. `v0.19.0`). release-please-action@v4
-      # emits `tag_name` when a release is created; the `pages` job uses it to
-      # upload the .prx.gz artifacts to that release.
-      tag_name: ${{ steps.release.outputs.tag_name }}
+      # The pr4xis-domains component's git tag (e.g. `pr4xis-domains-v0.20.0`).
+      # The workspace is a multi-package monorepo so release-please-action@v4
+      # does NOT emit a top-level `tag_name`; instead it emits per-package
+      # outputs as `<path>--tag_name` for every released path. The `pages`
+      # job uses this tag to upload the .prx.gz artifacts to the
+      # pr4xis-domains release because the bundled OWL data the artifacts
+      # encode lives under `crates/domains/data/ontologies/`.
+      tag_name: ${{ steps.release.outputs['crates/domains--tag_name'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release


### PR DESCRIPTION
## Summary
- The `Deploy Pages` job's last step (`Upload .prx.gz to release`) failed on master CI run 26680076917 with `release not found` because `needs.release-please.outputs.tag_name` was empty.
- Root cause: workspace is a release-please monorepo (`cargo-workspace` plugin, 5 packages). In monorepo mode `release-please-action@v4` does NOT emit a top-level `tag_name`; per-package outputs use the `<path>--tag_name` form (e.g. `crates/domains--tag_name` → `pr4xis-domains-v0.20.0`).
- Anchor the upload to the `pr4xis-domains` component release since the bundled OWL data encoded in the `.prx.gz` envelopes lives under `crates/domains/data/ontologies/`.

Release / publish / Pages deployment all succeeded on that run; only the immutable-archive attach step failed. This patch fixes it forward — the next master release will get its `.prx.gz` artifacts attached to the `pr4xis-domains-vX.Y.Z` tag.

## Test plan
- [ ] CI green on this PR (workflow file change; the upload step itself only runs on the post-merge release-please dispatch on master, so verification is "next release" not "this PR").
- [ ] After merge, the next release-triggered `Deploy Pages` job uploads `.prx.gz` artifacts to the `pr4xis-domains-vX.Y.Z` GitHub Release.