### PR TITLE
feat!: sync all praxis crates to one version (0.22.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "pr4xis"
-version = "0.16.0"
+version = "0.22.0"
 dependencies = [
  "hashbrown 0.17.1",
  "linkme",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "pr4xis-chat"
-version = "0.8.1"
+version = "0.22.0"
 dependencies = [
  "criterion",
  "pr4xis",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "pr4xis-cli"
-version = "0.7.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "pr4xis-derive"
-version = "0.1.0"
+version = "0.22.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "pr4xis-domains"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "pr4xis-examples"
-version = "0.5.1"
+version = "0.22.0"
 dependencies = [
  "pr4xis",
  "pr4xis-domains",
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "pr4xis-web"
-version = "0.1.0"
+version = "0.22.0"
 dependencies = [
  "tiny_http",
 ]

--- a/crates/chat/Cargo.toml
+++ b/crates/chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pr4xis-chat"
-version = "0.8.1"
+version = "0.22.0"
 edition = "2024"
 authors = ["i-am-logger"]
 description = "Praxis chat engine — shared logic for CLI and WASM"
@@ -9,8 +9,8 @@ repository = "https://github.com/i-am-logger/pr4xis"
 homepage = "https://github.com/i-am-logger/pr4xis"
 
 [dependencies]
-pr4xis = { version = "0.16.0", path = "../pr4xis" }
-pr4xis-domains = { version = "0.21.0", path = "../domains" }
+pr4xis = { version = "0.22.0", path = "../pr4xis" }
+pr4xis-domains = { version = "0.22.0", path = "../domains" }
 
 [lints]
 workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pr4xis-cli"
-version = "0.7.0"
+version = "0.22.0"
 edition = "2024"
 authors = ["i-am-logger"]
 description = "Praxis chatbot CLI — axiomatic intelligence via ontology"
@@ -16,9 +16,9 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-pr4xis = { version = "0.16.0", path = "../pr4xis" }
-pr4xis-chat = { version = "0.8.1", path = "../chat" }
-pr4xis-domains = { version = "0.21.0", path = "../domains", features = ["fetch"] }
+pr4xis = { version = "0.22.0", path = "../pr4xis" }
+pr4xis-chat = { version = "0.22.0", path = "../chat" }
+pr4xis-domains = { version = "0.22.0", path = "../domains", features = ["fetch"] }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 
@@ -26,4 +26,4 @@ anyhow = "1"
 workspace = true
 
 [build-dependencies]
-pr4xis = { version = "0.16.0", path = "../pr4xis", features = ["codegen"] }
+pr4xis = { version = "0.22.0", path = "../pr4xis", features = ["codegen"] }

--- a/crates/domains/Cargo.toml
+++ b/crates/domains/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pr4xis-domains"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2024"
 authors = ["i-am-logger"]
 description = "Applied domains — chess, calculator, elevator, legal, traffic, HTTP, games, math, physics, music, colors"
@@ -16,7 +16,7 @@ homepage = "https://github.com/i-am-logger/pr4xis"
 # Keeping it off the normal dep keeps `xsd-parser` out of the WASM graph
 # (this crate is a WASM default-feature dependency — see the fetch
 # gating notes below).
-pr4xis = { version = "0.16.0", path = "../pr4xis", default-features = false, features = ["std"] }
+pr4xis = { version = "0.22.0", path = "../pr4xis", default-features = false, features = ["std"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 toml = "1"
@@ -108,7 +108,7 @@ fetch = ["prx", "dep:ureq", "dep:rustls", "dep:rustls-rustcrypto"]
 # emits Rust modules under $OUT_DIR/<name>_codegen.rs for every Statute-kind
 # source whose lock carries structural data. The crate's runtime tree then
 # `include!`s those modules under `social::compliance::law::<name>::`.
-pr4xis = { version = "0.16.0", path = "../pr4xis", default-features = false, features = ["codegen"] }
+pr4xis = { version = "0.22.0", path = "../pr4xis", default-features = false, features = ["codegen"] }
 serde = { version = "1.0", features = ["derive"] }
 toml = "1"
 # SHA-256 for build-time source hashing.
@@ -122,7 +122,7 @@ workspace = true
 # `pr4xis::codegen::wordnet::parse_wordnet_xml` directly. `codegen` is
 # off the normal dep (it leaks `xsd-parser` into WASM), so unify it back
 # in for test builds here.
-pr4xis = { version = "0.16.0", path = "../pr4xis", features = ["codegen"] }
+pr4xis = { version = "0.22.0", path = "../pr4xis", features = ["codegen"] }
 criterion = { version = "0.8", features = ["html_reports"] }
 proptest = "1.11"
 tempfile = "3"

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pr4xis-examples"
-version = "0.5.1"
+version = "0.22.0"
 edition = "2024"
 authors = ["i-am-logger"]
 description = "Example puzzles and reference implementations"
@@ -10,8 +10,8 @@ repository = "https://github.com/i-am-logger/pr4xis"
 homepage = "https://github.com/i-am-logger/pr4xis"
 
 [dependencies]
-pr4xis = { version = "0.16.0", path = "../pr4xis" }
-pr4xis-domains = { version = "0.21.0", path = "../domains" }
+pr4xis = { version = "0.22.0", path = "../pr4xis" }
+pr4xis-domains = { version = "0.22.0", path = "../domains" }
 
 [lints]
 workspace = true

--- a/crates/pr4xis-derive/Cargo.toml
+++ b/crates/pr4xis-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pr4xis-derive"
-version = "0.1.0"
+version = "0.22.0"
 edition = "2024"
 authors = ["i-am-logger"]
 description = "Derive macros for pr4xis ontology traits"

--- a/crates/pr4xis/Cargo.toml
+++ b/crates/pr4xis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pr4xis"
-version = "0.16.0"
+version = "0.22.0"
 edition = "2024"
 authors = ["i-am-logger"]
 description = "Prove your domain is correct — ontology-driven rule enforcement with category theory, logical composition, and runtime state machines"
@@ -18,7 +18,7 @@ codegen = ["std", "dep:quick-xml", "dep:serde", "dep:serde_json"]
 hashbrown = { version = "0.17", default-features = false, features = ["default-hasher"] }
 linkme = "0.3"
 paste = "1"
-pr4xis-derive = { version = "0.1.0", path = "../pr4xis-derive" }
+pr4xis-derive = { version = "0.22.0", path = "../pr4xis-derive" }
 quick-xml = { version = "0.40", features = ["serialize"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pr4xis-web"
-version = "0.1.0"
+version = "0.22.0"
 edition = "2024"
 authors = ["i-am-logger"]
 description = "Dev server for pr4xis — serves presentation + WASM chatbot with live reload"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -52,23 +52,41 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 """
 
-# Per-package overrides — pr4xis-examples is not a library to publish;
-# it carries runnable demos that consumers don't pull in transitively.
-[[package]]
-name = "pr4xis-examples"
-publish = false
-
-# Couple `pr4xis` and `pr4xis-derive` so they always release at the
-# same version — the derive crate is meaningless apart from its host
-# (a `pr4xis-derive 0.X` only ever pairs with a single `pr4xis 0.X`),
-# so the standard `*-derive` convention from the wider Rust ecosystem
-# (serde+serde_derive, thiserror+thiserror-impl, rkyv+rkyv_derive) is
-# to version-lock the pair. Application crates (`pr4xis-domains`,
-# `pr4xis-cli`, `pr4xis-chat`, `pr4xis-web`) version independently.
-[[package]]
-name = "pr4xis"
-version_group = "pr4xis-core"
-
+# Full workspace version sync — every workspace member shares a single
+# version number. Modelled on the Bevy / Tauri / SeaORM convention:
+# users install one praxis version and every supporting crate moves in
+# lockstep. Removes the per-crate version drift that previously let
+# pr4xis-derive sit at 0.1.0 while pr4xis evolved through 0.16.0 (the
+# bug that broke catch-up publish; see chore/sync-all-versions-0.22.0).
+#
+# `pr4xis-examples` is in the version group so its number stays aligned
+# with the rest, but `publish = false` keeps it off crates.io — examples
+# aren't a library consumers pull in transitively.
 [[package]]
 name = "pr4xis-derive"
-version_group = "pr4xis-core"
+version_group = "praxis"
+
+[[package]]
+name = "pr4xis"
+version_group = "praxis"
+
+[[package]]
+name = "pr4xis-domains"
+version_group = "praxis"
+
+[[package]]
+name = "pr4xis-cli"
+version_group = "praxis"
+
+[[package]]
+name = "pr4xis-chat"
+version_group = "praxis"
+
+[[package]]
+name = "pr4xis-web"
+version_group = "praxis"
+
+[[package]]
+name = "pr4xis-examples"
+version_group = "praxis"
+publish = false


### PR DESCRIPTION
## Why

When we tried the manual crates.io catch-up publish after #188, it failed on the very first crate: pr4xis's verify-build couldn't find the macros it expected from pr4xis-derive. The pr4xis-derive on crates.io has been frozen at version 0.1.0 since forever — the local 0.1.0 has all the current macros (`Concept`, `ontology!`, the per-domain macros), but they were never actually published. The publish step quietly failed for months and we only noticed when trying to publish the rest of the workspace.

Bumping pr4xis-derive past 0.1.0 unblocks the catch-up. Doing the full Pattern B sync (all crates at one shared version) at the same time prevents this exact failure mode from ever happening again — every crate moves in lockstep, no individual crate's version can quietly fall behind.

## What changes

Every workspace crate is now at version `0.22.0`:

| Crate | Before | After |
|---|---|---|
| pr4xis | 0.16.0 | 0.22.0 |
| pr4xis-derive | 0.1.0 | 0.22.0 |
| pr4xis-domains | 0.21.0 | 0.22.0 |
| pr4xis-cli | 0.7.0 | 0.22.0 |
| pr4xis-chat | 0.8.1 | 0.22.0 |
| pr4xis-web | 0.1.0 | 0.22.0 |
| pr4xis-examples | 0.5.1 | 0.22.0 |

`release-plz.toml` switches from a 2-crate version group (just pr4xis + pr4xis-derive) to a single 7-crate group covering the whole workspace. Modelled on Bevy / Tauri / SeaORM: one praxis version number, every supporting crate moves with it.

`0.22.0` is one step past the highest existing tag (`pr4xis-domains-v0.21.0`), so no conflict with the orphan release-please-era tags still sitting in git history.

## What happens after this merges

1. The manual `cargo workspaces publish --from-git` (or `cargo publish` per crate in dep order) now succeeds — every crate publishes at the same 0.22.0, pr4xis-derive included, so pr4xis's verify-build finds fresh macros.
2. crates.io catches up to where master is. The orphan tags become valid (they no longer claim "this version was published" while crates.io says otherwise).
3. release-plz takes over: future commits on master flow through release-plz-pr → Release PR → merge → release-plz-release publishes everything at the next shared version (0.23.0 or higher depending on commit types).