### PR TITLE
ci: sequence release-plz-pr after release to stop the self-feeding release loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,7 +499,18 @@ jobs:
   release-plz-pr:
     name: Release-PR
     runs-on: ubuntu-latest
-    needs: [lint-docs, test, wasm, format, no-ignored-doctests]
+    # MUST run AFTER release-plz-release. That job publishes + creates the new
+    # version tags; this one computes the NEXT bump from the latest tag. Run in
+    # parallel (the old setup), the fast release-pr job finished before the slow
+    # publish job created the new tag, so it diffed from the PREVIOUS tag,
+    # re-listed the just-released commits, and opened a redundant `chore: release`
+    # PR every cycle — a self-feeding loop (v0.25.2 → v0.25.3 → …). Sequencing
+    # breaks it: by the time release-pr runs, the just-released version is tagged,
+    # so there are no unreleased commits left to propose. The `if` also requires
+    # Release to have SUCCEEDED — a failed publish leaves no new tag, which would
+    # re-trigger the same loop, so skip release-pr in that case. (On an ordinary
+    # feature merge Release succeeds as a no-op, so this never blocks the first PR.)
+    needs: [lint-docs, test, wasm, format, no-ignored-doctests, release-plz-release]
     if: |
       always() &&
       github.event_name == 'push' &&
@@ -508,7 +519,8 @@ jobs:
       needs.test.result == 'success' &&
       needs.wasm.result == 'success' &&
       needs.format.result == 'success' &&
-      needs.no-ignored-doctests.result == 'success'
+      needs.no-ignored-doctests.result == 'success' &&
+      needs.release-plz-release.result == 'success'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Why

Every `chore: release` PR you merge spawns another one a patch higher — v0.25.2 opened v0.25.3, and it keeps going. The cause is a race in CI: the **Release** job (which publishes and creates the new version tag) and the **Release-PR** job (which computes the next bump) run in parallel with no ordering between them. Release-PR is fast and the publish is slow, so Release-PR always finished first — computing the next version against the *previous* tag, re-listing the commits that were just released, and proposing them again as a new release. Because the fast job always wins the race, it happened every single time, not occasionally.

## What changes

Release-PR now waits for Release (`needs: release-plz-release`). By the time it runs, the just-released version is published and tagged, so it finds no unreleased commits and opens nothing. The first release PR after a real feature merge still opens as normal — only the redundant follow-on is gone.
