### PR TITLE
feat(deps): update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     name: Build (host + test archive + data)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           lfs: false
           submodules: recursive
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           lfs: false
           submodules: recursive
@@ -197,7 +197,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           lfs: false
           submodules: recursive
@@ -269,7 +269,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           lfs: false
           submodules: recursive
@@ -352,7 +352,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -362,7 +362,7 @@ jobs:
     name: No ignored doctests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Forbid ```ignore in code/docs
         run: |
           if command grep -rn '```ignore' crates/ docs/ --include='*.rs' --include='*.md' ; then
@@ -380,7 +380,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           lfs: false
           submodules: recursive
@@ -482,7 +482,7 @@ jobs:
       releases_created: ${{ steps.release-plz.outputs.releases_created }}
       releases: ${{ steps.release-plz.outputs.releases }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
@@ -528,7 +528,7 @@ jobs:
       group: release-plz-pr-${{ github.ref }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.release.tag_name, 'pr4xis-v')
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           lfs: false
           submodules: recursive


### PR DESCRIPTION
Bumps GitHub Actions to their latest releases.

| action | old → new |
|---|---|
| actions/checkout | v6 → v7 |

All other action pins are already at latest; rolling refs (`dtolnay/rust-toolchain@stable`, `taiki-e/install-action@cargo-*`) left untouched. `actionlint` clean. Major bump is the node24 runtime only — no behaviour change.