### PR TITLE
feat(input): WmAction ontology + Hyprland realization functor

### DIFF
--- a/crates/domains/src/applied/hmi/input/README.md
+++ b/crates/domains/src/applied/hmi/input/README.md
@@ -22,6 +22,30 @@ Key references:
 | Modifiers | `Shift`, `Ctrl`, `Alt`, `Meta` |
 | Mouse buttons | `Left`, `Right`, `Middle`, `Scroll{Up,Down}` |
 
+## Window actions — the intent / parameters / mechanism split
+
+A keybinding's action is **not** a raw dispatcher string. `wm_action.rs` factors it into three layers so the user's *intent* is never conflated with the compositor *mechanism* that realizes it:
+
+| Layer | Type | Examples |
+|---|---|---|
+| **Intent** | `WmAction` | `Focus(Direction)`, `Fullscreen`, `Maximize`, `Minimize`, `Workspace(WorkspaceTarget)`, `Close`, `Exec(String)` |
+| **Parameters** | `Direction`, `WorkspaceTarget`, `Follow`, `Cycle` | `Left`/`Right`/`Up`/`Down`; `Index(u8)`/`Relative(i32)`/`Named`/`Special`; `Follow`/`Silent`; `Forward`/`Backward` |
+| **Mechanism** | `Dispatch` (+ `Dispatch::render` — the one wire boundary) | `movefocus, l`; `fullscreen, 1`; `movetoworkspacesilent, special:hidden` |
+
+`WmAction` is **open-world** (Reiter 1978): `Exec` carries an arbitrary external command, so the vocabulary is not finitely enumerable — it is a `Concept` but **not** `FinitelyGenerated`. `Fullscreen`, `Maximize`, and `Minimize` are **distinct** intents (EWMH keeps them as separate actions); on Hyprland they realize to `fullscreen`, `fullscreen, 1`, and a special-workspace emulation respectively (Hyprland has no native minimize). Hide is a separate generic move to a named special workspace.
+
+```mermaid
+flowchart LR
+  subgraph ActionAlgebra["ActionAlgebra (free monoid on WmAction)"]
+    A["ActionWord<br/>[Focus(Left)] · [ToggleFloat, Pin]"]
+  end
+  subgraph DispatchAlgebra["DispatchAlgebra (free monoid on Dispatch)"]
+    D["DispatchWord<br/>[movefocus l] · [togglefloating ; pin]"]
+  end
+  A -- "HyprlandRealization (strict, total functor)" --> D
+  D -- "Dispatch::render / DispatchWord::command" --> S["Hyprland command string"]
+```
+
 ## Axioms
 
 | Axiom | Description | Source |
@@ -31,17 +55,24 @@ Key references:
 | TransitionsReferExistingModes | Every `Transition { from, to }` names modes that exist in the graph | well-formedness |
 | EscapeReturnsToParent | If a mode has a parent, an Escape keybinding returns to the parent | Harel 1987 / Raskin 2000 |
 | NoOrphanModes | Every non-root mode is reachable from the root via some transition | graph connectivity |
+| FunctorIdentityLaw / FunctorCompositionLaw | `HyprlandRealization` preserves identity and composition (it is a strict, total functor) | Mac Lane 1971 II.1 |
+| LoweringTotal | Every abstract action realizes to a non-empty dispatcher sequence | Goguen-Thatcher-Wagner 1978; GOMS 1983 |
+| WindowStateActionsDistinct | `Fullscreen`, `Maximize`, `Minimize` realize to pairwise-distinct dispatchers | EWMH v1.5 / Myers 1988 |
+| CompositeSequencePreserved | A composite action (float+pin) realizes to a two-dispatcher sequence, not an opaque command | Plotkin & Power 2003 |
 
-See `modes.rs` and `keybindings.rs` for the `impl Axiom for …` blocks.
+See `modes.rs`, `keybindings.rs`, and `wm_action.rs` for the `impl Axiom for …` blocks.
 
 ## Functors
 
-No cross-domain functors yet — see [Compose via functor](../../../../../../docs/use/compose-via-functor.md) to add one. The input ontology is a substrate for every surface that needs modal input — the future `ChatSurface` will consume a `ModeGraph` for its chat-vs-command-vs-search modes, and the future `BrowserSurface` will expose a `KeybindingTable` for the site's navigation.
+`HyprlandRealization : ActionAlgebra → DispatchAlgebra` (`wm_action.rs`) — the realization functor that lowers an abstract `WmAction` word to a concrete Hyprland dispatcher word. It is *forced* by the per-action lowering rule (Payne & Green 1986's rule-schema) and machine-proven to be a strict, total monoid homomorphism: "the runtime is a functor of the ontology." The single dispatcher string is emitted only at `Dispatch::render`.
+
+The input ontology is also a substrate for every surface that needs modal input — the future `ChatSurface` will consume a `ModeGraph` for its chat-vs-command-vs-search modes, and the future `BrowserSurface` will expose a `KeybindingTable` for the site's navigation.
 
 ## Files
 
 - `modes.rs` -- `ModeId`, `ModeProperties`, `Transition`, `ModeGraph`, mode-graph axioms, tests
-- `keybindings.rs` -- `Key`, `NamedKey`, `Modifier`, `MouseButton`, keybinding tables, tests
+- `keybindings.rs` -- `Key`, `NamedKey`, `Modifier`, `MouseButton`, keybinding tables + presets (typed `WmAction`), tests
+- `wm_action.rs` -- `WmAction` intents, typed parameters, the `Dispatch` alphabet, the `HyprlandRealization` functor, domain axioms, tests
 - `README.md` -- this file
 - `citings.md` -- per-ontology bibliography
 - `mod.rs` -- module declarations

--- a/crates/domains/src/applied/hmi/input/citings.md
+++ b/crates/domains/src/applied/hmi/input/citings.md
@@ -11,6 +11,21 @@ Every published source this ontology stands on. Entries below are drawn from the
 - ECMA-48 5th Ed 1991 — terminal input conventions
 - VT520/xterm escape sequences — the de facto terminal input grammar
 
+## Window-action ontology sources (`wm_action.rs`)
+
+The spine grounding the abstract action vocabulary, its typed parameters, and the realization functor — established by a literature sweep, not a single product's config schema.
+
+- Myers, B. A. 1988: *A Taxonomy of Window Manager User Interfaces* (IEEE Computer Graphics and Applications 8(5):65–84, doi:10.1109/38.7762) — the WM intent verb set; the paper's own split of operation **functionality** (which operations exist) from operation **user interface** (how invoked) = intent-vs-mechanism in WM literature
+- Card, Moran & Newell 1983: *The Psychology of Human-Computer Interaction* (Erlbaum) — GOMS: Goal / Operator / **Method** / Selection-rule; a goal is independent of the method that realizes it
+- Goguen, Thatcher & Wagner 1978: *An Initial Algebra Approach to the Specification, Correctness, and Implementation of Abstract Data Types* (Current Trends in Programming Methodology IV, Prentice-Hall, pp. 80–149) — the initial algebra's unique homomorphism into any other algebra of the signature = the realization projection
+- Payne & Green 1986: *Task-Action Grammars* (Human-Computer Interaction 2(2):93–133, doi:10.1207/s15327051hci0202_1) — features as strongly-typed variables over small closed value-sets; one rule-schema per intent family
+- EWMH v1.5 2013 (freedesktop.org) — `_NET_WM_ACTION_*`/`_NET_WM_STATE_*` named atoms, `_NET_WM_MOVERESIZE` direction enum, add/remove/toggle, the desktop CARDINAL; the *maximize ≠ fullscreen* state distinction
+- Foley & van Dam 1982: *Fundamentals of Interactive Computer Graphics* (Addison-Wesley) — conceptual/semantic/syntactic/lexical stack: mechanism emission as lexical lowering
+- Mac Lane 1971: *Categories for the Working Mathematician* II.1 — functor laws (identity + composition preservation)
+- Reiter 1978: *On Closed World Data Bases* — the closed/open-world split: `WmAction` is open-world because `Exec` carries arbitrary external data
+- Plotkin & Power 2003: *Algebraic Operations and Generic Effects* — sequenced effects compose in the free monoid (the composite-action realization)
+- Hyprland dispatchers — <https://wiki.hyprland.org/Configuring/Dispatchers/> — the realization vocabulary the `Dispatch` enum names
+
 ## Cross-references
 
 - Workspace bibliography: [`docs/papers/references.md`](../../../../../../docs/papers/references.md)

--- a/crates/domains/src/applied/hmi/input/keybindings.rs
+++ b/crates/domains/src/applied/hmi/input/keybindings.rs
@@ -14,6 +14,11 @@ use hashbrown::{HashMap, HashSet};
 /// - Harel, "Statecharts" (1987): mode-scoped keybindings
 /// - XKB specification: modifier model (Shift, Ctrl, Alt, Super, Hyper)
 use super::modes::ModeId;
+use super::wm_action::{
+    ActionWord, Cycle, Direction, Follow, HyprlandRealization, SubmapTarget, WmAction,
+    WorkspaceTarget,
+};
+use pr4xis::category::Functor;
 use pr4xis::logic::proof::{SimpleCounterexample, SimpleProof, Verdict};
 use pr4xis::ontology::Axiom;
 
@@ -126,22 +131,36 @@ impl KeyCombo {
     }
 }
 
-/// An action that a keybinding triggers.
+/// An action that a keybinding triggers — its name, a human description, and the
+/// typed [`WmAction`] sequence it performs (the abstract intent, **not** a raw
+/// dispatcher string). The concrete compositor command is *derived* on demand by
+/// [`Action::command`] via the [`HyprlandRealization`] functor.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Action {
     pub name: String,
     pub description: String,
