### PR TITLE
ci: sync pr4xis-runtime version + skip release commits in changelog

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -52,6 +52,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 """
 
+# Skip release-plz's own release commits when generating changelogs.
+# A `chore: release` merge commit is not a real change — but on the next
+# run release-plz would otherwise attribute it to a package (notably one
+# force-bumped by the version_group with no commits of its own), back-fill
+# a changelog entry, and open a redundant "chore: release" PR (e.g. #196).
+# Left unfiltered this self-feeds: merging that PR creates another release
+# commit, which spawns the next empty PR. Filtering breaks the loop.
+commit_parsers = [
+    { message = "^chore: release", skip = true },
+    { message = "^chore\\(release\\)", skip = true },
+]
+
 # Full workspace version sync — every workspace member shares a single
 # version number. Modelled on the Bevy / Tauri / SeaORM convention:
 # users install one praxis version and every supporting crate moves in
@@ -68,6 +80,14 @@ version_group = "praxis"
 
 [[package]]
 name = "pr4xis"
+version_group = "praxis"
+
+# `pr4xis-runtime` (the `.prx` runtime crate) is a workspace member and
+# must move in lockstep with the rest of the group. Without this block it
+# is invisible to the version_group sync and drifts behind (it sat at
+# 0.22.0 while the group reached 0.23.0).
+[[package]]
+name = "pr4xis-runtime"
 version_group = "praxis"
 
 # `pr4xis-domains` is held back from crates.io until the registered-source


### PR DESCRIPTION
## Why

Two release-plz issues, one root cause each:

1. **`pr4xis-runtime` drifted to 0.22.0** while the rest of the workspace reached 0.23.0. It's a workspace member but was never listed in `release-plz.toml`, so it was excluded from the `praxis` version_group lockstep sync. Added its `[[package]]` block.

2. **Redundant `chore: release` PR (#196)** that bumped nothing. The version_group force-bumped `pr4xis-web`'s Cargo.toml in #195 without a changelog entry; on the next run release-plz re-attributed the `chore: release (#195)` merge commit to web and opened a changelog-only PR. Left unfiltered this self-feeds. Added a `[changelog] commit_parsers` rule to skip `chore: release` / `chore(release)` commits.

## Notes
- Workspace-root config change only — does not touch any crate's API, so it won't bump versions itself.
- TOML validated with `taplo check`.
- #196 already closed manually.