### PR TITLE
fix(domains): use https:// URL for tinted-schemes submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "crates/domains/data/tinted-schemes"]
 	path = crates/domains/data/tinted-schemes
-	url = git@github.com:i-am-logger/tinted-schemes.git
+	url = https://github.com/i-am-logger/tinted-schemes.git


### PR DESCRIPTION
## Summary
The submodule URL was the git CLI shorthand `git@github.com:i-am-logger/tinted-schemes.git`. That isn't a parseable URL — it's git's scp-like shorthand. **libgit2 (which cargo uses) rejects it** and emits exactly:

> invalid url \`git@github.com:i-am-logger/tinted-schemes.git\`: relative URL without a base; try using \`ssh://git@github.com/i-am-logger/tinted-schemes.git\` instead

So any cargo consumer that pulls praxis as a git dependency fails at submodule init (cargo [#12295](https://github.com/rust-lang/cargo/issues/12295), [#13549](https://github.com/rust-lang/cargo/issues/13549)).

This PR switches the URL to `https://github.com/i-am-logger/tinted-schemes.git`:

- **cargo** now parses the URL successfully — fixes the original problem.
- **git locally** still uses SSH via the user's global `[url "git@github.com:"] insteadOf = "https://github.com/"` rewrite, so authenticated fetches keep working as before.
- **Sandboxed builds** (e.g. nix) fetch over public HTTPS with no credentials, which is what an external consumer (vogix) needs.

Nothing else changes — the submodule keeps providing the base16/base24 theme data that `applied/hmi/report/validator.rs` consumes for theme validation.

## Test plan
- [x] `cargo nextest run -p pr4xis-domains applied::hmi::report::validator::tests` — 5/5 pass locally (including the previously-failing `test_scan_all_datasets`).
- [ ] Full CI suite green.
- [ ] After merge, downstream cargo git-dep consumers (e.g. vogix) can now pull praxis without failing at submodule init.