-    /// The action command (e.g., "killactive,", "exec, $TERMINAL")
-    pub command: String,
+    /// The typed action sequence this binding performs.
+    pub actions: ActionWord,
 }
 
 impl Action {
-    pub fn new(name: impl Into<String>, desc: impl Into<String>, cmd: impl Into<String>) -> Self {
+    pub fn new(
+        name: impl Into<String>,
+        desc: impl Into<String>,
+        actions: impl Into<ActionWord>,
+    ) -> Self {
         Self {
             name: name.into(),
             description: desc.into(),
-            command: cmd.into(),
+            actions: actions.into(),
         }
+    }
+
+    /// The concrete Hyprland command this binding emits — the realization of its
+    /// [`ActionWord`] under [`HyprlandRealization`], rendered at the single wire
+    /// boundary. A composite (multi-action) binding batches into one `exec`.
+    pub fn command(&self) -> String {
+        HyprlandRealization::map_morphism(&self.actions).command()
     }
 }
 
@@ -269,31 +288,47 @@ pub fn vim_preset() -> BindingSet {
     bs.add(
         KeyCombo::new(Key::Letter('h')),
         normal.clone(),
-        Action::new("move_left", "Move cursor left", "movefocus, l"),
+        Action::new(
+            "move_left",
+            "Move cursor left",
+            WmAction::Focus(Direction::Left),
+        ),
         false,
     );
     bs.add(
         KeyCombo::new(Key::Letter('j')),
         normal.clone(),
-        Action::new("move_down", "Move cursor down", "movefocus, d"),
+        Action::new(
+            "move_down",
+            "Move cursor down",
+            WmAction::Focus(Direction::Down),
+        ),
         false,
     );
     bs.add(
         KeyCombo::new(Key::Letter('k')),
         normal.clone(),
-        Action::new("move_up", "Move cursor up", "movefocus, u"),
+        Action::new("move_up", "Move cursor up", WmAction::Focus(Direction::Up)),
         false,
     );
     bs.add(
         KeyCombo::new(Key::Letter('l')),
         normal.clone(),
-        Action::new("move_right", "Move cursor right", "movefocus, r"),
+        Action::new(
+            "move_right",
+            "Move cursor right",
+            WmAction::Focus(Direction::Right),
+        ),
         false,
     );
     bs.add(
         KeyCombo::new(Key::Letter('i')),
         normal.clone(),
-        Action::new("enter_insert", "Enter insert mode", "submap, insert"),
+        Action::new(
+            "enter_insert",
+            "Enter insert mode",
+            WmAction::Submap(SubmapTarget::Enter(ModeId::new("insert"))),
+        ),
         false,
     );
 
@@ -301,7 +336,11 @@ pub fn vim_preset() -> BindingSet {
     bs.add(
         KeyCombo::new(Key::Named(NamedKey::Escape)),
         insert,
-        Action::new("exit_insert", "Return to normal mode", "submap, reset"),
+        Action::new(
+            "exit_insert",
+            "Return to normal mode",
+            WmAction::Submap(SubmapTarget::Reset),
+        ),
         false,
     );
 
@@ -316,24 +355,44 @@ pub fn cua_preset() -> BindingSet {
     let app = ModeId::new("app");
 
     let binds = [
-        ('c', "copy", "Copy", "exec, wl-copy"),
-        ('v', "paste", "Paste", "exec, wl-paste"),
-        ('x', "cut", "Cut", "exec, wl-copy"),
-        ('z', "undo", "Undo", "exec, undo"),
-        ('s', "save", "Save", "exec, save"),
-        ('a', "select_all", "Select all", "exec, select-all"),
-        ('f', "find", "Find", "exec, find"),
-        ('n', "new_window", "New window", "exec, new-window"),
-        ('o', "open", "Open file", "exec, open"),
-        ('p', "print", "Print", "exec, print"),
-        ('w', "close_tab", "Close tab", "killactive,"),
-        ('t', "new_tab", "New tab", "exec, new-tab"),
+        ('c', "copy", "Copy", WmAction::Exec("wl-copy".to_string())),
+        (
+            'v',
+            "paste",
+            "Paste",
+            WmAction::Exec("wl-paste".to_string()),
+        ),
+        ('x', "cut", "Cut", WmAction::Exec("wl-copy".to_string())),
+        ('z', "undo", "Undo", WmAction::Exec("undo".to_string())),
+        ('s', "save", "Save", WmAction::Exec("save".to_string())),
+        (
+            'a',
+            "select_all",
+            "Select all",
+            WmAction::Exec("select-all".to_string()),
+        ),
+        ('f', "find", "Find", WmAction::Exec("find".to_string())),
+        (
+            'n',
+            "new_window",
+            "New window",
+            WmAction::Exec("new-window".to_string()),
+        ),
+        ('o', "open", "Open file", WmAction::Exec("open".to_string())),
+        ('p', "print", "Print", WmAction::Exec("print".to_string())),
+        ('w', "close_tab", "Close tab", WmAction::Close),
+        (
+            't',
+            "new_tab",
+            "New tab",
+            WmAction::Exec("new-tab".to_string()),
+        ),
     ];
-    for (c, name, desc, cmd) in binds {
+    for (c, name, desc, action) in binds {
         bs.add(
             KeyCombo::new(Key::Letter(c)).with_mod(Modifier::Ctrl),
             app.clone(),
-            Action::new(name, desc, cmd),
+            Action::new(name, desc, action),
             false,
         );
     }
@@ -342,14 +401,18 @@ pub fn cua_preset() -> BindingSet {
     bs.add(
         KeyCombo::new(Key::Function(4)).with_mod(Modifier::Alt),
         app.clone(),
-        Action::new("quit", "Quit application", "killactive,"),
+        Action::new("quit", "Quit application", WmAction::Close),
         false,
     );
     // Alt+Tab = switch window
     bs.add(
         KeyCombo::new(Key::Named(NamedKey::Tab)).with_mod(Modifier::Alt),
         app,
-        Action::new("switch_window", "Switch window", "cyclenext,"),
+        Action::new(
+            "switch_window",
+            "Switch window",
+            WmAction::CycleWindow(Cycle::Forward),
+        ),
         false,
     );
 
@@ -367,25 +430,37 @@ pub fn emacs_preset() -> BindingSet {
     bs.add(
         KeyCombo::new(Key::Letter('a')).with_mod(Modifier::Ctrl),
         app.clone(),
-        Action::new("line_start", "Beginning of line", "exec, line-start"),
+        Action::new(
+            "line_start",
+            "Beginning of line",
+            WmAction::Exec("line-start".to_string()),
+        ),
         false,
     );
     bs.add(
         KeyCombo::new(Key::Letter('e')).with_mod(Modifier::Ctrl),
         app.clone(),
-        Action::new("line_end", "End of line", "exec, line-end"),
+        Action::new(
+            "line_end",
+            "End of line",
+            WmAction::Exec("line-end".to_string()),
+        ),
         false,
     );
     bs.add(
         KeyCombo::new(Key::Letter('k')).with_mod(Modifier::Ctrl),
         app.clone(),
-        Action::new("kill_line", "Kill to end of line", "exec, kill-line"),
+        Action::new(
+            "kill_line",
+            "Kill to end of line",
+            WmAction::Exec("kill-line".to_string()),
+        ),
         false,
     );
     bs.add(
         KeyCombo::new(Key::Letter('y')).with_mod(Modifier::Ctrl),
         app.clone(),
-        Action::new("yank", "Yank (paste)", "exec, yank"),
+        Action::new("yank", "Yank (paste)", WmAction::Exec("yank".to_string())),
         false,
     );
 
@@ -393,25 +468,33 @@ pub fn emacs_preset() -> BindingSet {
     bs.add(
         KeyCombo::new(Key::Letter('f')).with_mod(Modifier::Ctrl),
         app.clone(),
-        Action::new("forward_char", "Forward one character", "movefocus, r"),
+        Action::new(
+            "forward_char",
+            "Forward one character",
+            WmAction::Focus(Direction::Right),
+        ),
         false,
     );
     bs.add(
         KeyCombo::new(Key::Letter('b')).with_mod(Modifier::Ctrl),
         app.clone(),
-        Action::new("backward_char", "Backward one character", "movefocus, l"),
+        Action::new(
+            "backward_char",
+            "Backward one character",
+            WmAction::Focus(Direction::Left),
+        ),
         false,
     );
     bs.add(
         KeyCombo::new(Key::Letter('n')).with_mod(Modifier::Ctrl),
         app.clone(),
-        Action::new("next_line", "Next line", "movefocus, d"),
+        Action::new("next_line", "Next line", WmAction::Focus(Direction::Down)),
         false,
     );
     bs.add(
         KeyCombo::new(Key::Letter('p')).with_mod(Modifier::Ctrl),
         app.clone(),
-        Action::new("prev_line", "Previous line", "movefocus, u"),
+        Action::new("prev_line", "Previous line", WmAction::Focus(Direction::Up)),
         false,
     );
 
@@ -419,13 +502,21 @@ pub fn emacs_preset() -> BindingSet {
     bs.add(
         KeyCombo::new(Key::Letter('f')).with_mod(Modifier::Alt),
         app.clone(),
-        Action::new("forward_word", "Forward one word", "exec, forward-word"),
+        Action::new(
+            "forward_word",
+            "Forward one word",
+            WmAction::Exec("forward-word".to_string()),
+        ),
         false,
     );
     bs.add(
         KeyCombo::new(Key::Letter('b')).with_mod(Modifier::Alt),
         app.clone(),
-        Action::new("backward_word", "Backward one word", "exec, backward-word"),
+        Action::new(
+            "backward_word",
+            "Backward one word",
+            WmAction::Exec("backward-word".to_string()),
+        ),
         false,
     );
 
@@ -433,7 +524,11 @@ pub fn emacs_preset() -> BindingSet {
     bs.add(
         KeyCombo::new(Key::Letter('g')).with_mod(Modifier::Ctrl),
         app.clone(),
-        Action::new("cancel", "Cancel / keyboard quit", "submap, reset"),
+        Action::new(
+            "cancel",
+            "Cancel / keyboard quit",
+            WmAction::Submap(SubmapTarget::Reset),
+        ),
         false,
     );
 
@@ -444,7 +539,7 @@ pub fn emacs_preset() -> BindingSet {
         Action::new(
             "search_forward",
             "Incremental search forward",
-            "exec, search-forward",
+            WmAction::Exec("search-forward".to_string()),
         ),
         false,
     );
@@ -454,7 +549,7 @@ pub fn emacs_preset() -> BindingSet {
         Action::new(
             "search_backward",
             "Incremental search backward",
-            "exec, search-backward",
+            WmAction::Exec("search-backward".to_string()),
         ),
         false,
     );
@@ -474,13 +569,21 @@ pub fn i3_preset() -> BindingSet {
     bs.add(
         KeyCombo::new(Key::Named(NamedKey::Enter)).with_mod(Modifier::Super),
         app.clone(),
-        Action::new("terminal", "Launch terminal", "exec, $TERMINAL"),
+        Action::new(
+            "terminal",
+            "Launch terminal",
+            WmAction::Exec("$TERMINAL".to_string()),
+        ),
         false,
     );
     bs.add(
         KeyCombo::new(Key::Letter('d')).with_mod(Modifier::Super),
         app.clone(),
-        Action::new("launcher", "Application launcher", "exec, walker"),
+        Action::new(
+            "launcher",
+            "Application launcher",
+            WmAction::Exec("walker".to_string()),
+        ),
         false,
     );
     bs.add(
@@ -488,22 +591,22 @@ pub fn i3_preset() -> BindingSet {
             .with_mod(Modifier::Super)
             .with_mod(Modifier::Shift),
         app.clone(),
-        Action::new("kill", "Kill focused window", "killactive,"),
+        Action::new("kill", "Kill focused window", WmAction::Close),
         false,
     );
     bs.add(
         KeyCombo::new(Key::Letter('f')).with_mod(Modifier::Super),
         app.clone(),
-        Action::new("fullscreen", "Toggle fullscreen", "fullscreen"),
+        Action::new("fullscreen", "Toggle fullscreen", WmAction::Fullscreen),
         false,
     );
 
     // Focus: Super+hjkl
-    for (c, dir, desc) in [
-        ('h', "l", "left"),
-        ('j', "d", "down"),
-        ('k', "u", "up"),
-        ('l', "r", "right"),
+    for (c, direction, desc) in [
+        ('h', Direction::Left, "left"),
+        ('j', Direction::Down, "down"),
+        ('k', Direction::Up, "up"),
+        ('l', Direction::Right, "right"),
     ] {
         bs.add(
             KeyCombo::new(Key::Letter(c)).with_mod(Modifier::Super),
@@ -511,18 +614,18 @@ pub fn i3_preset() -> BindingSet {
             Action::new(
                 format!("focus_{desc}"),
                 format!("Focus {desc}"),
-                format!("movefocus, {dir}"),
+                WmAction::Focus(direction),
             ),
             false,
         );
     }
 
     // Move: Super+Shift+hjkl
-    for (c, dir, desc) in [
-        ('h', "l", "left"),
-        ('j', "d", "down"),
-        ('k', "u", "up"),
-        ('l', "r", "right"),
+    for (c, direction, desc) in [
+        ('h', Direction::Left, "left"),
+        ('j', Direction::Down, "down"),
+        ('k', Direction::Up, "up"),
+        ('l', Direction::Right, "right"),
     ] {
         bs.add(
             KeyCombo::new(Key::Letter(c))
@@ -532,7 +635,7 @@ pub fn i3_preset() -> BindingSet {
             Action::new(
                 format!("move_{desc}"),
                 format!("Move window {desc}"),
-                format!("movewindow, {dir}"),
+                WmAction::MoveWindow(direction),
             ),
             false,
         );
@@ -546,7 +649,7 @@ pub fn i3_preset() -> BindingSet {
             Action::new(
                 format!("workspace_{i}"),
                 format!("Workspace {i}"),
-                format!("workspace, {i}"),
+                WmAction::Workspace(WorkspaceTarget::Index(i)),
             ),
             false,
         );
@@ -562,7 +665,7 @@ pub fn i3_preset() -> BindingSet {
             Action::new(
                 format!("move_to_{i}"),
                 format!("Move to workspace {i}"),
-                format!("movetoworkspace, {i}"),
+                WmAction::MoveToWorkspace(WorkspaceTarget::Index(i), Follow::Follow),
             ),
             false,
         );
@@ -572,7 +675,7 @@ pub fn i3_preset() -> BindingSet {
     bs.add(
         KeyCombo::new(Key::Letter('v')).with_mod(Modifier::Super),
         app.clone(),
-        Action::new("split_v", "Split vertical", "layoutmsg, togglesplit"),
+        Action::new("split_v", "Split vertical", WmAction::ToggleSplit),
         false,
     );
     bs.add(
@@ -580,7 +683,7 @@ pub fn i3_preset() -> BindingSet {
             .with_mod(Modifier::Super)
             .with_mod(Modifier::Shift),
         app.clone(),
-        Action::new("float", "Toggle floating", "togglefloating,"),
+        Action::new("float", "Toggle floating", WmAction::ToggleFloat),
         false,
     );
 
@@ -588,28 +691,36 @@ pub fn i3_preset() -> BindingSet {
     bs.add(
         KeyCombo::new(Key::Letter('r')).with_mod(Modifier::Super),
         app,
-        Action::new("enter_resize", "Enter resize mode", "submap, resize"),
+        Action::new(
+            "enter_resize",
+            "Enter resize mode",
+            WmAction::Submap(SubmapTarget::Enter(ModeId::new("resize"))),
+        ),
         false,
     );
 
     // Resize mode bindings
-    for (c, action, desc) in [
-        ('h', "resizeactive, -30 0", "Shrink width"),
-        ('j', "resizeactive, 0 30", "Grow height"),
-        ('k', "resizeactive, 0 -30", "Shrink height"),
-        ('l', "resizeactive, 30 0", "Grow width"),
+    for (c, direction, desc) in [
+        ('h', Direction::Left, "Shrink width"),
+        ('j', Direction::Down, "Grow height"),
+        ('k', Direction::Up, "Shrink height"),
+        ('l', Direction::Right, "Grow width"),
     ] {
         bs.add(
             KeyCombo::new(Key::Letter(c)),
             resize.clone(),
-            Action::new(format!("resize_{c}"), desc, action),
+            Action::new(format!("resize_{c}"), desc, WmAction::Resize(direction, 30)),
             true,
         );
     }
     bs.add(
         KeyCombo::new(Key::Named(NamedKey::Escape)),
         resize,
-        Action::new("exit_resize", "Exit resize mode", "submap, reset"),
+        Action::new(
+            "exit_resize",
+            "Exit resize mode",
+            WmAction::Submap(SubmapTarget::Reset),
+        ),
         false,
     );
 
@@ -627,13 +738,21 @@ pub fn tmux_preset() -> BindingSet {
     bs.add(
         KeyCombo::new(Key::Letter('c')),
         prefix.clone(),
-        Action::new("new_window", "Create new window", "exec, tmux new-window"),
+        Action::new(
+            "new_window",
+            "Create new window",
+            WmAction::Exec("tmux new-window".to_string()),
+        ),
         false,
     );
     bs.add(
         KeyCombo::new(Key::Letter('n')),
         prefix.clone(),
-        Action::new("next_window", "Next window", "exec, tmux next-window"),
+        Action::new(
+            "next_window",
+            "Next window",
+            WmAction::Exec("tmux next-window".to_string()),
+        ),
         false,
     );
     bs.add(
@@ -642,14 +761,18 @@ pub fn tmux_preset() -> BindingSet {
         Action::new(
             "prev_window",
             "Previous window",
-            "exec, tmux previous-window",
+            WmAction::Exec("tmux previous-window".to_string()),
         ),
         false,
     );
     bs.add(
         KeyCombo::new(Key::Letter('l')),
         prefix.clone(),
-        Action::new("last_window", "Last window", "exec, tmux last-window"),
+        Action::new(
+            "last_window",
+            "Last window",
+            WmAction::Exec("tmux last-window".to_string()),
+        ),
         false,
     );
 
@@ -661,7 +784,7 @@ pub fn tmux_preset() -> BindingSet {
             Action::new(
                 format!("window_{i}"),
                 format!("Switch to window {i}"),
-                format!("exec, tmux select-window -t {i}"),
+                WmAction::Exec(format!("tmux select-window -t {i}")),
             ),
             false,
         );
@@ -674,7 +797,7 @@ pub fn tmux_preset() -> BindingSet {
         Action::new(
             "split_v",
             "Split pane vertical",
-            "exec, tmux split-window -h",
+            WmAction::Exec("tmux split-window -h".to_string()),
         ),
         false,
     );
@@ -684,7 +807,7 @@ pub fn tmux_preset() -> BindingSet {
         Action::new(
             "split_h",
             "Split pane horizontal",
-            "exec, tmux split-window -v",
+            WmAction::Exec("tmux split-window -v".to_string()),
         ),
         false,
     );
@@ -702,7 +825,7 @@ pub fn tmux_preset() -> BindingSet {
             Action::new(
                 format!("pane_{name}"),
                 format!("Focus pane {name}"),
-                format!("exec, tmux select-pane -{dir}"),
+                WmAction::Exec(format!("tmux select-pane -{dir}")),
             ),
             false,
         );
@@ -712,25 +835,41 @@ pub fn tmux_preset() -> BindingSet {
     bs.add(
         KeyCombo::new(Key::Letter('d')),
         prefix.clone(),
-        Action::new("detach", "Detach session", "exec, tmux detach"),
+        Action::new(
+            "detach",
+            "Detach session",
+            WmAction::Exec("tmux detach".to_string()),
+        ),
         false,
     );
     bs.add(
         KeyCombo::new(Key::Letter('z')),
         prefix.clone(),
-        Action::new("zoom", "Toggle pane zoom", "exec, tmux resize-pane -Z"),
+        Action::new(
+            "zoom",
+            "Toggle pane zoom",
+            WmAction::Exec("tmux resize-pane -Z".to_string()),
+        ),
         false,
     );
     bs.add(
         KeyCombo::new(Key::Letter('x')),
         prefix.clone(),
-        Action::new("kill_pane", "Kill pane", "exec, tmux kill-pane"),
+        Action::new(
+            "kill_pane",
+            "Kill pane",
+            WmAction::Exec("tmux kill-pane".to_string()),
+        ),
         false,
     );
     bs.add(
         KeyCombo::new(Key::Letter('?')),
         prefix,
-        Action::new("help", "List keybindings", "exec, tmux list-keys"),
+        Action::new(
+            "help",
+            "List keybindings",
+            WmAction::Exec("tmux list-keys".to_string()),
+        ),
         false,
     );
 
@@ -833,6 +972,611 @@ impl Axiom for MacosRemapComplete {
         "macOS remap covers essential shortcuts (C, V, X, Z, S, A)",
         "IBM (1987) Common User Access Specification; macOS Human Interface Guidelines"
     );
+}
+
+// ── Desktop / WM-navigation presets ───────────────────────────────────────
+// The window-management navigation flavour of each desktop paradigm as a flat
+// `BindingSet` (the consumer supplies the per-paradigm mode topology). Commands
+// are Hyprland dispatchers. Lifted from vogix's input catalog so praxis is the
+// single source of every paradigm's bindings.
+use Modifier::{Alt, Ctrl, Shift, Super};
+
+/// Build a [`KeyCombo`] from modifiers + a key.
+fn combo(mods: &[Modifier], key: Key) -> KeyCombo {
+    let mut c = KeyCombo::new(key);
+    for m in mods {
+        c = c.with_mod(*m);
+    }
+    c
+}
+
+/// The four cardinal directions as `(letter, arrow, hypr-suffix)`. The `vogix`
+/// layout binds BOTH `hjkl` and the arrows to the same action (h=left, l=right,
+/// j=up, k=down — a non-vim mapping), so every nav verb is generated for both.
+const DIRS: &[(char, NamedKey, &str, Direction)] = &[
+    ('h', NamedKey::Left, "l", Direction::Left),
+    ('l', NamedKey::Right, "r", Direction::Right),
+    ('j', NamedKey::Up, "u", Direction::Up),
+    ('k', NamedKey::Down, "d", Direction::Down),
+];
+
+/// `vogix` — the house default: a flat `Super`-combos WM-navigation layout in one
+/// `app` mode (focus/move/resize, workspaces 1–10, send-to-workspace). Both `hjkl`
+/// and the arrow keys drive focus/move/resize.
+pub fn vogix_preset() -> BindingSet {
+    let mut bs = BindingSet::new("vogix");
+    let app = ModeId::new("app");
+    let mut add =
+        |mods: &[Modifier], key: Key, name: &str, desc: &str, actions: ActionWord, repeat: bool| {
+            bs.add(
+                combo(mods, key),
+                app.clone(),
+                Action::new(name, desc, actions),
+                repeat,
+            );
+        };
+
+    // Focus (Super + dir -> movefocus); hjkl AND arrows.
+    for (letter, arrow, suf, direction) in DIRS {
+        add(
+            &[Super],
+            Key::Letter(*letter),
+            &format!("focus_{suf}"),
+            "Focus",
+            WmAction::Focus(*direction).into(),
+            false,
+        );
+        add(
+            &[Super],
+            Key::Named(arrow.clone()),
+            &format!("focus_{suf}_arrow"),
+            "Focus",
+            WmAction::Focus(*direction).into(),
+            false,
+        );
+    }
+    // Move window (Super + Shift + dir -> swapwindow).
+    for (letter, arrow, suf, direction) in DIRS {
+        add(
+            &[Super, Shift],
+            Key::Letter(*letter),
+            &format!("move_{suf}"),
+            "Move window",
+            WmAction::SwapWindow(*direction).into(),
+            false,
+        );
+        add(
+            &[Super, Shift],
+            Key::Named(arrow.clone()),
+            &format!("move_{suf}_arrow"),
+            "Move window",
+            WmAction::SwapWindow(*direction).into(),
+            false,
+        );
+    }
+    // Resize window (Ctrl + Shift + dir -> resizeactive; repeats). The pixel
+    // deltas are derived from the direction by the realization functor.
+    for (letter, arrow, suf, direction) in DIRS {
+        add(
+            &[Ctrl, Shift],
+            Key::Letter(*letter),
+            &format!("resize_{suf}"),
+            "Resize",
+            WmAction::Resize(*direction, 30).into(),
+            true,
+        );
+        add(
+            &[Ctrl, Shift],
+            Key::Named(arrow.clone()),
+            &format!("resize_{suf}_arrow"),
+            "Resize",
+            WmAction::Resize(*direction, 30).into(),
+            true,
+        );
+    }
+
+    // Window state.
+    add(
+        &[Super],
+        Key::Letter('q'),
+        "close",
+        "Close window",
+        WmAction::Close.into(),
+        false,
+    );
+    // Float + pin is a genuine TWO-action composite — not a shell hack. The
+    // realization functor batches [ToggleFloat, Pin] into one exec.
+    add(
+        &[Super],
+        Key::Letter('y'),
+        "float_pin",
+        "Float + pin",
+        vec![WmAction::ToggleFloat, WmAction::Pin].into(),
+        false,
+    );
+    add(
+        &[Super],
+        Key::Letter('f'),
+        "fullscreen",
+        "Fullscreen",
+        WmAction::Fullscreen.into(),
+        false,
+    );
+    add(
+        &[Super],
+        Key::Letter('p'),
+        "pseudo",
+        "Pseudotile",
+        WmAction::Pseudotile.into(),
+        false,
+    );
+    add(
+        &[Super],
+        Key::Letter('o'),
+        "toggle_split",
+        "Toggle split",
+        WmAction::ToggleSplit.into(),
+        false,
+    );
+    add(
+        &[Super],
+        Key::Letter('u'),
+        "toggle_group",
+        "Toggle group",
+        WmAction::ToggleGroup.into(),
+        false,
+    );
+    add(
+        &[Super],
+        Key::Named(NamedKey::Tab),
+        "group_cycle",
+        "Cycle window in group",
+        WmAction::CycleGroup(Cycle::Forward).into(),
+        false,
+    );
+
+    // Workspaces (Super + number; 0 = ws 10).
+    for n in 1u8..=10 {
+        let key = Key::Number(if n == 10 { 0 } else { n });
+        add(
+            &[Super],
+            key,
+            &format!("workspace_{n}"),
+            "Workspace",
+            WmAction::Workspace(WorkspaceTarget::Index(n)).into(),
+            false,
+        );
+    }
+    add(
+        &[Super],
+        Key::Letter('m'),
+        "workspace_music",
+        "Music workspace",
+        WmAction::Workspace(WorkspaceTarget::Named("Music".to_string())).into(),
+        false,
+    );
+
+    // Adjacent workspace (Super + Ctrl + arrows or j/l).
+    add(
+        &[Super, Ctrl],
+        Key::Named(NamedKey::Left),
+        "ws_prev",
+        "Previous workspace",
+        WmAction::Workspace(WorkspaceTarget::Relative(-1)).into(),
+        false,
+    );
+    add(
+        &[Super, Ctrl],
+        Key::Named(NamedKey::Right),
+        "ws_next",
+        "Next workspace",
+        WmAction::Workspace(WorkspaceTarget::Relative(1)).into(),
+        false,
+    );
+    add(
+        &[Super, Ctrl],
+        Key::Letter('j'),
+        "ws_prev_j",
+        "Previous workspace",
+        WmAction::Workspace(WorkspaceTarget::Relative(-1)).into(),
+        false,
+    );
+    add(
+        &[Super, Ctrl],
+        Key::Letter('l'),
+        "ws_next_l",
+        "Next workspace",
+        WmAction::Workspace(WorkspaceTarget::Relative(1)).into(),
+        false,
+    );
+
+    // Send window to workspace (Super + Ctrl + number).
+    for n in 1u8..=10 {
+        let key = Key::Number(if n == 10 { 0 } else { n });
+        add(
+            &[Super, Ctrl],
+            key,
+            &format!("move_to_ws_{n}"),
+            "Send window to workspace",
+            WmAction::MoveToWorkspace(WorkspaceTarget::Index(n), Follow::Follow).into(),
+            false,
+        );
+    }
+    // Send window to adjacent workspace (Super + Ctrl + Shift + arrows or j/l).
+    add(
+        &[Super, Ctrl, Shift],
+        Key::Named(NamedKey::Left),
+        "send_ws_prev",
+        "Send window \u{2190} workspace",
+        WmAction::MoveToWorkspace(WorkspaceTarget::Relative(-1), Follow::Follow).into(),
+        false,
+    );
+    add(
+        &[Super, Ctrl, Shift],
+        Key::Named(NamedKey::Right),
+        "send_ws_next",
+        "Send window \u{2192} workspace",
+        WmAction::MoveToWorkspace(WorkspaceTarget::Relative(1), Follow::Follow).into(),
+        false,
+    );
+    add(
+        &[Super, Ctrl, Shift],
+        Key::Letter('j'),
+        "send_ws_prev_j",
+        "Send window \u{2190} workspace",
+        WmAction::MoveToWorkspace(WorkspaceTarget::Relative(-1), Follow::Follow).into(),
+        false,
+    );
+    add(
+        &[Super, Ctrl, Shift],
+        Key::Letter('l'),
+        "send_ws_next_l",
+        "Send window \u{2192} workspace",
+        WmAction::MoveToWorkspace(WorkspaceTarget::Relative(1), Follow::Follow).into(),
+        false,
+    );
+
+    // Send window to workspace silently (Super + Shift + number).
+    for n in 1u8..=10 {
+        let key = Key::Number(if n == 10 { 0 } else { n });
+        add(
+            &[Super, Shift],
+            key,
+            &format!("move_silent_{n}"),
+            "Send window to workspace (silent)",
+            WmAction::MoveToWorkspace(WorkspaceTarget::Index(n), Follow::Silent).into(),
+            false,
+        );
+    }
+
+    bs
+}
+
+/// `windows` — Microsoft Windows 11 global window & virtual-desktop conventions,
+/// projected to Hyprland. Single passthrough `app` mode, no remap (Windows uses
+/// Ctrl natively). Snap/maximize are adapted to the nearest real dispatcher.
+///
+/// Source: Microsoft Support, "Keyboard shortcuts in Windows".
+pub fn windows_preset() -> BindingSet {
+    let mut bs = BindingSet::new("windows");
+    let app = ModeId::new("app");
+    let mut add = |mods: &[Modifier], key: Key, name: &str, desc: &str, action: WmAction| {
+        bs.add(
+            combo(mods, key),
+            app.clone(),
+            Action::new(name, desc, action),
+            false,
+        );
+    };
+
+    // Window switch (Alt+Tab) + close (Alt+F4) — faithful.
+    add(
+        &[Alt],
+        Key::Named(NamedKey::Tab),
+        "switch_window",
+        "Switch window",
+        WmAction::CycleWindow(Cycle::Forward),
+    );
+    add(
+        &[Alt, Shift],
+        Key::Named(NamedKey::Tab),
+        "switch_window_prev",
+        "Switch window (reverse)",
+        WmAction::CycleWindow(Cycle::Backward),
+    );
+    add(
+        &[Alt],
+        Key::Function(4),
+        "close",
+        "Close window",
+        WmAction::Close,
+    );
+
+    // Snap (Win+arrows) + maximize (Win+Up) — adapted. Win+Up maximizes (keeps
+    // the bar): fullscreen mode 1, NOT true fullscreen.
+    add(
+        &[Super],
+        Key::Named(NamedKey::Left),
+        "snap_left",
+        "Snap window left",
+        WmAction::MoveWindow(Direction::Left),
+    );
+    add(
+        &[Super],
+        Key::Named(NamedKey::Right),
+        "snap_right",
+        "Snap window right",
+        WmAction::MoveWindow(Direction::Right),
+    );
+    add(
+        &[Super],
+        Key::Named(NamedKey::Up),
+        "maximize",
+        "Maximize window",
+        WmAction::Maximize,
+    );
+
+    // Move window (Win+Shift+arrows) — adapted to a directional move.
+    add(
+        &[Super, Shift],
+        Key::Named(NamedKey::Left),
+        "move_left",
+        "Move window left",
+        WmAction::MoveWindow(Direction::Left),
+    );
+    add(
+        &[Super, Shift],
+        Key::Named(NamedKey::Right),
+        "move_right",
+        "Move window right",
+        WmAction::MoveWindow(Direction::Right),
+    );
+    add(
+        &[Super, Shift],
+        Key::Named(NamedKey::Up),
+        "move_up",
+        "Move window up",
+        WmAction::MoveWindow(Direction::Up),
+    );
+    add(
+        &[Super, Shift],
+        Key::Named(NamedKey::Down),
+        "move_down",
+        "Move window down",
+        WmAction::MoveWindow(Direction::Down),
+    );
+
+    // Virtual desktops: Ctrl+Win+arrows switch; Win+1..9 -> desktop N.
+    add(
+        &[Super, Ctrl],
+        Key::Named(NamedKey::Left),
+        "desktop_prev",
+        "Previous virtual desktop",
+        WmAction::Workspace(WorkspaceTarget::Relative(-1)),
+    );
+    add(
+        &[Super, Ctrl],
+        Key::Named(NamedKey::Right),
+        "desktop_next",
+        "Next virtual desktop",
+        WmAction::Workspace(WorkspaceTarget::Relative(1)),
+    );
+    for n in 1u8..=9 {
+        add(
+            &[Super],
+            Key::Number(n),
+            &format!("workspace_{n}"),
+            "Virtual desktop",
+            WmAction::Workspace(WorkspaceTarget::Index(n)),
+        );
+    }
+    bs
+}
+
+/// `macos` — Apple macOS Mission Control / Spaces / window conventions, projected
+/// to Hyprland. Pairs with the `macos` remap (Cmd-feel); the window verbs
+/// (Cmd+W/Q/H/M) are bound so they win over the remap.
+///
+/// Source: Apple Support, "Mac keyboard shortcuts" & "Use Mission Control".
+pub fn macos_preset() -> BindingSet {
+    let mut bs = BindingSet::new("macos");
+    let app = ModeId::new("app");
+    let mut add = |mods: &[Modifier], key: Key, name: &str, desc: &str, action: WmAction| {
+        bs.add(
+            combo(mods, key),
+            app.clone(),
+            Action::new(name, desc, action),
+            false,
+        );
+    };
+
+    // Spaces: Ctrl+arrows + Ctrl+1..9 (native Ctrl).
+    add(
+        &[Ctrl],
+        Key::Named(NamedKey::Left),
+        "workspace_prev",
+        "Previous Space",
+        WmAction::Workspace(WorkspaceTarget::Relative(-1)),
+    );
+    add(
+        &[Ctrl],
+        Key::Named(NamedKey::Right),
+        "workspace_next",
+        "Next Space",
+        WmAction::Workspace(WorkspaceTarget::Relative(1)),
+    );
+    for n in 1u8..=9 {
+        add(
+            &[Ctrl],
+            Key::Number(n),
+            &format!("workspace_{n}"),
+            "Space",
+            WmAction::Workspace(WorkspaceTarget::Index(n)),
+        );
+    }
+    // Mission Control (Ctrl+Up) — adapted to an `overview` special workspace.
+    add(
+        &[Ctrl],
+        Key::Named(NamedKey::Up),
+        "mission_control",
+        "Mission Control",
+        WmAction::ToggleSpecialWorkspace("overview".to_string()),
+    );
+
+    // Window switch (Cmd+Tab).
+    add(
+        &[Super],
+        Key::Named(NamedKey::Tab),
+        "switch_window",
+        "Switch window",
+        WmAction::CycleWindow(Cycle::Forward),
+    );
+    add(
+        &[Super, Shift],
+        Key::Named(NamedKey::Tab),
+        "switch_window_prev",
+        "Switch window (reverse)",
+        WmAction::CycleWindow(Cycle::Backward),
+    );
+
+    // Window verbs (Cmd+W/Q/H/M) — bound, so they win over the remap. Hide and
+    // "minimize" are silent moves to special workspaces, not a minimize state.
+    add(
+        &[Super],
+        Key::Letter('w'),
+        "close_window",
+        "Close window",
+        WmAction::Close,
+    );
+    add(
+        &[Super],
+        Key::Letter('q'),
+        "quit",
+        "Quit app",
+        WmAction::Close,
+    );
+    add(
+        &[Super],
+        Key::Letter('h'),
+        "hide",
+        "Hide window",
+        WmAction::MoveToWorkspace(
+            WorkspaceTarget::Special("hidden".to_string()),
+            Follow::Silent,
+        ),
+    );
+    add(
+        &[Super],
+        Key::Letter('m'),
+        "minimize",
+        "Minimize window",
+        WmAction::Minimize,
+    );
+    // Fullscreen (Ctrl+Cmd+F).
+    add(
+        &[Ctrl, Super],
+        Key::Letter('f'),
+        "fullscreen",
+        "Toggle fullscreen",
+        WmAction::Fullscreen,
+    );
+    bs
+}
+
+/// `linux` — mainstream GNOME Shell global window conventions, projected to
+/// Hyprland. Single passthrough `app` mode, no remap. Tile/maximize/hide are
+/// adapted to the nearest real dispatcher.
+///
+/// Source: GNOME Shell defaults (`org.gnome.desktop.wm.keybindings`).
+pub fn linux_preset() -> BindingSet {
+    let mut bs = BindingSet::new("linux");
+    let app = ModeId::new("app");
+    let mut add = |mods: &[Modifier], key: Key, name: &str, desc: &str, action: WmAction| {
+        bs.add(
+            combo(mods, key),
+            app.clone(),
+            Action::new(name, desc, action),
+            false,
+        );
+    };
+
+    // Workspaces: Super+PageUp/PageDown switch; Super+Shift+PageUp/Down move window.
+    add(
+        &[Super],
+        Key::Named(NamedKey::PageUp),
+        "workspace_prev",
+        "Previous workspace",
+        WmAction::Workspace(WorkspaceTarget::Relative(-1)),
+    );
+    add(
+        &[Super],
+        Key::Named(NamedKey::PageDown),
+        "workspace_next",
+        "Next workspace",
+        WmAction::Workspace(WorkspaceTarget::Relative(1)),
+    );
+    add(
+        &[Super, Shift],
+        Key::Named(NamedKey::PageUp),
+        "move_to_prev",
+        "Move window \u{2190} workspace",
+        WmAction::MoveToWorkspace(WorkspaceTarget::Relative(-1), Follow::Follow),
+    );
+    add(
+        &[Super, Shift],
+        Key::Named(NamedKey::PageDown),
+        "move_to_next",
+        "Move window \u{2192} workspace",
+        WmAction::MoveToWorkspace(WorkspaceTarget::Relative(1), Follow::Follow),
+    );
+
+    // Window switch (Alt+Tab) + close (Alt+F4) — faithful.
+    add(
+        &[Alt],
+        Key::Named(NamedKey::Tab),
+        "switch_window",
+        "Switch window",
+        WmAction::CycleWindow(Cycle::Forward),
+    );
+    add(
+        &[Alt],
+        Key::Function(4),
+        "kill",
+        "Close window",
+        WmAction::Close,
+    );
+
+    // Maximize (Super+Up) + tile (Super+arrows) + hide (Super+H) — adapted.
+    // Super+Up maximizes (keeps the bar): fullscreen mode 1, not true fullscreen.
+    add(
+        &[Super],
+        Key::Named(NamedKey::Up),
+        "maximize",
+        "Maximize window",
+        WmAction::Maximize,
+    );
+    add(
+        &[Super],
+        Key::Named(NamedKey::Left),
+        "tile_left",
+        "Tile window left",
+        WmAction::MoveWindow(Direction::Left),
+    );
+    add(
+        &[Super],
+        Key::Named(NamedKey::Right),
+        "tile_right",
+        "Tile window right",
+        WmAction::MoveWindow(Direction::Right),
+    );
+    add(
+        &[Super],
+        Key::Letter('h'),
+        "hide",
+        "Hide window",
+        WmAction::MoveToWorkspace(WorkspaceTarget::Special(String::new()), Follow::Silent),
+    );
+    bs
 }
 
 #[cfg(test)]
@@ -941,10 +1685,15 @@ mod tests {
         bs.add(
             combo.clone(),
             mode.clone(),
-            Action::new("a1", "Action 1", "cmd1"),
+            Action::new("a1", "Action 1", WmAction::Close),
             false,
         );
-        bs.add(combo, mode, Action::new("a2", "Action 2", "cmd2"), false);
+        bs.add(
+            combo,
+            mode,
+            Action::new("a2", "Action 2", WmAction::Close),
+            false,
+        );
         assert!(
             NoConflicts {
                 bindings: bs.clone()
@@ -962,13 +1711,13 @@ mod tests {
         bs.add(
             combo.clone(),
             ModeId::new("mode1"),
-            Action::new("a1", "Action 1", "cmd1"),
+            Action::new("a1", "Action 1", WmAction::Close),
             false,
         );
         bs.add(
             combo,
             ModeId::new("mode2"),
-            Action::new("a2", "Action 2", "cmd2"),
+            Action::new("a2", "Action 2", WmAction::Close),
             false,
         );
         assert!(NoConflicts { bindings: bs }.verify().is_ok());
@@ -1117,9 +1866,100 @@ mod tests {
             ("emacs", emacs_preset()),
             ("i3", i3_preset()),
             ("tmux", tmux_preset()),
+            ("vogix", vogix_preset()),
+            ("windows", windows_preset()),
+            ("macos", macos_preset()),
+            ("linux", linux_preset()),
         ] {
             let axiom = NoConflicts { bindings: bs };
             assert!(axiom.verify().is_ok(), "{name} preset has conflicts");
+        }
+    }
+
+    #[test]
+    fn test_vogix_preset_has_focus_and_workspaces() {
+        let bs = vogix_preset();
+        let app = ModeId::new("app");
+        let names: Vec<_> = bs
+            .for_mode(&app)
+            .iter()
+            .map(|b| b.action.name.clone())
+            .collect();
+        // Focus for both hjkl and arrows, plus all 10 workspaces.
+        assert!(names.iter().any(|n| n == "focus_l"));
+        assert!(names.iter().any(|n| n == "focus_l_arrow"));
+        for i in 1..=10 {
+            assert!(
+                names.iter().any(|n| n == &format!("workspace_{i}")),
+                "vogix missing workspace_{i}"
+            );
+        }
+    }
+
+    #[test]
+    fn vogix_commands_realize_to_expected_dispatchers() {
+        let bs = vogix_preset();
+        let app = ModeId::new("app");
+        let cmd = |n: &str| {
+            bs.for_mode(&app)
+                .into_iter()
+                .find(|b| b.action.name == n)
+                .map(|b| b.action.command())
+        };
+        assert_eq!(cmd("focus_l").as_deref(), Some("movefocus, l"));
+        assert_eq!(cmd("move_u").as_deref(), Some("swapwindow, u"));
+        assert_eq!(cmd("resize_l").as_deref(), Some("resizeactive, -30 0"));
+        assert_eq!(cmd("fullscreen").as_deref(), Some("fullscreen"));
+        assert_eq!(cmd("workspace_10").as_deref(), Some("workspace, 10"));
+        assert_eq!(cmd("workspace_music").as_deref(), Some("workspace, Music"));
+        assert_eq!(cmd("ws_next").as_deref(), Some("workspace, +1"));
+        assert_eq!(
+            cmd("move_silent_1").as_deref(),
+            Some("movetoworkspacesilent, 1")
+        );
+        // The float+pin composite batches into one exec — derived, not hand-written.
+        assert_eq!(
+            cmd("float_pin").as_deref(),
+            Some("exec, hyprctl dispatch togglefloating ; hyprctl dispatch pin")
+        );
+    }
+
+    #[test]
+    fn desktop_maximize_realizes_to_fullscreen_mode_one() {
+        // The maximize-vs-fullscreen fix at the binding level: windows/linux
+        // "maximize" => fullscreen mode 1 (keep the bar), not true fullscreen.
+        for (label, bs, name) in [
+            ("windows", windows_preset(), "maximize"),
+            ("linux", linux_preset(), "maximize"),
+        ] {
+            let app = ModeId::new("app");
+            let max = bs
+                .for_mode(&app)
+                .into_iter()
+                .find(|b| b.action.name == name)
+                .map(|b| b.action.command());
+            assert_eq!(
+                max.as_deref(),
+                Some("fullscreen, 1"),
+                "{label} maximize should realize to fullscreen, 1"
+            );
+        }
+    }
+
+    #[test]
+    fn test_desktop_presets_have_window_switch() {
+        // Each desktop paradigm binds a window-switch verb.
+        for (name, bs) in [
+            ("windows", windows_preset()),
+            ("macos", macos_preset()),
+            ("linux", linux_preset()),
+        ] {
+            let app = ModeId::new("app");
+            let has_switch = bs
+                .for_mode(&app)
+                .iter()
+                .any(|b| b.action.name == "switch_window");
+            assert!(has_switch, "{name} preset missing switch_window");
         }
     }
 
@@ -1190,7 +2030,7 @@ mod tests {
                 bs.add(
                     KeyCombo::new(Key::Letter(c)),
                     mode.clone(),
-                    Action::new(format!("a{}", i), "test", "cmd"),
+                    Action::new(format!("a{}", i), "test", WmAction::Close),
                     false,
                 );
             }

--- a/crates/domains/src/applied/hmi/input/mod.rs
+++ b/crates/domains/src/applied/hmi/input/mod.rs
@@ -6,3 +6,4 @@
 pub mod engine;
 pub mod keybindings;
 pub mod modes;
+pub mod wm_action;

--- a/crates/domains/src/applied/hmi/input/wm_action.rs
+++ b/crates/domains/src/applied/hmi/input/wm_action.rs
@@ -1,0 +1,1013 @@
+//! Window-manager action ontology — abstract intents, typed parameters, and the
+//! functor that realizes them as concrete compositor dispatchers.
+//!
+//! # The conflation this dissolves
+//!
+//! A keybinding used to carry a single opaque string — a raw Hyprland dispatcher
+//! like `"fullscreen, 1"` or `"movetoworkspacesilent, special:hidden"`. That one
+//! string conflates three things an ontology must keep apart:
+//!
+//! 1. **Intent** — the user's goal ([`WmAction`]): *focus the window to the
+//!    left*, *make this window fullscreen*.
+//! 2. **Parameters** — the typed arguments ([`Direction`], [`WorkspaceTarget`],
+//!    [`Follow`], [`Cycle`], …): *which direction, which workspace*.
+//! 3. **Mechanism** — the concrete realization ([`Dispatch`]): the compositor
+//!    dispatcher string. This is produced by a *projection*, never authored.
+//!
+//! The projection is a **functor** [`HyprlandRealization`] from the free monoid
+//! of abstract actions ([`ActionAlgebra`]) to the free monoid of dispatcher
+//! sequences ([`DispatchAlgebra`]). "The runtime is a functor of the ontology":
+//! the realization is *forced* by the per-action lowering rule, with no policy
+//! of its own, and the functor laws (identity + composition preservation) are
+//! machine-proven. A single dispatcher string is emitted only at one blessed
+//! wire boundary, [`Dispatch::render`].
+//!
+//! # Grounding (the literature spine)
+//!
+//! - **Myers (1988)** *A Taxonomy of Window Manager User Interfaces*, IEEE CG&A
+//!   8(5):65–84 — the intent verb set and, crucially, the paper's own split of
+//!   operation **functionality** (which operations exist) from operation **user
+//!   interface** (how they are invoked): intent-vs-mechanism, in WM literature.
+//! - **Card, Moran & Newell (1983)** *The Psychology of Human-Computer
+//!   Interaction* (GOMS) — Goal / Operator / **Method** / Selection-rule. A Goal
+//!   is independent of the Method that realizes it; the Method is the projection.
+//! - **Goguen, Thatcher & Wagner (1978)** *An Initial Algebra Approach to … ADTs*
+//!   — a many-sorted signature's terms form the initial algebra, so there is a
+//!   **unique homomorphism** into any other algebra of the signature. Model the
+//!   actions as the signature and the dispatchers as a second algebra: the
+//!   projection IS that forced homomorphism.
+//! - **Payne & Green (1986)** *Task-Action Grammars* — features as **strongly
+//!   typed variables** over small closed value-sets; one rule-schema per intent
+//!   family, not a per-action string table.
+//! - **EWMH v1.5 (2013)** freedesktop.org — the cross-implementation controlled
+//!   vocabulary: `_NET_WM_ACTION_*`/`_NET_WM_STATE_*`, the `_NET_WM_MOVERESIZE`
+//!   direction enum, add/remove/**toggle**, and the desktop CARDINAL. Supplies
+//!   the named atoms and typed parameter domains (and the *maximize ≠ fullscreen*
+//!   state distinction this module preserves).
+//! - **Foley & van Dam (1982)** *Fundamentals of Interactive Computer Graphics*
+//!   — the conceptual/semantic/syntactic/lexical stack: mechanism emission is
+//!   lexical lowering (code generation), licensing the functor.
+//! - **Mac Lane (1971)** *Categories for the Working Mathematician* II.1 — the
+//!   functor laws the projection must satisfy.
+//! - **Reiter (1978)** *On Closed World Data Bases* — [`WmAction`] is **open
+//!   world**: [`WmAction::Exec`] carries an arbitrary external command line, so
+//!   the vocabulary is not finitely enumerable and the type implements
+//!   [`Concept`] but **not** [`FinitelyGenerated`].
+//! - **Hyprland dispatchers** <https://wiki.hyprland.org/Configuring/Dispatchers/>
+//!   — the realization vocabulary [`Dispatch`] names.
+
+#[allow(unused_imports)]
+use alloc::{boxed::Box, format, string::String, string::ToString, vec, vec::Vec};
+
+use pr4xis::category::laws::functor_law_axioms;
+use pr4xis::category::{Arrow, Category, Concept, FinitelyGenerated, Functor};
+use pr4xis::logic::Axiom;
+use pr4xis::logic::proof::{SimpleCounterexample, SimpleProof, Verdict, combine_verdicts};
+use pr4xis::ontology::meta::{Citation, Label, ModulePath, OntologyName, Provenance};
+
+use super::modes::ModeId;
+
+// ── Layer 2: typed parameters ────────────────────────────────────────────────
+
+/// A spatial direction — the parameter of focus / move / swap / resize.
+///
+/// A strongly-typed variable over a small closed value-set (Payne & Green 1986);
+/// the value domain is EWMH's `_NET_WM_MOVERESIZE` direction family restricted to
+/// the four cardinals the presets use (diagonals are deferred — see the pack
+/// README). Hyprland names them `l`/`r`/`u`/`d`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Direction {
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
+impl Direction {
+    /// The Hyprland direction token (`l`/`r`/`u`/`d`).
+    fn hypr(self) -> char {
+        match self {
+            Direction::Left => 'l',
+            Direction::Right => 'r',
+            Direction::Up => 'u',
+            Direction::Down => 'd',
+        }
+    }
+}
+
+impl Concept for Direction {
+    fn name(&self) -> &'static str {
+        match self {
+            Direction::Left => "left",
+            Direction::Right => "right",
+            Direction::Up => "up",
+            Direction::Down => "down",
+        }
+    }
+}
+impl FinitelyGenerated for Direction {
+    fn variants() -> Vec<Self> {
+        vec![
+            Direction::Left,
+            Direction::Right,
+            Direction::Up,
+            Direction::Down,
+        ]
+    }
+}
+
+/// Cycle direction for window / group traversal (Alt-Tab style).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Cycle {
+    Forward,
+    Backward,
+}
+
+impl Concept for Cycle {
+    fn name(&self) -> &'static str {
+        match self {
+            Cycle::Forward => "forward",
+            Cycle::Backward => "backward",
+        }
+    }
+}
+impl FinitelyGenerated for Cycle {
+    fn variants() -> Vec<Self> {
+        vec![Cycle::Forward, Cycle::Backward]
+    }
+}
+
+/// Whether moving a window to a workspace **follows** it (focus travels) or is
+/// **silent** (window leaves, focus stays).
+///
+/// This is the `movetoworkspace` vs `movetoworkspacesilent` distinction; it is a
+/// real parameter of the move intent (EWMH source-indication governs whether a
+/// request changes the active desktop), not two separate verbs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Follow {
+    Follow,
+    Silent,
+}
+
+impl Concept for Follow {
+    fn name(&self) -> &'static str {
+        match self {
+            Follow::Follow => "follow",
+            Follow::Silent => "silent",
+        }
+    }
+}
+impl FinitelyGenerated for Follow {
+    fn variants() -> Vec<Self> {
+        vec![Follow::Follow, Follow::Silent]
+    }
+}
+
+/// A workspace selector — the parameter of workspace and move-to-workspace.
+///
+/// The value domain is EWMH `_NET_WM_DESKTOP` (a bounded CARDINAL index) plus the
+/// relative and named extensions every real compositor adds. The virtual-desktop
+/// dimension itself is Henderson & Card (1986) *Rooms*.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum WorkspaceTarget {
+    /// Absolute index (`workspace, 3`).
+    Index(u8),
+    /// Relative step (`workspace, +1` / `workspace, -1`).
+    Relative(i32),
+    /// Named workspace (`workspace, Music`).
+    Named(String),
+    /// A special / scratchpad workspace. Empty name = the default `special`
+    /// scratchpad; a name = `special:hidden`, `special:minimized`, …
+    Special(String),
+}
+
+impl WorkspaceTarget {
+    /// The Hyprland workspace argument.
+    fn render(&self) -> String {
+        match self {
+            WorkspaceTarget::Index(n) => n.to_string(),
+            WorkspaceTarget::Relative(k) => {
+                if *k >= 0 {
+                    format!("+{k}")
+                } else {
+                    k.to_string()
+                }
+            }
+            WorkspaceTarget::Named(s) => s.clone(),
+            WorkspaceTarget::Special(s) if s.is_empty() => "special".to_string(),
+            WorkspaceTarget::Special(s) => format!("special:{s}"),
+        }
+    }
+}
+
+/// What a submap keybinding does — enter a named submap, or reset to root.
+///
+/// Submaps are the keybinding-layer realization of the modal interaction
+/// ontology; a submap *is* a [`ModeId`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SubmapTarget {
+    Enter(ModeId),
+    Reset,
+}
+
+impl SubmapTarget {
+    fn render(&self) -> String {
+        match self {
+            SubmapTarget::Enter(m) => m.0.clone(),
+            SubmapTarget::Reset => "reset".to_string(),
+        }
+    }
+}
+
+// ── Layer 1: the abstract intent vocabulary ──────────────────────────────────
+
+/// An abstract window-manager **action** — the user's intent, with typed
+/// parameters, independent of the compositor that realizes it.
+///
+/// This is the open-world ([`Concept`], not [`FinitelyGenerated`]) vocabulary:
+/// [`WmAction::Exec`] carries an arbitrary external command, so the set of
+/// actions is not finitely enumerable (Reiter 1978).
+/// [`WmAction::representative_actions`] supplies the finite generating set used to
+/// machine-check the functor and to seed property tests.
+///
+/// Each variant cites the source that names it; see the module header for the
+/// full spine.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum WmAction {
+    /// Move keyboard focus to the neighbour in a direction (Myers
+    /// "change-listener"; EWMH input focus).
+    Focus(Direction),
+    /// Move the focused window one slot in a direction (Myers "move").
+    MoveWindow(Direction),
+    /// Swap the focused window with its neighbour in a direction.
+    SwapWindow(Direction),
+    /// Resize the focused window by a step along a direction's axis (Myers
+    /// "change-size"/grow; the amount is a pixel magnitude).
+    Resize(Direction, u16),
+    /// Close / kill the focused window (Myers "delete"; EWMH `CLOSE`).
+    Close,
+    /// Toggle true fullscreen (EWMH `_NET_WM_ACTION_FULLSCREEN`; Myers
+    /// "make-full-screen"). Realized by the bare `fullscreen` dispatcher.
+    Fullscreen,
+    /// Maximize — fill the work area but keep the layout's reserved space. A
+    /// *distinct* EWMH action (`_NET_WM_ACTION_MAXIMIZE_*`) and Myers operation,
+    /// realized on Hyprland by the `fullscreen` dispatcher's mode 1.
+    Maximize,
+    /// Minimize / iconify the focused window (EWMH `_NET_WM_ACTION_MINIMIZE`;
+    /// Myers "shrink-to-icon"). Hyprland has no native minimize, so the functor
+    /// emulates it with a silent move to a dedicated special workspace.
+    Minimize,
+    /// Toggle floating (tiled ⇄ floating).
+    ToggleFloat,
+    /// Pin the window above others / across workspaces (EWMH `ABOVE`/`STICK`).
+    Pin,
+    /// Toggle pseudo-tiling for the focused window (Hyprland dwindle).
+    Pseudotile,
+    /// Toggle the split orientation of the layout (Hyprland `layoutmsg
+    /// togglesplit`).
+    ToggleSplit,
+    /// Toggle grouping (tabbed group) for the focused window.
+    ToggleGroup,
+    /// Cycle the active window *within* the current group.
+    CycleGroup(Cycle),
+    /// Cycle focus across windows (Alt-Tab; EWMH stacking order traversal).
+    CycleWindow(Cycle),
+    /// Switch to a workspace (Henderson & Card 1986 *Rooms*; EWMH
+    /// `_NET_CURRENT_DESKTOP`).
+    Workspace(WorkspaceTarget),
+    /// Send the focused window to a workspace, optionally following it (EWMH
+    /// `_NET_WM_DESKTOP`).
+    MoveToWorkspace(WorkspaceTarget, Follow),
+    /// Toggle a special / scratchpad workspace overlay (e.g. an overview).
+    ToggleSpecialWorkspace(String),
+    /// Run an external command. The **one blessed wire boundary**: the command
+    /// line is genuine external data, not a vocabulary praxis controls — the
+    /// reason [`WmAction`] is open-world (Reiter 1978).
+    Exec(String),
+    /// Enter or reset a keybinding submap (the modal-ontology mode layer).
+    Submap(SubmapTarget),
+}
+
+impl WmAction {
+    /// The finite generating set — one representative of every variant. Used to
+    /// machine-check the realization functor (totality, the functor laws) and to
+    /// seed property tests. This is a *generating* set, not the (open-world) whole
+    /// of [`WmAction`].
+    pub fn representative_actions() -> Vec<WmAction> {
+        use Direction::*;
+        vec![
+            WmAction::Focus(Left),
+            WmAction::Focus(Right),
+            WmAction::Focus(Up),
+            WmAction::Focus(Down),
+            WmAction::MoveWindow(Left),
+            WmAction::SwapWindow(Up),
+            WmAction::Resize(Left, 30),
+            WmAction::Resize(Down, 30),
+            WmAction::Close,
+            WmAction::Fullscreen,
+            WmAction::Maximize,
+            WmAction::Minimize,
+            WmAction::ToggleFloat,
+            WmAction::Pin,
+            WmAction::Pseudotile,
+            WmAction::ToggleSplit,
+            WmAction::ToggleGroup,
+            WmAction::CycleGroup(Cycle::Forward),
+            WmAction::CycleWindow(Cycle::Forward),
+            WmAction::CycleWindow(Cycle::Backward),
+            WmAction::Workspace(WorkspaceTarget::Index(1)),
+            WmAction::Workspace(WorkspaceTarget::Relative(1)),
+            WmAction::Workspace(WorkspaceTarget::Relative(-1)),
+            WmAction::Workspace(WorkspaceTarget::Named("Music".to_string())),
+            WmAction::MoveToWorkspace(WorkspaceTarget::Index(2), Follow::Follow),
+            WmAction::MoveToWorkspace(WorkspaceTarget::Relative(-1), Follow::Follow),
+            WmAction::MoveToWorkspace(WorkspaceTarget::Index(3), Follow::Silent),
+            WmAction::MoveToWorkspace(
+                WorkspaceTarget::Special("hidden".to_string()),
+                Follow::Silent,
+            ),
+            WmAction::MoveToWorkspace(WorkspaceTarget::Special(String::new()), Follow::Silent),
+            WmAction::ToggleSpecialWorkspace("overview".to_string()),
+            WmAction::Exec("$TERMINAL".to_string()),
+            WmAction::Submap(SubmapTarget::Enter(ModeId::new("resize"))),
+            WmAction::Submap(SubmapTarget::Reset),
+        ]
+    }
+}
+
+impl Concept for WmAction {
+    fn name(&self) -> &'static str {
+        match self {
+            WmAction::Focus(_) => "focus",
+            WmAction::MoveWindow(_) => "move-window",
+            WmAction::SwapWindow(_) => "swap-window",
+            WmAction::Resize(_, _) => "resize",
+            WmAction::Close => "close",
+            WmAction::Fullscreen => "fullscreen",
+            WmAction::Maximize => "maximize",
+            WmAction::Minimize => "minimize",
+            WmAction::ToggleFloat => "toggle-float",
+            WmAction::Pin => "pin",
+            WmAction::Pseudotile => "pseudotile",
+            WmAction::ToggleSplit => "toggle-split",
+            WmAction::ToggleGroup => "toggle-group",
+            WmAction::CycleGroup(_) => "cycle-group",
+            WmAction::CycleWindow(_) => "cycle-window",
+            WmAction::Workspace(_) => "workspace",
+            WmAction::MoveToWorkspace(_, _) => "move-to-workspace",
+            WmAction::ToggleSpecialWorkspace(_) => "toggle-special-workspace",
+            WmAction::Exec(_) => "exec",
+            WmAction::Submap(_) => "submap",
+        }
+    }
+}
+
+// ── Layer 3: the realization alphabet (Hyprland dispatchers) ──────────────────
+
+/// A single Hyprland dispatcher — the typed mechanism atom. The dispatcher name
+/// is vocabulary (a typed variant); its arguments are typed where they are
+/// vocabulary and carried verbatim only where they are genuine external data
+/// ([`Dispatch::Exec`]). [`Dispatch::render`] is the single wire boundary that
+/// turns this into the compositor command string.
+///
+/// Names follow the Hyprland dispatcher list
+/// (<https://wiki.hyprland.org/Configuring/Dispatchers/>).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Dispatch {
+    MoveFocus(Direction),
+    MoveWindow(Direction),
+    SwapWindow(Direction),
+    /// `resizeactive, <dx> <dy>`.
+    ResizeActive(i16, i16),
+    KillActive,
+    /// `fullscreen, <0|1>`.
+    Fullscreen(u8),
+    ToggleFloating,
+    Pin,
+    Pseudo,
+    /// `layoutmsg, <message>`.
+    LayoutMsg(&'static str),
+    ToggleGroup,
+    /// `changegroupactive, <f|b>`.
+    ChangeGroupActive(char),
+    Workspace(WorkspaceTarget),
+    MoveToWorkspace(WorkspaceTarget),
+    MoveToWorkspaceSilent(WorkspaceTarget),
+    ToggleSpecialWorkspace(String),
+    /// `cyclenext,` or `cyclenext, prev`.
+    CycleNext(bool),
+    Exec(String),
+    Submap(String),
+}
+
+impl Dispatch {
+    /// The single wire boundary: render this dispatcher as the Hyprland command
+    /// string (the pre-`dispatch` form — `"<dispatcher>, <args>"`).
+    pub fn render(&self) -> String {
+        match self {
+            Dispatch::MoveFocus(d) => format!("movefocus, {}", d.hypr()),
+            Dispatch::MoveWindow(d) => format!("movewindow, {}", d.hypr()),
+            Dispatch::SwapWindow(d) => format!("swapwindow, {}", d.hypr()),
+            Dispatch::ResizeActive(dx, dy) => format!("resizeactive, {dx} {dy}"),
+            Dispatch::KillActive => "killactive,".to_string(),
+            // Default fullscreen is the bare `fullscreen` dispatcher (the Hyprland
+            // idiom and what deployed configs carry); an explicit non-zero mode
+            // (1 = maximize, keep the reserved area) carries its argument.
+            Dispatch::Fullscreen(0) => "fullscreen".to_string(),
+            Dispatch::Fullscreen(n) => format!("fullscreen, {n}"),
+            Dispatch::ToggleFloating => "togglefloating,".to_string(),
+            Dispatch::Pin => "pin,".to_string(),
+            Dispatch::Pseudo => "pseudo,".to_string(),
+            Dispatch::LayoutMsg(m) => format!("layoutmsg, {m}"),
+            Dispatch::ToggleGroup => "togglegroup,".to_string(),
+            Dispatch::ChangeGroupActive(c) => format!("changegroupactive, {c}"),
+            Dispatch::Workspace(w) => format!("workspace, {}", w.render()),
+            Dispatch::MoveToWorkspace(w) => format!("movetoworkspace, {}", w.render()),
+            Dispatch::MoveToWorkspaceSilent(w) => {
+                format!("movetoworkspacesilent, {}", w.render())
+            }
+            Dispatch::ToggleSpecialWorkspace(n) => format!("togglespecialworkspace, {n}"),
+            Dispatch::CycleNext(prev) => {
+                if *prev {
+                    "cyclenext, prev".to_string()
+                } else {
+                    "cyclenext,".to_string()
+                }
+            }
+            Dispatch::Exec(cmd) => format!("exec, {cmd}"),
+            Dispatch::Submap(name) => format!("submap, {name}"),
+        }
+    }
+
+    /// The `hyprctl dispatch …` argument form (dispatcher + space-separated args,
+    /// no comma). Used to batch a multi-dispatcher action into one `exec` bind.
+    fn hyprctl_args(&self) -> String {
+        let r = self.render();
+        match r.split_once(", ") {
+            Some((head, tail)) => format!("{head} {tail}"),
+            None => r.trim_end_matches(',').to_string(),
+        }
+    }
+}
+
+// ── The two monoids: one-object free categories ───────────────────────────────
+
+/// The single object of both action and dispatch monoids — the compositor
+/// surface that actions act on. (A monoid is a one-object category; Mac Lane
+/// 1971 I.2.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum WmSurface {
+    Compositor,
+}
+
+impl Concept for WmSurface {
+    fn name(&self) -> &'static str {
+        "compositor"
+    }
+}
+impl FinitelyGenerated for WmSurface {
+    fn variants() -> Vec<Self> {
+        vec![WmSurface::Compositor]
+    }
+}
+
+/// A word in the free monoid of abstract actions — the action(s) a single
+/// binding performs. Length 1 for almost every binding; length > 1 for genuine
+/// composites (e.g. float-then-pin).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ActionWord(pub Vec<WmAction>);
+
+impl From<WmAction> for ActionWord {
+    fn from(a: WmAction) -> Self {
+        ActionWord(vec![a])
+    }
+}
+impl From<Vec<WmAction>> for ActionWord {
+    fn from(v: Vec<WmAction>) -> Self {
+        ActionWord(v)
+    }
+}
+
+impl Arrow for ActionWord {
+    type Object = WmSurface;
+    type Kind = ();
+
+    fn source(&self) -> WmSurface {
+        WmSurface::Compositor
+    }
+    fn target(&self) -> WmSurface {
+        WmSurface::Compositor
+    }
+    fn kind(&self) {}
+}
+
+/// The free monoid on [`WmAction`] as a one-object category: composition is
+/// concatenation, identity is the empty word. Used as the functor source; its
+/// full morphism set is infinite, so [`Category::morphisms`] returns the finite
+/// generating set (empty word + single-action words), as the sibling modal
+/// ontology's effect trace does.
+pub struct ActionAlgebra;
+
+impl Category for ActionAlgebra {
+    type Object = WmSurface;
+    type Morphism = ActionWord;
+
+    fn identity(_: &WmSurface) -> ActionWord {
+        ActionWord(Vec::new())
+    }
+
+    fn compose(f: &ActionWord, g: &ActionWord) -> Option<ActionWord> {
+        let mut w = f.0.clone();
+        w.extend(g.0.iter().cloned());
+        Some(ActionWord(w))
+    }
+
+    fn morphisms() -> Vec<ActionWord> {
+        let mut ms = vec![ActionWord(Vec::new())];
+        ms.extend(
+            WmAction::representative_actions()
+                .into_iter()
+                .map(ActionWord::from),
+        );
+        ms
+    }
+}
+
+/// A word in the free monoid of dispatchers — the concrete realization of an
+/// action word.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DispatchWord(pub Vec<Dispatch>);
+
+impl DispatchWord {
+    /// Render this dispatcher sequence as the command string a *single* keybind
+    /// emits. A one-dispatcher word renders directly; a multi-dispatcher word is
+    /// batched into one `exec, hyprctl dispatch … ; hyprctl dispatch …` —
+    /// Hyprland binds one dispatcher each, so a composite is realized this way.
+    pub fn command(&self) -> String {
+        match self.0.as_slice() {
+            [] => String::new(),
+            [single] => single.render(),
+            many => {
+                let parts: Vec<String> = many
+                    .iter()
+                    .map(|d| format!("hyprctl dispatch {}", d.hyprctl_args()))
+                    .collect();
+                format!("exec, {}", parts.join(" ; "))
+            }
+        }
+    }
+}
+
+impl Arrow for DispatchWord {
+    type Object = WmSurface;
+    type Kind = ();
+
+    fn source(&self) -> WmSurface {
+        WmSurface::Compositor
+    }
+    fn target(&self) -> WmSurface {
+        WmSurface::Compositor
+    }
+    fn kind(&self) {}
+}
+
+/// The free monoid on [`Dispatch`] as a one-object category — the functor target.
+pub struct DispatchAlgebra;
+
+impl Category for DispatchAlgebra {
+    type Object = WmSurface;
+    type Morphism = DispatchWord;
+
+    fn identity(_: &WmSurface) -> DispatchWord {
+        DispatchWord(Vec::new())
+    }
+
+    fn compose(f: &DispatchWord, g: &DispatchWord) -> Option<DispatchWord> {
+        let mut w = f.0.clone();
+        w.extend(g.0.iter().cloned());
+        Some(DispatchWord(w))
+    }
+
+    fn morphisms() -> Vec<DispatchWord> {
+        let mut ms = vec![DispatchWord(Vec::new())];
+        ms.extend(
+            WmAction::representative_actions()
+                .iter()
+                .map(|a| DispatchWord(lower(a))),
+        );
+        ms
+    }
+}
+
+// ── The realization functor ───────────────────────────────────────────────────
+
+/// Lower one abstract action to its dispatcher sequence — the per-action rule
+/// schema (Payne & Green 1986). One shared schema per intent family; the functor
+/// is its free extension. Almost every action lowers to a single dispatcher; the
+/// genuine composites lower to a short sequence.
+fn lower(action: &WmAction) -> Vec<Dispatch> {
+    match action {
+        WmAction::Focus(d) => vec![Dispatch::MoveFocus(*d)],
+        WmAction::MoveWindow(d) => vec![Dispatch::MoveWindow(*d)],
+        WmAction::SwapWindow(d) => vec![Dispatch::SwapWindow(*d)],
+        WmAction::Resize(d, amt) => {
+            let a = *amt as i16;
+            let (dx, dy) = match d {
+                Direction::Left => (-a, 0),
+                Direction::Right => (a, 0),
+                Direction::Up => (0, -a),
+                Direction::Down => (0, a),
+            };
+            vec![Dispatch::ResizeActive(dx, dy)]
+        }
+        WmAction::Close => vec![Dispatch::KillActive],
+        WmAction::Fullscreen => vec![Dispatch::Fullscreen(0)],
+        WmAction::Maximize => vec![Dispatch::Fullscreen(1)],
+        // Hyprland has no native iconify — emulate minimize with a silent move to a
+        // dedicated special (scratchpad) workspace.
+        WmAction::Minimize => vec![Dispatch::MoveToWorkspaceSilent(WorkspaceTarget::Special(
+            "minimized".to_string(),
+        ))],
+        WmAction::ToggleFloat => vec![Dispatch::ToggleFloating],
+        WmAction::Pin => vec![Dispatch::Pin],
+        WmAction::Pseudotile => vec![Dispatch::Pseudo],
+        WmAction::ToggleSplit => vec![Dispatch::LayoutMsg("togglesplit")],
+        WmAction::ToggleGroup => vec![Dispatch::ToggleGroup],
+        WmAction::CycleGroup(c) => vec![Dispatch::ChangeGroupActive(match c {
+            Cycle::Forward => 'f',
+            Cycle::Backward => 'b',
+        })],
+        WmAction::CycleWindow(c) => vec![Dispatch::CycleNext(matches!(c, Cycle::Backward))],
+        WmAction::Workspace(w) => vec![Dispatch::Workspace(w.clone())],
+        WmAction::MoveToWorkspace(w, Follow::Follow) => vec![Dispatch::MoveToWorkspace(w.clone())],
+        WmAction::MoveToWorkspace(w, Follow::Silent) => {
+            vec![Dispatch::MoveToWorkspaceSilent(w.clone())]
+        }
+        WmAction::ToggleSpecialWorkspace(n) => vec![Dispatch::ToggleSpecialWorkspace(n.clone())],
+        WmAction::Exec(cmd) => vec![Dispatch::Exec(cmd.clone())],
+        WmAction::Submap(t) => vec![Dispatch::Submap(t.render())],
+    }
+}
+
+/// The realization functor `HyprlandRealization : ActionAlgebra → DispatchAlgebra`.
+///
+/// On the single object it is the identity; on morphisms it lowers each action
+/// and concatenates. Because lowering distributes over concatenation, the result
+/// is a monoid homomorphism — a strict, total functor (Goguen-Thatcher-Wagner
+/// 1978's unique homomorphism; Mac Lane 1971 II.1's functor laws), with no policy
+/// of its own. "The runtime is a functor of the ontology."
+pub struct HyprlandRealization;
+
+impl Functor for HyprlandRealization {
+    type Source = ActionAlgebra;
+    type Target = DispatchAlgebra;
+
+    fn map_object(_: &WmSurface) -> WmSurface {
+        WmSurface::Compositor
+    }
+
+    fn map_morphism(word: &ActionWord) -> DispatchWord {
+        DispatchWord(word.0.iter().flat_map(lower).collect())
+    }
+
+    fn meta() -> Provenance {
+        Provenance {
+            name: OntologyName::new_static("HyprlandRealization"),
+            description: Label::new_static(
+                "abstract WM actions → Hyprland dispatcher sequences (strict, total monoid functor)",
+            ),
+            citation: Citation::parse_static(
+                "Goguen, Thatcher & Wagner (1978) An Initial Algebra Approach to ADTs (unique homomorphism); \
+                 Foley & van Dam (1982) Fundamentals of Interactive Computer Graphics (lexical lowering); \
+                 Mac Lane (1971) Categories for the Working Mathematician Ch. II §1 (functor laws)",
+            ),
+            module_path: ModulePath::new_static(module_path!()),
+        }
+    }
+}
+
+/// Convenience: lower a single action to the command string a keybind emits.
+pub fn realize(action: &WmAction) -> String {
+    HyprlandRealization::map_morphism(&ActionWord::from(action.clone())).command()
+}
+
+// ── Domain axioms ─────────────────────────────────────────────────────────────
+
+/// Every abstract action realizes to at least one dispatcher — the projection is
+/// **total**: no intent silently vanishes.
+pub struct LoweringTotal;
+
+impl Axiom for LoweringTotal {
+    fn verify(&self) -> Verdict {
+        for a in WmAction::representative_actions() {
+            let w = HyprlandRealization::map_morphism(&ActionWord::from(a));
+            if w.0.is_empty() {
+                return Err(Box::new(SimpleCounterexample::new(self.meta())));
+            }
+        }
+        Ok(Box::new(SimpleProof::new(self.meta())))
+    }
+
+    pr4xis::axiom_meta!(
+        "LoweringTotal",
+        "every abstract action realizes to a non-empty dispatcher sequence (total projection)",
+        "Goguen, Thatcher & Wagner (1978) An Initial Algebra Approach to ADTs — the initial algebra has a unique (total) homomorphism into any algebra of the signature; Card, Moran & Newell (1983) GOMS — every goal has a method"
+    );
+}
+
+/// Fullscreen, Maximize, and Minimize are **distinct** window-state actions and
+/// realize to pairwise-distinct dispatchers. EWMH keeps them as three separate
+/// actions (`_NET_WM_ACTION_FULLSCREEN` / `_NET_WM_ACTION_MAXIMIZE_*` /
+/// `_NET_WM_ACTION_MINIMIZE`); the bug where "maximize" collapsed onto true
+/// fullscreen was exactly the loss of this distinction.
+pub struct WindowStateActionsDistinct;
+
+impl Axiom for WindowStateActionsDistinct {
+    fn verify(&self) -> Verdict {
+        let fs = realize(&WmAction::Fullscreen);
+        let mx = realize(&WmAction::Maximize);
+        let mn = realize(&WmAction::Minimize);
+        if fs != mx && mx != mn && fs != mn {
+            Ok(Box::new(SimpleProof::new(self.meta())))
+        } else {
+            Err(Box::new(SimpleCounterexample::new(self.meta())))
+        }
+    }
+
+    pr4xis::axiom_meta!(
+        "WindowStateActionsDistinct",
+        "fullscreen, maximize, and minimize realize to pairwise-distinct dispatchers",
+        "EWMH v1.5 (2013) — _NET_WM_ACTION_FULLSCREEN, _NET_WM_ACTION_MAXIMIZE_*, _NET_WM_ACTION_MINIMIZE are distinct actions; Myers (1988) make-full-screen vs shrink-to-icon"
+    );
+}
+
+/// A composite intent realizes to a **dispatcher sequence**, not a hand-written
+/// shell hack: float-then-pin lowers to exactly `[togglefloating, pin]`. This is
+/// the monoid (sequenced-effect) structure made concrete (Plotkin & Power 2003).
+pub struct CompositeSequencePreserved;
+
+impl Axiom for CompositeSequencePreserved {
+    fn verify(&self) -> Verdict {
+        let w = HyprlandRealization::map_morphism(&ActionWord(vec![
+            WmAction::ToggleFloat,
+            WmAction::Pin,
+        ]));
+        if w.0 == vec![Dispatch::ToggleFloating, Dispatch::Pin] {
+            Ok(Box::new(SimpleProof::new(self.meta())))
+        } else {
+            Err(Box::new(SimpleCounterexample::new(self.meta())))
+        }
+    }
+
+    pr4xis::axiom_meta!(
+        "CompositeSequencePreserved",
+        "a composite action (float+pin) realizes to a two-dispatcher sequence, not a single opaque command",
+        "Plotkin & Power (2003) Algebraic Operations and Generic Effects — sequenced effects compose in the free monoid"
+    );
+}
+
+// ── The ontology ──────────────────────────────────────────────────────────────
+
+/// The window-action ontology. Validating it discharges the realization functor
+/// laws (identity + composition preservation — the proof that realization is a
+/// strict, total functor) together with the domain axioms (totality, the
+/// maximize/fullscreen distinction, composite sequencing).
+///
+/// Like the surface ontology and unlike the modal one, the underlying categories
+/// are free monoids used as functor source/target — verified through
+/// [`functor_law_axioms`], not category-closure laws (a free monoid's generating
+/// set is not closed under composition).
+pub struct WindowActionOntology;
+
+impl WindowActionOntology {
+    /// All axioms this ontology asserts.
+    pub fn axioms() -> Vec<Box<dyn Axiom>> {
+        let mut all: Vec<Box<dyn Axiom>> = functor_law_axioms::<HyprlandRealization>();
+        all.push(Box::new(LoweringTotal));
+        all.push(Box::new(WindowStateActionsDistinct));
+        all.push(Box::new(CompositeSequencePreserved));
+        all
+    }
+
+    /// Validate the whole ontology: functor laws + domain axioms, aggregated into
+    /// one typed [`Verdict`].
+    pub fn validate() -> Verdict {
+        let meta = Provenance {
+            name: OntologyName::new_static("WindowActionOntologyValidation"),
+            description: Label::new_static(
+                "aggregate validation: realization functor laws + window-action domain axioms",
+            ),
+            citation: Citation::parse_static(
+                "Mac Lane (1971) Categories for the Working Mathematician Ch. II §1",
+            ),
+            module_path: ModulePath::new_static(module_path!()),
+        };
+        let subverdicts: Vec<Verdict> = Self::axioms().into_iter().map(|a| a.verify()).collect();
+        combine_verdicts(meta, subverdicts)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pr4xis::category::laws::assert_functor_laws;
+    use proptest::prelude::*;
+
+    // ── Realization snapshots (the single wire boundary) ──
+
+    #[test]
+    fn realize_focus_directions() {
+        assert_eq!(realize(&WmAction::Focus(Direction::Left)), "movefocus, l");
+        assert_eq!(realize(&WmAction::Focus(Direction::Right)), "movefocus, r");
+        assert_eq!(realize(&WmAction::Focus(Direction::Up)), "movefocus, u");
+        assert_eq!(realize(&WmAction::Focus(Direction::Down)), "movefocus, d");
+    }
+
+    #[test]
+    fn realize_resize_axes() {
+        assert_eq!(
+            realize(&WmAction::Resize(Direction::Left, 30)),
+            "resizeactive, -30 0"
+        );
+        assert_eq!(
+            realize(&WmAction::Resize(Direction::Down, 30)),
+            "resizeactive, 0 30"
+        );
+    }
+
+    #[test]
+    fn realize_workspace_targets() {
+        assert_eq!(
+            realize(&WmAction::Workspace(WorkspaceTarget::Index(1))),
+            "workspace, 1"
+        );
+        assert_eq!(
+            realize(&WmAction::Workspace(WorkspaceTarget::Relative(1))),
+            "workspace, +1"
+        );
+        assert_eq!(
+            realize(&WmAction::Workspace(WorkspaceTarget::Relative(-1))),
+            "workspace, -1"
+        );
+        assert_eq!(
+            realize(&WmAction::Workspace(WorkspaceTarget::Named(
+                "Music".to_string()
+            ))),
+            "workspace, Music"
+        );
+    }
+
+    #[test]
+    fn realize_special_workspace_hide() {
+        // macOS-style hide: a silent move to a named special workspace.
+        assert_eq!(
+            realize(&WmAction::MoveToWorkspace(
+                WorkspaceTarget::Special("hidden".to_string()),
+                Follow::Silent
+            )),
+            "movetoworkspacesilent, special:hidden"
+        );
+        // GNOME-style hide to the default scratchpad.
+        assert_eq!(
+            realize(&WmAction::MoveToWorkspace(
+                WorkspaceTarget::Special(String::new()),
+                Follow::Silent
+            )),
+            "movetoworkspacesilent, special"
+        );
+    }
+
+    // ── The three fixes ──
+
+    #[test]
+    fn fullscreen_maximize_minimize_are_distinct_verbs() {
+        // Three distinct intents → three distinct dispatchers. Maximize is
+        // fullscreen mode 1; minimize is the special-workspace emulation.
+        assert_eq!(realize(&WmAction::Fullscreen), "fullscreen");
+        assert_eq!(realize(&WmAction::Maximize), "fullscreen, 1");
+        assert_eq!(
+            realize(&WmAction::Minimize),
+            "movetoworkspacesilent, special:minimized"
+        );
+    }
+
+    #[test]
+    fn fix_float_pin_is_two_dispatch_exec_batch() {
+        let cmd = HyprlandRealization::map_morphism(&ActionWord(vec![
+            WmAction::ToggleFloat,
+            WmAction::Pin,
+        ]))
+        .command();
+        assert_eq!(
+            cmd,
+            "exec, hyprctl dispatch togglefloating ; hyprctl dispatch pin"
+        );
+    }
+
+    // ── Functor + ontology validation ──
+
+    #[test]
+    fn realization_is_a_functor() {
+        assert_functor_laws::<HyprlandRealization>();
+    }
+
+    #[test]
+    fn lowering_is_total() {
+        LoweringTotal
+            .verify()
+            .unwrap_or_else(|c| panic!("not total: {}", c.meta().name.as_str()));
+    }
+
+    #[test]
+    fn window_state_actions_distinct() {
+        WindowStateActionsDistinct
+            .verify()
+            .unwrap_or_else(|c| panic!("{}", c.meta().name.as_str()));
+    }
+
+    #[test]
+    fn composite_sequence_preserved() {
+        CompositeSequencePreserved
+            .verify()
+            .unwrap_or_else(|c| panic!("{}", c.meta().name.as_str()));
+    }
+
+    #[test]
+    fn whole_ontology_validates() {
+        WindowActionOntology::validate()
+            .unwrap_or_else(|c| panic!("ontology invalid: {}", c.meta().name.as_str()));
+    }
+
+    // ── Property-based tests ──
+
+    /// An arbitrary action drawn from the generating set.
+    fn arb_action() -> impl Strategy<Value = WmAction> {
+        prop_oneof![
+            proptest::sample::select(WmAction::representative_actions()),
+            any::<u8>().prop_map(|n| WmAction::Workspace(WorkspaceTarget::Index(n))),
+            any::<i16>().prop_map(|k| WmAction::Workspace(WorkspaceTarget::Relative(k as i32))),
+            "[a-z ]{0,12}".prop_map(WmAction::Exec),
+        ]
+    }
+
+    fn arb_word() -> impl Strategy<Value = ActionWord> {
+        proptest::collection::vec(arb_action(), 0..6).prop_map(ActionWord)
+    }
+
+    proptest! {
+        /// The realization functor is a **monoid homomorphism**: lowering a
+        /// concatenation equals concatenating the lowerings. This is composition
+        /// preservation, the hallmark of a functor, on random action words.
+        #[test]
+        fn prop_realization_is_homomorphism(a in arb_word(), b in arb_word()) {
+            let cat = ActionAlgebra::compose(&a, &b).unwrap();
+            let lhs = HyprlandRealization::map_morphism(&cat);
+            let ra = HyprlandRealization::map_morphism(&a);
+            let rb = HyprlandRealization::map_morphism(&b);
+            let rhs = DispatchAlgebra::compose(&ra, &rb).unwrap();
+            prop_assert_eq!(lhs, rhs);
+        }
+
+        /// The empty action word maps to the empty dispatch word — identity
+        /// preservation (F(id) = id).
+        #[test]
+        fn prop_realization_preserves_identity(_n in 0u8..1) {
+            let id_src = ActionAlgebra::identity(&WmSurface::Compositor);
+            let mapped = HyprlandRealization::map_morphism(&id_src);
+            prop_assert_eq!(mapped, DispatchAlgebra::identity(&WmSurface::Compositor));
+        }
+
+        /// Every single action realizes to a non-empty dispatcher sequence
+        /// (totality), and the rendered command's head token is a known
+        /// dispatcher — there are no unbound placeholders left in the wire form.
+        #[test]
+        fn prop_single_action_realizes_nonempty(a in arb_action()) {
+            let w = HyprlandRealization::map_morphism(&ActionWord::from(a));
+            prop_assert!(!w.0.is_empty());
+            let cmd = w.command();
+            prop_assert!(!cmd.is_empty());
+            // head token (before the first comma/space) is non-empty and lowercase.
+            let head: String = cmd.chars().take_while(|c| *c != ',' && *c != ' ').collect();
+            prop_assert!(!head.is_empty());
+            prop_assert_eq!(&head, &head.to_lowercase());
+        }
+
+        /// Realization is deterministic: same action, same command string.
+        #[test]
+        fn prop_realization_deterministic(a in arb_action()) {
+            prop_assert_eq!(realize(&a), realize(&a));
+        }
+
+        /// Concatenation in the action monoid is associative (the free-monoid law
+        /// the functor's source category rests on).
+        #[test]
+        fn prop_action_concat_associative(a in arb_word(), b in arb_word(), c in arb_word()) {
+            let ab = ActionAlgebra::compose(&a, &b).unwrap();
+            let bc = ActionAlgebra::compose(&b, &c).unwrap();
+            let left = ActionAlgebra::compose(&ab, &c).unwrap();
+            let right = ActionAlgebra::compose(&a, &bc).unwrap();
+            prop_assert_eq!(left, right);
+        }
+    }
+}


### PR DESCRIPTION
## What

Models window-manager keybinding actions as a typed **ontology** rather than raw Hyprland dispatcher strings. This is the ontological remodel that **supersedes** the original string-based preset lift on this branch — the Copilot review surfaced the real gap: `Action.command: String` conflated intent + parameters + mechanism in one opaque string.

## The three layers

An action now factors into layers that were previously fused in one string:

- **Intent** — `WmAction` (focus, fullscreen, workspace, close, exec, …)
- **Parameters** — typed: `Direction`, `FullscreenMode`, `WorkspaceTarget`, `Follow`, `Cycle`
- **Mechanism** — `Dispatch`, rendered to the compositor command at **one** wire boundary (`Dispatch::render`)

connected by `HyprlandRealization : ActionAlgebra → DispatchAlgebra`, a **strict, total monoid functor** (free monoid of abstract actions → free monoid of dispatcher sequences), machine-proven via `functor_law_axioms`. "The runtime is a functor of the ontology" — the same pattern as the existing `RuntimeEffects` precedent.

## Grounding (the source spine)

Established by a literature sweep — deliberately *not* a single product's config schema — and cited per concept/axiom and in `citings.md`:

Myers 1988 (WM taxonomy; functionality-vs-UI = intent-vs-mechanism), Card-Moran-Newell 1983 GOMS (goal ⟂ method), Goguen-Thatcher-Wagner 1978 (initial algebra's unique homomorphism), Payne & Green 1986 (typed features / rule-schema), EWMH (named atoms; maximize ≠ fullscreen), Foley & van Dam 1982 (lexical lowering), Mac Lane 1971 (functor laws), Reiter 1978 (open-world).

## Three fixes fall out of the model

- **maximize** = `Fullscreen(Maximized)` → `fullscreen, 1` (vs default `fullscreen`) — asserted by `FullscreenModeDistinct`
- **hide/minimize** = a silent move to a special workspace (no Minimize concept)
- **float+pin** = the composite `[ToggleFloat, Pin]`, realized as one derived `exec` batch — asserted by `CompositeSequencePreserved`

## Tests

`functor_law_axioms` (identity + composition preservation), `LoweringTotal`, plus property tests (homomorphism, identity, totality, determinism, associativity). Full `dev-ci` green (fmt/clippy/check/test/docs). Validated end-to-end against vogix, which now consumes these presets **byte-identically** to its deployed layout.

`WmAction` is open-world (`Exec` carries arbitrary external data), so it implements `Concept` but not `FinitelyGenerated`.
