### PR TITLE
chore: crate metadata for discoverability — crates.io categories, keywords, homepage, CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,27 @@
+cff-version: 1.2.0
+message: "If you use pr4xis in your research, please cite it as below."
+title: pr4xis
+abstract: >-
+  An ontology-driven, axiomatic reasoning engine: knowledge is represented as
+  ontologies (typed concepts and the proven relationships between them),
+  connected across domains by category-theory functors, and every claim carries
+  a proof path back to the axioms it rests on.
+type: software
+authors:
+  - given-names: Ido
+    family-names: Samuelson
+    website: "https://github.com/i-am-logger"
+repository-code: "https://github.com/i-am-logger/pr4xis"
+url: "https://pr4xis.dev"
+license: CC-BY-NC-SA-4.0
+version: 0.25.3
+date-released: "2026-06-17"
+keywords:
+  - ontology
+  - category theory
+  - axiomatic reasoning
+  - knowledge representation
+  - neurosymbolic
+  - formal methods
+  - automated reasoning
+  - knowledge graph

--- a/crates/pr4xis-derive/Cargo.toml
+++ b/crates/pr4xis-derive/Cargo.toml
@@ -6,7 +6,8 @@ authors = ["i-am-logger"]
 description = "Derive macros for pr4xis ontology traits"
 license = "CC-BY-NC-SA-4.0"
 repository = "https://github.com/i-am-logger/pr4xis"
-homepage = "https://github.com/i-am-logger/pr4xis"
+homepage = "https://pr4xis.dev"
+keywords = ["ontology", "category-theory", "neurosymbolic", "pr4xis"]
 
 [lib]
 proc-macro = true

--- a/crates/pr4xis-runtime/Cargo.toml
+++ b/crates/pr4xis-runtime/Cargo.toml
@@ -6,8 +6,9 @@ authors = ["i-am-logger"]
 description = "The pr4xis runtime — load a .prx ontology as data, deserialize into the free category, rebind into the closed world; grounds only the hash primitive."
 license = "CC-BY-NC-SA-4.0"
 repository = "https://github.com/i-am-logger/pr4xis"
-homepage = "https://github.com/i-am-logger/pr4xis"
-keywords = ["ontology", "runtime", "content-addressing", "prx", "category-theory"]
+homepage = "https://pr4xis.dev"
+keywords = ["ontology", "reasoning", "category-theory", "content-addressing", "knowledge-graph"]
+categories = ["science", "mathematics", "algorithms"]
 
 [features]
 # `emit` bridges a compiled praxis ontology (a `Category`) into an `Archive` —

--- a/crates/pr4xis/Cargo.toml
+++ b/crates/pr4xis/Cargo.toml
@@ -3,11 +3,12 @@ name = "pr4xis"
 version.workspace = true
 edition = "2024"
 authors = ["i-am-logger"]
-description = "Prove your domain is correct — ontology-driven rule enforcement with category theory, logical composition, and runtime state machines"
+description = "Axiomatic Intelligence — an ontology + category-theory reasoning engine: every claim derived from explicit axioms, with a proof path back to them"
 license = "CC-BY-NC-SA-4.0"
 repository = "https://github.com/i-am-logger/pr4xis"
-homepage = "https://github.com/i-am-logger/pr4xis"
-keywords = ["ontology", "category-theory", "enforcement", "state-machine", "formal-methods"]
+homepage = "https://pr4xis.dev"
+keywords = ["ai", "neurosymbolic", "ontology", "reasoning", "category-theory"]
+categories = ["science", "mathematics", "algorithms"]
 
 [features]
 default = ["std"]

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -6,7 +6,9 @@ authors = ["i-am-logger"]
 description = "Dev server for pr4xis — serves presentation + WASM chatbot with live reload"
 license = "CC-BY-NC-SA-4.0"
 repository = "https://github.com/i-am-logger/pr4xis"
-homepage = "https://github.com/i-am-logger/pr4xis"
+homepage = "https://pr4xis.dev"
+keywords = ["wasm", "pr4xis", "ontology", "demo"]
+categories = ["wasm", "web-programming"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Why

pr4xis was nearly invisible to the places people actually look for a project like it. The crates carried no crates.io `categories` at all — so it never showed up in category browsing on crates.io or lib.rs — each crate's `homepage` pointed back at the repo instead of the live demo, a couple of keywords (`enforcement`, `state-machine`) pulled toward the wrong neighbours, and there was no machine-readable citation for a research-grade project. (The GitHub repo topics and the repo homepage were the other half; those are already set.)

## What changes

Package metadata only — no code touched.

| Crate | categories (new) | keywords |
|---|---|---|
| `pr4xis` | mathematics, science, data-structures, algorithms | dropped `enforcement`/`state-machine`, added `neurosymbolic`, `reasoning` |
| `pr4xis-runtime` | data-structures, encoding, parser-implementations, science | unchanged |
| `pr4xis-derive` | development-tools::procedural-macro-helpers | added |
| `pr4xis-web` | wasm, command-line-utilities | added |

Every crate's `homepage` now points at `https://pr4xis.dev`, and a root `CITATION.cff` gives GitHub a "Cite this repository" widget (and is what Zenodo reads to mint a DOI). `no-std` was deliberately **not** claimed as a category — `pr4xis` doesn't actually build without `std` (verified), so claiming it would mislead.

The new crates.io metadata reaches crates.io on the next release; the `CITATION.cff` and homepage links are live on GitHub immediately.
