### PR TITLE
feat(input): generalize the WM-action ontology — backend-independent, with a Sway realization

### DIFF
--- a/crates/domains/data/hmi/ewmh-wm-state.tsv
+++ b/crates/domains/data/hmi/ewmh-wm-state.tsv
@@ -1,0 +1,28 @@
+# Window-state atom vocabulary — the controlled set of window STATES an action
+# adds/removes/toggles. LOADED, not hand-encoded: this is the authoritative
+# source the StateBit enum is machine-checked complete-and-sound against
+# (window_state::VocabularyComplete).
+#
+# Primary source: EWMH (Extended Window Manager Hints) v1.5, freedesktop.org,
+# section "Application Window Properties" — _NET_WM_STATE (the 13 state atoms)
+# and _NET_WM_STATE mutation { _NET_WM_STATE_REMOVE=0, _ADD=1, _TOGGLE=2 }.
+# https://specifications.freedesktop.org/wm-spec/1.5/ar01s05.html
+# The final two rows are cited compositor extensions for the tiling layer that
+# EWMH (an X11/stacking spec) does not name — sourced as marked.
+#
+# bit_name<TAB>spec_atom<TAB>source
+modal	_NET_WM_STATE_MODAL	EWMH 1.5 §5
+sticky	_NET_WM_STATE_STICKY	EWMH 1.5 §5
+maximized-vert	_NET_WM_STATE_MAXIMIZED_VERT	EWMH 1.5 §5
+maximized-horz	_NET_WM_STATE_MAXIMIZED_HORZ	EWMH 1.5 §5
+shaded	_NET_WM_STATE_SHADED	EWMH 1.5 §5
+skip-taskbar	_NET_WM_STATE_SKIP_TASKBAR	EWMH 1.5 §5
+skip-pager	_NET_WM_STATE_SKIP_PAGER	EWMH 1.5 §5
+hidden	_NET_WM_STATE_HIDDEN	EWMH 1.5 §5
+fullscreen	_NET_WM_STATE_FULLSCREEN	EWMH 1.5 §5
+above	_NET_WM_STATE_ABOVE	EWMH 1.5 §5
+below	_NET_WM_STATE_BELOW	EWMH 1.5 §5
+demands-attention	_NET_WM_STATE_DEMANDS_ATTENTION	EWMH 1.5 §5
+focused	_NET_WM_STATE_FOCUSED	EWMH 1.5 §5
+floating	xdg_toplevel(tiled-states absent) / wlr "floating"	Wayland xdg-shell + wlroots
+pseudo-tiled	node flag "pseudo_tiled"	bspwm(1)

--- a/crates/domains/src/applied/hmi/input/citings.md
+++ b/crates/domains/src/applied/hmi/input/citings.md
@@ -26,6 +26,18 @@ The spine grounding the abstract action vocabulary, its typed parameters, and th
 - Plotkin & Power 2003: *Algebraic Operations and Generic Effects* — sequenced effects compose in the free monoid (the composite-action realization)
 - Hyprland dispatchers — <https://wiki.hyprland.org/Configuring/Dispatchers/> — the realization vocabulary the `Dispatch` enum names
 
+### Generalized, backend-independent layer (`window_state.rs`, the operation vocabulary, `SwayRealization`)
+
+The state-as-a-lattice restructure, the cross-system operation vocabulary, and the second backend that proves the source is backend-independent — grounded in the cross-implementation standards and the tiling-WM literature, not one compositor's config.
+
+- EWMH v1.5 2013 §5 — `_NET_WM_STATE`: the 13 window-state atoms (the `StateBit` vocabulary, **loaded** from `data/hmi/ewmh-wm-state.tsv` and machine-checked complete by `VocabularyComplete`) and the `_NET_WM_STATE_REMOVE=0 / _ADD=1 / _TOGGLE=2` mutation algebra — <https://specifications.freedesktop.org/wm-spec/1.5/ar01s05.html>
+- Boolean algebra / set theory — `2^StateBit` is a Boolean algebra; symmetric difference makes it the elementary abelian 2-group where every element is self-inverse — the `StateToggleInvolutive` law, proven exhaustively over all 2¹⁵ states in `window_state.rs`
+- ICCCM — `WM_STATE` {Withdrawn, Normal, Iconic}: the mutually-exclusive lifecycle 3-state machine, kept DISTINCT from the EWMH state set (modelling it is a tracked deferral) — <https://x.org/releases/X11R7.6/doc/xorg-docs/specs/ICCCM/icccm.html>
+- i3 User's Guide — <https://i3wm.org/docs/userguide.html> — the tiling command language sway inherits: `split`, `layout`, `focus parent|child|mode_toggle`, `focus output`, `move container to output`, `workspace back_and_forth`, `rename workspace` (the `Orientation` / `LayoutKind` / `FocusBy::Tree`+`Layer` / `OutputSel` / `WorkspaceTarget::Last` / `RenameWorkspace` vocabularies)
+- sway(5) — <https://man.archlinux.org/man/sway.5> — the exact command strings the `SwayRealization` functor emits (the second backend that makes the generality load-bearing)
+- bspwm(1) — <https://github.com/baskerville/bspwm> — `pseudo_tiled` as a first-class node state (the one tiling state EWMH does not name)
+- Wayland `xdg-shell` + wlroots — the floating layer (`xdg_toplevel` tiled states); `ext-workspace-v1` — the workspace lifecycle (create/activate/remove) and the per-backend `capabilities` enum that models unsupported operations explicitly rather than silently inert (the `RealizationMatchesCapability` discipline)
+
 ## Cross-references
 
 - Workspace bibliography: [`docs/papers/references.md`](../../../../../../docs/papers/references.md)
@@ -44,5 +56,5 @@ Open items for human review:
 
 ---
 
-- **Document date:** 2026-04-15
+- **Document date:** 2026-06-19 (generalized backend-independent layer + SwayRealization added)
 - **How this file is maintained:** initialized by the per-ontology rollout (issue #57 / #173) from `README.md`'s *Key references* section. Update by hand as code-comment citations, local PDFs, and `docs/papers/references.md` entries are added.

--- a/crates/domains/src/applied/hmi/input/keybindings.rs
+++ b/crates/domains/src/applied/hmi/input/keybindings.rs
@@ -15,7 +15,7 @@ use hashbrown::{HashMap, HashSet};
 /// - XKB specification: modifier model (Shift, Ctrl, Alt, Super, Hyper)
 use super::modes::ModeId;
 use super::wm_action::{
-    ActionWord, Cycle, Direction, Follow, HyprlandRealization, Orientation, OutputSel,
+    ActionWord, Cycle, Direction, Follow, HyprlandRealization, LayoutKind, Orientation, OutputSel,
     SubmapTarget, WmAction, WorkspaceTarget,
 };
 use pr4xis::category::Functor;
@@ -767,6 +767,54 @@ pub fn i3_preset() -> BindingSet {
             .with_mod(Modifier::Shift),
         app.clone(),
         Action::new("float", "Toggle floating", WmAction::toggle_float()),
+        false,
+    );
+
+    // Container layout + tree focus (i3 `layout`, `focus parent`, `focus
+    // mode_toggle`). NOTE: focus-parent, focus-layer and the stacking layout have
+    // NO Hyprland dispatcher — inert on Hyprland (capability gaps), realized
+    // natively on Sway.
+    for (c, name, desc, action) in [
+        (
+            'a',
+            "focus_parent",
+            "Focus parent container",
+            WmAction::focus_parent(),
+        ),
+        (
+            's',
+            "layout_stacking",
+            "Stacking layout",
+            WmAction::layout(LayoutKind::Stacking),
+        ),
+        (
+            'w',
+            "layout_tabbed",
+            "Tabbed layout",
+            WmAction::layout(LayoutKind::Tabbed),
+        ),
+        (
+            'e',
+            "layout_toggle_split",
+            "Toggle split layout",
+            WmAction::toggle_split(),
+        ),
+    ] {
+        bs.add(
+            KeyCombo::new(Key::Letter(c)).with_mod(Modifier::Super),
+            app.clone(),
+            Action::new(name, desc, action),
+            false,
+        );
+    }
+    bs.add(
+        KeyCombo::new(Key::Named(NamedKey::Space)).with_mod(Modifier::Super),
+        app.clone(),
+        Action::new(
+            "focus_layer",
+            "Focus tiling/floating layer",
+            WmAction::focus_layer(),
+        ),
         false,
     );
 

--- a/crates/domains/src/applied/hmi/input/keybindings.rs
+++ b/crates/domains/src/applied/hmi/input/keybindings.rs
@@ -858,21 +858,75 @@ pub fn i3_preset() -> BindingSet {
     bs
 }
 
-/// tmux-style keybindings — prefix key (Ctrl+B) then action key.
+/// tmux-style keybindings — a `Ctrl+B` PREFIX that drives WINDOW MANAGEMENT in the
+/// tmux idiom (panes -> windows, windows -> workspaces). The prefix is REACHABLE
+/// (an `app` passthrough root binds `Ctrl+B` to enter the submap) and EXITABLE
+/// (`Escape` returns to the root) — the previous preset authored a `tmux-prefix`
+/// mode that nothing entered and nothing exited. In-terminal tmux functions
+/// (copy-mode, the command prompt) are NOT bound; they pass through to the app.
 ///
-/// Source: tmux(1) man page, vi copy mode conventions
+/// Source: tmux(1) DEFAULT KEY BINDINGS — the prefix idiom and the
+/// window/pane/zoom/split mnemonics.
 pub fn tmux_preset() -> BindingSet {
     let mut bs = BindingSet::new("tmux");
+    let app = ModeId::new("app");
     let prefix = ModeId::new("tmux-prefix");
 
-    // Window management
+    // Enter the prefix submap with Ctrl+B (the tmux prefix); Escape leaves it.
+    bs.add(
+        KeyCombo::new(Key::Letter('b')).with_mod(Modifier::Ctrl),
+        app,
+        Action::new(
+            "enter_prefix",
+            "tmux prefix (Ctrl+B)",
+            WmAction::Submap(SubmapTarget::Enter(ModeId::new("tmux-prefix"))),
+        ),
+        false,
+    );
+    bs.add(
+        KeyCombo::new(Key::Named(NamedKey::Escape)),
+        prefix.clone(),
+        Action::new(
+            "exit_prefix",
+            "Leave the tmux prefix",
+            WmAction::Submap(SubmapTarget::Reset),
+        ),
+        false,
+    );
+
+    // Pane focus (prefix + hjkl / arrows) — panes are WM windows.
+    for (c, key, dir, dname) in [
+        ('h', NamedKey::Left, Direction::Left, "left"),
+        ('j', NamedKey::Down, Direction::Down, "down"),
+        ('k', NamedKey::Up, Direction::Up, "up"),
+        ('l', NamedKey::Right, Direction::Right, "right"),
+    ] {
+        bs.add(
+            KeyCombo::new(Key::Letter(c)),
+            prefix.clone(),
+            Action::new(format!("focus_{c}"), "Focus pane", WmAction::focus(dir)),
+            false,
+        );
+        bs.add(
+            KeyCombo::new(Key::Named(key)),
+            prefix.clone(),
+            Action::new(
+                format!("focus_arrow_{dname}"),
+                "Focus pane",
+                WmAction::focus(dir),
+            ),
+            false,
+        );
+    }
+
+    // Windows -> workspaces: prefix + c new, n/p next/prev, 1..9 by index.
     bs.add(
         KeyCombo::new(Key::Letter('c')),
         prefix.clone(),
         Action::new(
             "new_window",
-            "Create new window",
-            WmAction::Exec("tmux new-window".to_string()),
+            "New window (spawn terminal)",
+            WmAction::Exec("$TERMINAL".to_string()),
         ),
         false,
     );
@@ -882,7 +936,7 @@ pub fn tmux_preset() -> BindingSet {
         Action::new(
             "next_window",
             "Next window",
-            WmAction::Exec("tmux next-window".to_string()),
+            WmAction::Workspace(WorkspaceTarget::Relative(1)),
         ),
         false,
     );
@@ -892,43 +946,43 @@ pub fn tmux_preset() -> BindingSet {
         Action::new(
             "prev_window",
             "Previous window",
-            WmAction::Exec("tmux previous-window".to_string()),
+            WmAction::Workspace(WorkspaceTarget::Relative(-1)),
         ),
         false,
     );
-    bs.add(
-        KeyCombo::new(Key::Letter('l')),
-        prefix.clone(),
-        Action::new(
-            "last_window",
-            "Last window",
-            WmAction::Exec("tmux last-window".to_string()),
-        ),
-        false,
-    );
-
-    // Window numbers
-    for i in 0u8..=9 {
+    for i in 1u8..=9 {
         bs.add(
             KeyCombo::new(Key::Number(i)),
             prefix.clone(),
             Action::new(
                 format!("window_{i}"),
-                format!("Switch to window {i}"),
-                WmAction::Exec(format!("tmux select-window -t {i}")),
+                "Select window",
+                WmAction::Workspace(WorkspaceTarget::Index(i)),
             ),
             false,
         );
     }
 
-    // Pane splitting
+    // Pane verbs: zoom -> fullscreen, x -> close, splits, detach -> minimize.
+    bs.add(
+        KeyCombo::new(Key::Letter('z')),
+        prefix.clone(),
+        Action::new("zoom", "Zoom (fullscreen)", WmAction::fullscreen()),
+        false,
+    );
+    bs.add(
+        KeyCombo::new(Key::Letter('x')),
+        prefix.clone(),
+        Action::new("kill_pane", "Close pane", WmAction::Close),
+        false,
+    );
     bs.add(
         KeyCombo::new(Key::Letter('%')),
         prefix.clone(),
         Action::new(
-            "split_v",
-            "Split pane vertical",
-            WmAction::Exec("tmux split-window -h".to_string()),
+            "split_h",
+            "Split side-by-side",
+            WmAction::Split(Orientation::Horizontal),
         ),
         false,
     );
@@ -936,71 +990,16 @@ pub fn tmux_preset() -> BindingSet {
         KeyCombo::new(Key::Letter('"')),
         prefix.clone(),
         Action::new(
-            "split_h",
-            "Split pane horizontal",
-            WmAction::Exec("tmux split-window -v".to_string()),
+            "split_v",
+            "Split stacked",
+            WmAction::Split(Orientation::Vertical),
         ),
         false,
     );
-
-    // Pane navigation (arrows — hjkl conflicts with window commands in default tmux)
-    for (key, dir, name) in [
-        (NamedKey::Left, "L", "left"),
-        (NamedKey::Down, "D", "down"),
-        (NamedKey::Up, "U", "up"),
-        (NamedKey::Right, "R", "right"),
-    ] {
-        bs.add(
-            KeyCombo::new(Key::Named(key)),
-            prefix.clone(),
-            Action::new(
-                format!("pane_{name}"),
-                format!("Focus pane {name}"),
-                WmAction::Exec(format!("tmux select-pane -{dir}")),
-            ),
-            false,
-        );
-    }
-
-    // Session/pane management
     bs.add(
         KeyCombo::new(Key::Letter('d')),
-        prefix.clone(),
-        Action::new(
-            "detach",
-            "Detach session",
-            WmAction::Exec("tmux detach".to_string()),
-        ),
-        false,
-    );
-    bs.add(
-        KeyCombo::new(Key::Letter('z')),
-        prefix.clone(),
-        Action::new(
-            "zoom",
-            "Toggle pane zoom",
-            WmAction::Exec("tmux resize-pane -Z".to_string()),
-        ),
-        false,
-    );
-    bs.add(
-        KeyCombo::new(Key::Letter('x')),
-        prefix.clone(),
-        Action::new(
-            "kill_pane",
-            "Kill pane",
-            WmAction::Exec("tmux kill-pane".to_string()),
-        ),
-        false,
-    );
-    bs.add(
-        KeyCombo::new(Key::Letter('?')),
         prefix,
-        Action::new(
-            "help",
-            "List keybindings",
-            WmAction::Exec("tmux list-keys".to_string()),
-        ),
+        Action::new("detach", "Detach (minimize)", WmAction::minimize()),
         false,
     );
 
@@ -2023,15 +2022,39 @@ mod tests {
     }
 
     #[test]
-    fn test_tmux_has_pane_navigation() {
+    fn test_tmux_prefix_is_reachable_and_exitable() {
+        // The previous preset shipped a tmux-prefix mode that NOTHING entered and
+        // NOTHING exited. Now an `app` root binds Ctrl+B to enter it, and Escape
+        // exits — and pane focus lives in the prefix submap.
         let bs = tmux_preset();
+        let app = ModeId::new("app");
         let prefix = ModeId::new("tmux-prefix");
-        let bindings = bs.for_mode(&prefix);
-        let names: Vec<_> = bindings.iter().map(|b| b.action.name.as_str()).collect();
-        assert!(names.contains(&"pane_left"));
-        assert!(names.contains(&"pane_down"));
-        assert!(names.contains(&"pane_up"));
-        assert!(names.contains(&"pane_right"));
+        let app_names: Vec<_> = bs
+            .for_mode(&app)
+            .iter()
+            .map(|b| b.action.name.as_str())
+            .collect();
+        assert!(
+            app_names.contains(&"enter_prefix"),
+            "Ctrl+B enters the prefix"
+        );
+        let prefix_names: Vec<_> = bs
+            .for_mode(&prefix)
+            .iter()
+            .map(|b| b.action.name.as_str())
+            .collect();
+        assert!(
+            prefix_names.contains(&"exit_prefix"),
+            "Escape exits the prefix"
+        );
+        assert!(
+            prefix_names.contains(&"focus_h"),
+            "prefix + h focuses a pane"
+        );
+        assert!(
+            prefix_names.contains(&"focus_arrow_left"),
+            "prefix + Left focuses a pane"
+        );
     }
 
     // ── Cross-preset tests ──

--- a/crates/domains/src/applied/hmi/input/keybindings.rs
+++ b/crates/domains/src/applied/hmi/input/keybindings.rs
@@ -15,8 +15,8 @@ use hashbrown::{HashMap, HashSet};
 /// - XKB specification: modifier model (Shift, Ctrl, Alt, Super, Hyper)
 use super::modes::ModeId;
 use super::wm_action::{
-    ActionWord, Cycle, Direction, Follow, HyprlandRealization, Orientation, SubmapTarget, WmAction,
-    WorkspaceTarget,
+    ActionWord, Cycle, Direction, Follow, HyprlandRealization, Orientation, OutputSel,
+    SubmapTarget, WmAction, WorkspaceTarget,
 };
 use pr4xis::category::Functor;
 use pr4xis::logic::proof::{SimpleCounterexample, SimpleProof, Verdict};
@@ -347,71 +347,150 @@ pub fn vim_preset() -> BindingSet {
     bs
 }
 
-/// CUA/Windows-style keybindings — standard PC shortcuts.
+/// CUA / Windows-style keybindings — the *window-management* keys of the IBM CUA
+/// standard (Alt+Tab, Alt+F4) plus the Windows Win-key conventions (snap, virtual
+/// desktops, move-to-monitor). The in-app accelerators (Ctrl+C/V/X/Z/S/A/F/N/O/P/
+/// T/W) are deliberately NOT bound — they pass through to the focused application
+/// (this is a window-manager paradigm, not an editor).
 ///
-/// Source: IBM CUA specification (1987), Microsoft Windows UX Guidelines
+/// Source: IBM Common User Access (SAA CUA, 1987) — Alt+Tab task-switch, Alt+F4
+/// close; Microsoft "Keyboard shortcuts in Windows" — Win+arrows snap/maximize/
+/// minimize, Win+Shift+arrows move-to-monitor, Win+number virtual desktop,
+/// Win+Ctrl+arrows switch desktop, Win+Tab Task View.
 pub fn cua_preset() -> BindingSet {
     let mut bs = BindingSet::new("cua");
     let app = ModeId::new("app");
 
-    let binds = [
-        ('c', "copy", "Copy", WmAction::Exec("wl-copy".to_string())),
-        (
-            'v',
-            "paste",
-            "Paste",
-            WmAction::Exec("wl-paste".to_string()),
-        ),
-        ('x', "cut", "Cut", WmAction::Exec("wl-copy".to_string())),
-        ('z', "undo", "Undo", WmAction::Exec("undo".to_string())),
-        ('s', "save", "Save", WmAction::Exec("save".to_string())),
-        (
-            'a',
-            "select_all",
-            "Select all",
-            WmAction::Exec("select-all".to_string()),
-        ),
-        ('f', "find", "Find", WmAction::Exec("find".to_string())),
-        (
-            'n',
-            "new_window",
-            "New window",
-            WmAction::Exec("new-window".to_string()),
-        ),
-        ('o', "open", "Open file", WmAction::Exec("open".to_string())),
-        ('p', "print", "Print", WmAction::Exec("print".to_string())),
-        ('w', "close_tab", "Close tab", WmAction::Close),
-        (
-            't',
-            "new_tab",
-            "New tab",
-            WmAction::Exec("new-tab".to_string()),
-        ),
-    ];
-    for (c, name, desc, action) in binds {
-        bs.add(
-            KeyCombo::new(Key::Letter(c)).with_mod(Modifier::Ctrl),
-            app.clone(),
-            Action::new(name, desc, action),
-            false,
-        );
-    }
-
-    // Alt+F4 = quit
-    bs.add(
-        KeyCombo::new(Key::Function(4)).with_mod(Modifier::Alt),
-        app.clone(),
-        Action::new("quit", "Quit application", WmAction::Close),
-        false,
-    );
-    // Alt+Tab = switch window
+    // App switching (Alt+Tab / Alt+Shift+Tab).
     bs.add(
         KeyCombo::new(Key::Named(NamedKey::Tab)).with_mod(Modifier::Alt),
-        app,
+        app.clone(),
         Action::new(
             "switch_window",
             "Switch window",
             WmAction::cycle_window(Cycle::Forward),
+        ),
+        false,
+    );
+    bs.add(
+        KeyCombo::new(Key::Named(NamedKey::Tab))
+            .with_mod(Modifier::Alt)
+            .with_mod(Modifier::Shift),
+        app.clone(),
+        Action::new(
+            "switch_window_back",
+            "Switch window (reverse)",
+            WmAction::cycle_window(Cycle::Backward),
+        ),
+        false,
+    );
+    // Close the focused WINDOW (Alt+F4). Ctrl+W closes a TAB — the app's concern.
+    bs.add(
+        KeyCombo::new(Key::Function(4)).with_mod(Modifier::Alt),
+        app.clone(),
+        Action::new("close", "Close window", WmAction::Close),
+        false,
+    );
+
+    // Window snap left/right (Win+arrows) + maximize/minimize (Win+Up/Down).
+    bs.add(
+        KeyCombo::new(Key::Named(NamedKey::Left)).with_mod(Modifier::Super),
+        app.clone(),
+        Action::new(
+            "snap_left",
+            "Snap left",
+            WmAction::MoveWindow(Direction::Left),
+        ),
+        false,
+    );
+    bs.add(
+        KeyCombo::new(Key::Named(NamedKey::Right)).with_mod(Modifier::Super),
+        app.clone(),
+        Action::new(
+            "snap_right",
+            "Snap right",
+            WmAction::MoveWindow(Direction::Right),
+        ),
+        false,
+    );
+    bs.add(
+        KeyCombo::new(Key::Named(NamedKey::Up)).with_mod(Modifier::Super),
+        app.clone(),
+        Action::new("maximize", "Maximize", WmAction::maximize()),
+        false,
+    );
+    bs.add(
+        KeyCombo::new(Key::Named(NamedKey::Down)).with_mod(Modifier::Super),
+        app.clone(),
+        Action::new("minimize", "Minimize", WmAction::minimize()),
+        false,
+    );
+
+    // Move window to the monitor in a direction (Win+Shift+arrows).
+    for (key, dir, name) in [
+        (NamedKey::Left, Direction::Left, "left"),
+        (NamedKey::Right, Direction::Right, "right"),
+    ] {
+        bs.add(
+            KeyCombo::new(Key::Named(key))
+                .with_mod(Modifier::Super)
+                .with_mod(Modifier::Shift),
+            app.clone(),
+            Action::new(
+                format!("to_monitor_{name}"),
+                format!("Move to monitor {name}"),
+                WmAction::move_to_monitor(OutputSel::Direction(dir)),
+            ),
+            false,
+        );
+    }
+
+    // Virtual desktops: Win+1..9 switch.
+    for i in 1u8..=9 {
+        bs.add(
+            KeyCombo::new(Key::Number(i)).with_mod(Modifier::Super),
+            app.clone(),
+            Action::new(
+                format!("desktop_{i}"),
+                format!("Virtual desktop {i}"),
+                WmAction::Workspace(WorkspaceTarget::Index(i)),
+            ),
+            false,
+        );
+    }
+    // Win+Ctrl+Left/Right switch the adjacent desktop.
+    bs.add(
+        KeyCombo::new(Key::Named(NamedKey::Left))
+            .with_mod(Modifier::Super)
+            .with_mod(Modifier::Ctrl),
+        app.clone(),
+        Action::new(
+            "desktop_prev",
+            "Previous desktop",
+            WmAction::Workspace(WorkspaceTarget::Relative(-1)),
+        ),
+        false,
+    );
+    bs.add(
+        KeyCombo::new(Key::Named(NamedKey::Right))
+            .with_mod(Modifier::Super)
+            .with_mod(Modifier::Ctrl),
+        app.clone(),
+        Action::new(
+            "desktop_next",
+            "Next desktop",
+            WmAction::Workspace(WorkspaceTarget::Relative(1)),
+        ),
+        false,
+    );
+    // Task View overview (Win+Tab).
+    bs.add(
+        KeyCombo::new(Key::Named(NamedKey::Tab)).with_mod(Modifier::Super),
+        app,
+        Action::new(
+            "overview",
+            "Task view",
+            WmAction::ToggleSpecialWorkspace("overview".to_string()),
         ),
         false,
     );
@@ -1741,14 +1820,24 @@ mod tests {
     }
 
     #[test]
-    fn test_cua_has_copy_paste() {
+    fn test_cua_is_wm_not_inapp() {
+        // The WM-paradigm cua binds the global window-management keys (Alt+Tab /
+        // Alt+F4 / Win-key) — the in-app accelerators (copy/paste/save/find) are
+        // NOT bound; they pass through to the focused application.
         let bs = cua_preset();
         let app = ModeId::new("app");
         let bindings = bs.for_mode(&app);
         let names: Vec<_> = bindings.iter().map(|b| b.action.name.as_str()).collect();
-        assert!(names.contains(&"copy"));
-        assert!(names.contains(&"paste"));
-        assert!(names.contains(&"cut"));
+        assert!(names.contains(&"switch_window"), "Alt+Tab switch");
+        assert!(names.contains(&"close"), "Alt+F4 close");
+        assert!(names.contains(&"desktop_1"), "Win+1 desktop");
+        assert!(names.contains(&"maximize"), "Win+Up maximize");
+        for stub in ["copy", "paste", "cut", "save", "find", "undo", "select_all"] {
+            assert!(
+                !names.contains(&stub),
+                "in-app `{stub}` must pass through, not be bound"
+            );
+        }
     }
 
     // ── emacs preset ──

--- a/crates/domains/src/applied/hmi/input/keybindings.rs
+++ b/crates/domains/src/applied/hmi/input/keybindings.rs
@@ -597,7 +597,7 @@ pub fn i3_preset() -> BindingSet {
     bs.add(
         KeyCombo::new(Key::Letter('f')).with_mod(Modifier::Super),
         app.clone(),
-        Action::new("fullscreen", "Toggle fullscreen", WmAction::Fullscreen),
+        Action::new("fullscreen", "Toggle fullscreen", WmAction::fullscreen()),
         false,
     );
 
@@ -683,7 +683,7 @@ pub fn i3_preset() -> BindingSet {
             .with_mod(Modifier::Super)
             .with_mod(Modifier::Shift),
         app.clone(),
-        Action::new("float", "Toggle floating", WmAction::ToggleFloat),
+        Action::new("float", "Toggle floating", WmAction::toggle_float()),
         false,
     );
 
@@ -1091,7 +1091,7 @@ pub fn vogix_preset() -> BindingSet {
         Key::Letter('y'),
         "float_pin",
         "Float + pin",
-        vec![WmAction::ToggleFloat, WmAction::Pin].into(),
+        vec![WmAction::toggle_float(), WmAction::pin()].into(),
         false,
     );
     add(
@@ -1099,7 +1099,7 @@ pub fn vogix_preset() -> BindingSet {
         Key::Letter('f'),
         "fullscreen",
         "Fullscreen",
-        WmAction::Fullscreen.into(),
+        WmAction::fullscreen().into(),
         false,
     );
     add(
@@ -1107,7 +1107,7 @@ pub fn vogix_preset() -> BindingSet {
         Key::Letter('p'),
         "pseudo",
         "Pseudotile",
-        WmAction::Pseudotile.into(),
+        WmAction::pseudotile().into(),
         false,
     );
     add(
@@ -1313,7 +1313,7 @@ pub fn windows_preset() -> BindingSet {
         Key::Named(NamedKey::Up),
         "maximize",
         "Maximize window",
-        WmAction::Maximize,
+        WmAction::maximize(),
     );
 
     // Move window (Win+Shift+arrows) — adapted to a directional move.
@@ -1470,7 +1470,7 @@ pub fn macos_preset() -> BindingSet {
         Key::Letter('m'),
         "minimize",
         "Minimize window",
-        WmAction::Minimize,
+        WmAction::minimize(),
     );
     // Fullscreen (Ctrl+Cmd+F).
     add(
@@ -1478,7 +1478,7 @@ pub fn macos_preset() -> BindingSet {
         Key::Letter('f'),
         "fullscreen",
         "Toggle fullscreen",
-        WmAction::Fullscreen,
+        WmAction::fullscreen(),
     );
     bs
 }
@@ -1553,7 +1553,7 @@ pub fn linux_preset() -> BindingSet {
         Key::Named(NamedKey::Up),
         "maximize",
         "Maximize window",
-        WmAction::Maximize,
+        WmAction::maximize(),
     );
     add(
         &[Super],

--- a/crates/domains/src/applied/hmi/input/keybindings.rs
+++ b/crates/domains/src/applied/hmi/input/keybindings.rs
@@ -1398,21 +1398,29 @@ pub fn windows_preset() -> BindingSet {
         "Maximize window",
         WmAction::maximize(),
     );
+    add(
+        &[Super],
+        Key::Named(NamedKey::Down),
+        "minimize",
+        "Minimize window",
+        WmAction::minimize(),
+    );
 
-    // Move window (Win+Shift+arrows) — adapted to a directional move.
+    // Win+Shift+Left/Right move the window to the adjacent monitor (real Windows
+    // semantics); Win+Shift+Up/Down move it directionally within the layout.
     add(
         &[Super, Shift],
         Key::Named(NamedKey::Left),
-        "move_left",
-        "Move window left",
-        WmAction::MoveWindow(Direction::Left),
+        "to_monitor_left",
+        "Move window to monitor left",
+        WmAction::move_to_monitor(OutputSel::Direction(Direction::Left)),
     );
     add(
         &[Super, Shift],
         Key::Named(NamedKey::Right),
-        "move_right",
-        "Move window right",
-        WmAction::MoveWindow(Direction::Right),
+        "to_monitor_right",
+        "Move window to monitor right",
+        WmAction::move_to_monitor(OutputSel::Direction(Direction::Right)),
     );
     add(
         &[Super, Shift],
@@ -1453,6 +1461,14 @@ pub fn windows_preset() -> BindingSet {
             WmAction::Workspace(WorkspaceTarget::Index(n)),
         );
     }
+    // Task View overview (Win+Tab).
+    add(
+        &[Super],
+        Key::Named(NamedKey::Tab),
+        "overview",
+        "Task view",
+        WmAction::ToggleSpecialWorkspace("overview".to_string()),
+    );
     bs
 }
 

--- a/crates/domains/src/applied/hmi/input/keybindings.rs
+++ b/crates/domains/src/applied/hmi/input/keybindings.rs
@@ -1613,6 +1613,26 @@ pub fn linux_preset() -> BindingSet {
         WmAction::MoveToWorkspace(WorkspaceTarget::Relative(1), Follow::Follow),
     );
 
+    // Workspaces by index: Super+1..9 switch; Super+Shift+1..9 move window. (The
+    // GNOME schema reserves these numeric slots; binding them is GNOME's documented
+    // numeric-workspace mechanism, not the empty default.)
+    for i in 1u8..=9 {
+        add(
+            &[Super],
+            Key::Number(i),
+            &format!("workspace_{i}"),
+            &format!("Workspace {i}"),
+            WmAction::Workspace(WorkspaceTarget::Index(i)),
+        );
+        add(
+            &[Super, Shift],
+            Key::Number(i),
+            &format!("move_to_{i}"),
+            &format!("Move window to workspace {i}"),
+            WmAction::MoveToWorkspace(WorkspaceTarget::Index(i), Follow::Follow),
+        );
+    }
+
     // Window switch (Alt+Tab) + close (Alt+F4) — faithful.
     add(
         &[Alt],
@@ -1652,12 +1672,13 @@ pub fn linux_preset() -> BindingSet {
         "Tile window right",
         WmAction::MoveWindow(Direction::Right),
     );
+    // GNOME Super+H is MINIMIZE (not the special-workspace hide it was mapped to).
     add(
         &[Super],
         Key::Letter('h'),
-        "hide",
-        "Hide window",
-        WmAction::MoveToWorkspace(WorkspaceTarget::Special(String::new()), Follow::Silent),
+        "minimize",
+        "Minimize window",
+        WmAction::minimize(),
     );
     bs
 }

--- a/crates/domains/src/applied/hmi/input/keybindings.rs
+++ b/crates/domains/src/applied/hmi/input/keybindings.rs
@@ -15,7 +15,7 @@ use hashbrown::{HashMap, HashSet};
 /// - XKB specification: modifier model (Shift, Ctrl, Alt, Super, Hyper)
 use super::modes::ModeId;
 use super::wm_action::{
-    ActionWord, Cycle, Direction, Follow, HyprlandRealization, SubmapTarget, WmAction,
+    ActionWord, Cycle, Direction, Follow, HyprlandRealization, Orientation, SubmapTarget, WmAction,
     WorkspaceTarget,
 };
 use pr4xis::category::Functor;
@@ -675,7 +675,11 @@ pub fn i3_preset() -> BindingSet {
     bs.add(
         KeyCombo::new(Key::Letter('v')).with_mod(Modifier::Super),
         app.clone(),
-        Action::new("split_v", "Split vertical", WmAction::ToggleSplit),
+        Action::new(
+            "split_v",
+            "Split vertical",
+            WmAction::Split(Orientation::Vertical),
+        ),
         false,
     );
     bs.add(
@@ -1115,7 +1119,7 @@ pub fn vogix_preset() -> BindingSet {
         Key::Letter('o'),
         "toggle_split",
         "Toggle split",
-        WmAction::ToggleSplit.into(),
+        WmAction::toggle_split().into(),
         false,
     );
     add(

--- a/crates/domains/src/applied/hmi/input/keybindings.rs
+++ b/crates/domains/src/applied/hmi/input/keybindings.rs
@@ -291,7 +291,7 @@ pub fn vim_preset() -> BindingSet {
         Action::new(
             "move_left",
             "Move cursor left",
-            WmAction::Focus(Direction::Left),
+            WmAction::focus(Direction::Left),
         ),
         false,
     );
@@ -301,14 +301,14 @@ pub fn vim_preset() -> BindingSet {
         Action::new(
             "move_down",
             "Move cursor down",
-            WmAction::Focus(Direction::Down),
+            WmAction::focus(Direction::Down),
         ),
         false,
     );
     bs.add(
         KeyCombo::new(Key::Letter('k')),
         normal.clone(),
-        Action::new("move_up", "Move cursor up", WmAction::Focus(Direction::Up)),
+        Action::new("move_up", "Move cursor up", WmAction::focus(Direction::Up)),
         false,
     );
     bs.add(
@@ -317,7 +317,7 @@ pub fn vim_preset() -> BindingSet {
         Action::new(
             "move_right",
             "Move cursor right",
-            WmAction::Focus(Direction::Right),
+            WmAction::focus(Direction::Right),
         ),
         false,
     );
@@ -411,7 +411,7 @@ pub fn cua_preset() -> BindingSet {
         Action::new(
             "switch_window",
             "Switch window",
-            WmAction::CycleWindow(Cycle::Forward),
+            WmAction::cycle_window(Cycle::Forward),
         ),
         false,
     );
@@ -471,7 +471,7 @@ pub fn emacs_preset() -> BindingSet {
         Action::new(
             "forward_char",
             "Forward one character",
-            WmAction::Focus(Direction::Right),
+            WmAction::focus(Direction::Right),
         ),
         false,
     );
@@ -481,20 +481,20 @@ pub fn emacs_preset() -> BindingSet {
         Action::new(
             "backward_char",
             "Backward one character",
-            WmAction::Focus(Direction::Left),
+            WmAction::focus(Direction::Left),
         ),
         false,
     );
     bs.add(
         KeyCombo::new(Key::Letter('n')).with_mod(Modifier::Ctrl),
         app.clone(),
-        Action::new("next_line", "Next line", WmAction::Focus(Direction::Down)),
+        Action::new("next_line", "Next line", WmAction::focus(Direction::Down)),
         false,
     );
     bs.add(
         KeyCombo::new(Key::Letter('p')).with_mod(Modifier::Ctrl),
         app.clone(),
-        Action::new("prev_line", "Previous line", WmAction::Focus(Direction::Up)),
+        Action::new("prev_line", "Previous line", WmAction::focus(Direction::Up)),
         false,
     );
 
@@ -614,7 +614,7 @@ pub fn i3_preset() -> BindingSet {
             Action::new(
                 format!("focus_{desc}"),
                 format!("Focus {desc}"),
-                WmAction::Focus(direction),
+                WmAction::focus(direction),
             ),
             false,
         );
@@ -1027,7 +1027,7 @@ pub fn vogix_preset() -> BindingSet {
             Key::Letter(*letter),
             &format!("focus_{suf}"),
             "Focus",
-            WmAction::Focus(*direction).into(),
+            WmAction::focus(*direction).into(),
             false,
         );
         add(
@@ -1035,7 +1035,7 @@ pub fn vogix_preset() -> BindingSet {
             Key::Named(arrow.clone()),
             &format!("focus_{suf}_arrow"),
             "Focus",
-            WmAction::Focus(*direction).into(),
+            WmAction::focus(*direction).into(),
             false,
         );
     }
@@ -1279,14 +1279,14 @@ pub fn windows_preset() -> BindingSet {
         Key::Named(NamedKey::Tab),
         "switch_window",
         "Switch window",
-        WmAction::CycleWindow(Cycle::Forward),
+        WmAction::cycle_window(Cycle::Forward),
     );
     add(
         &[Alt, Shift],
         Key::Named(NamedKey::Tab),
         "switch_window_prev",
         "Switch window (reverse)",
-        WmAction::CycleWindow(Cycle::Backward),
+        WmAction::cycle_window(Cycle::Backward),
     );
     add(
         &[Alt],
@@ -1433,14 +1433,14 @@ pub fn macos_preset() -> BindingSet {
         Key::Named(NamedKey::Tab),
         "switch_window",
         "Switch window",
-        WmAction::CycleWindow(Cycle::Forward),
+        WmAction::cycle_window(Cycle::Forward),
     );
     add(
         &[Super, Shift],
         Key::Named(NamedKey::Tab),
         "switch_window_prev",
         "Switch window (reverse)",
-        WmAction::CycleWindow(Cycle::Backward),
+        WmAction::cycle_window(Cycle::Backward),
     );
 
     // Window verbs (Cmd+W/Q/H/M) — bound, so they win over the remap. Hide and
@@ -1540,7 +1540,7 @@ pub fn linux_preset() -> BindingSet {
         Key::Named(NamedKey::Tab),
         "switch_window",
         "Switch window",
-        WmAction::CycleWindow(Cycle::Forward),
+        WmAction::cycle_window(Cycle::Forward),
     );
     add(
         &[Alt],

--- a/crates/domains/src/applied/hmi/input/mod.rs
+++ b/crates/domains/src/applied/hmi/input/mod.rs
@@ -6,4 +6,5 @@
 pub mod engine;
 pub mod keybindings;
 pub mod modes;
+pub mod window_state;
 pub mod wm_action;

--- a/crates/domains/src/applied/hmi/input/window_state.rs
+++ b/crates/domains/src/applied/hmi/input/window_state.rs
@@ -444,30 +444,29 @@ impl Axiom for StateAddRemoveComplementary {
     );
 }
 
-/// The [`StateBit`] enum is exactly the loaded EWMH-plus-extensions vocabulary —
-/// **sound** (every variant has a loaded definition) and **complete** (every
-/// loaded atom has a variant). This is what makes "loaded, not hand-encoded"
-/// real: the typed alphabet cannot drift from the cited source without this
-/// axiom failing.
+/// The [`StateBit`] enum is exactly the loaded EWMH-plus-extensions vocabulary,
+/// **in the same order** — sound (every variant has a loaded definition),
+/// complete (every loaded atom has a variant), and order-faithful (the i-th
+/// variant is the i-th loaded row, so `StateBit::index` — and thus the bit
+/// positions — is pinned to the loaded row order). This is what makes "loaded,
+/// not hand-encoded" real: the typed alphabet cannot drift from the cited source,
+/// in membership OR order, without this axiom failing.
 pub struct VocabularyComplete;
 
 impl Axiom for VocabularyComplete {
     fn verify(&self) -> Verdict {
         let loaded = wm_state_vocabulary();
         let variants = StateBit::variants();
-        // Same cardinality.
+        // Same cardinality AND same ORDER: the i-th StateBit variant must be the
+        // i-th loaded atom. Ordered equality is stronger than set equality — it
+        // also pins `StateBit::index` (and thus the bit positions) to the loaded
+        // row order, so a reorder of either the enum or the TSV fails here rather
+        // than silently breaking the index <-> vocabulary-order correspondence.
         if loaded.len() != variants.len() {
             return Err(Box::new(SimpleCounterexample::new(self.meta())));
         }
-        // Sound + complete: every variant name appears in the loaded vocabulary,
-        // and every loaded name is a variant (bijection on names).
-        for v in &variants {
-            if !loaded.iter().any(|d| d.name == v.name()) {
-                return Err(Box::new(SimpleCounterexample::new(self.meta())));
-            }
-        }
-        for d in &loaded {
-            if !variants.iter().any(|v| v.name() == d.name) {
+        for (i, v) in variants.iter().enumerate() {
+            if loaded[i].name != v.name() {
                 return Err(Box::new(SimpleCounterexample::new(self.meta())));
             }
         }
@@ -476,8 +475,8 @@ impl Axiom for VocabularyComplete {
 
     pr4xis::axiom_meta!(
         "VocabularyComplete",
-        "the StateBit alphabet is exactly the loaded EWMH _NET_WM_STATE vocabulary (sound and complete)",
-        "EWMH v1.5 (2013) §5 — the _NET_WM_STATE atom set is the controlled source; the typed enum is checked against the loaded vocabulary, not merely cited"
+        "the StateBit alphabet is exactly the loaded EWMH _NET_WM_STATE vocabulary, in the same order (sound, complete, and order-faithful: index() matches the loaded row order)",
+        "EWMH v1.5 (2013) §5 — the _NET_WM_STATE atom set is the controlled source; the typed enum is checked against the loaded vocabulary positionally, not merely cited"
     );
 }
 

--- a/crates/domains/src/applied/hmi/input/window_state.rs
+++ b/crates/domains/src/applied/hmi/input/window_state.rs
@@ -1,0 +1,603 @@
+//! Window-state ontology — the EWMH `_NET_WM_STATE` set as a Boolean algebra,
+//! and the add/remove/toggle operations that act on it.
+//!
+//! # The conflation this dissolves
+//!
+//! Window-manager "actions" like *fullscreen*, *maximize*, *minimize*, *float*,
+//! *pin* are not independent verbs — they are **mutations of a window's STATE**.
+//! EWMH models this exactly: a window carries a *set* of state atoms
+//! (`_NET_WM_STATE`), and a client mutates it with a `_NET_WM_STATE` message
+//! whose action field is one of `{ _NET_WM_STATE_REMOVE = 0, _NET_WM_STATE_ADD
+//! = 1, _NET_WM_STATE_TOGGLE = 2 }` (EWMH v1.5 §5). So the right model is the
+//! **Boolean algebra** `2^StateBit` together with its add / remove / toggle
+//! operators — *not* a flat list of state verbs.
+//!
+//! Modelling state this way is what makes the inverses **expressible**: a flat
+//! `Maximize` verb has no `Restore`; `StateDelta { Remove, MaximizedVert }`
+//! *is* restore, for free. And it is what makes the laws **provable**: toggle is
+//! an involution because it is symmetric-difference in the elementary abelian
+//! 2-group `(2^StateBit, △)`; add/remove are idempotent join/meet-with-complement.
+//! These are theorems over the model (verified exhaustively here), not analogies.
+//!
+//! # Grounding
+//!
+//! - **EWMH v1.5 (2013)** freedesktop.org §5 — `_NET_WM_STATE`: the controlled
+//!   atom set (loaded as [`wm_state_vocabulary`]) and the REMOVE/ADD/TOGGLE
+//!   mutation. <https://specifications.freedesktop.org/wm-spec/1.5/ar01s05.html>
+//! - **Boolean algebra / set theory** — `2^S` is a Boolean algebra; symmetric
+//!   difference `△` makes it the elementary abelian 2-group where every element
+//!   is its own inverse, so toggling twice is the identity (the involution law).
+//! - **ICCCM** `WM_STATE` `{Withdrawn, Normal, Iconic}` — the *mutually-exclusive
+//!   lifecycle* 3-state machine, kept DISTINCT from this *set* algebra; modelling
+//!   it is a separate concern (tracked), because folding a lifecycle sum into the
+//!   power-set re-introduces the conflation this module removes.
+//! - **bspwm(1)** — `pseudo_tiled` as a first-class node state (the one tiling
+//!   state EWMH does not name); **Wayland xdg-shell / wlroots** — the floating
+//!   layer. The two compositor extensions are cited in the loaded vocabulary.
+
+#[allow(unused_imports)]
+use alloc::{boxed::Box, format, string::String, string::ToString, vec, vec::Vec};
+
+use pr4xis::category::{Concept, FinitelyGenerated};
+use pr4xis::logic::Axiom;
+use pr4xis::logic::proof::{SimpleCounterexample, SimpleProof, Verdict};
+
+// ── The loaded window-state vocabulary ───────────────────────────────────────
+
+/// One row of the loaded window-state vocabulary: the praxis bit name, the
+/// authoritative spec atom it stands for, and the source that names it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StateBitDef {
+    /// The praxis bit name (matches [`StateBit::name`]).
+    pub name: String,
+    /// The authoritative spec atom (e.g. `_NET_WM_STATE_FULLSCREEN`).
+    pub atom: String,
+    /// The source that names the atom (e.g. `EWMH 1.5 §5`).
+    pub source: String,
+}
+
+/// The committed window-state atom vocabulary — EWMH `_NET_WM_STATE` (13 atoms)
+/// plus two cited compositor extensions. One `bit_name<TAB>atom<TAB>source` row
+/// each. This is the authority the [`StateBit`] enum is proven complete-and-sound
+/// against ([`VocabularyComplete`]); the enum is the typed working representation,
+/// the loaded data is what it must conform to.
+const WM_STATE_TSV: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/data/hmi/ewmh-wm-state.tsv"
+));
+
+/// The loaded window-state atom vocabulary (EWMH `_NET_WM_STATE` + 2 cited
+/// compositor extensions), parsed from the committed TSV.
+///
+/// Under `std` the parse is cached process-wide ([`OnceLock`](std::sync::OnceLock)):
+/// the completeness axiom and any vocabulary lookup re-read it, so re-parsing per
+/// call would be wasteful. The `no_std`/wasm surface keeps the fresh-parse.
+pub fn wm_state_vocabulary() -> Vec<StateBitDef> {
+    #[cfg(feature = "std")]
+    {
+        wm_state_cached().to_vec()
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        parse_wm_state_tsv(WM_STATE_TSV)
+    }
+}
+
+#[cfg(feature = "std")]
+fn wm_state_cached() -> &'static [StateBitDef] {
+    use std::sync::OnceLock;
+    static CACHE: OnceLock<Vec<StateBitDef>> = OnceLock::new();
+    CACHE.get_or_init(|| parse_wm_state_tsv(WM_STATE_TSV))
+}
+
+fn parse_wm_state_tsv(tsv: &str) -> Vec<StateBitDef> {
+    tsv.lines()
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .filter_map(|l| {
+            let mut it = l.split('\t');
+            let name = it.next()?.trim();
+            let atom = it.next()?.trim();
+            let source = it.next()?.trim();
+            if name.is_empty() {
+                return None;
+            }
+            Some(StateBitDef {
+                name: name.to_string(),
+                atom: atom.to_string(),
+                source: source.to_string(),
+            })
+        })
+        .collect()
+}
+
+// ── The state atoms (the typed alphabet) ─────────────────────────────────────
+
+/// A single window-state atom — one bit of a window's state set.
+///
+/// The typed image of the loaded [`wm_state_vocabulary`]; their correspondence
+/// is machine-checked by [`VocabularyComplete`], so the enum cannot drift from
+/// the cited EWMH atom set. Each is one bit position in a [`StateSet`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum StateBit {
+    Modal,
+    Sticky,
+    MaximizedVert,
+    MaximizedHorz,
+    Shaded,
+    SkipTaskbar,
+    SkipPager,
+    Hidden,
+    Fullscreen,
+    Above,
+    Below,
+    DemandsAttention,
+    Focused,
+    /// Compositor extension (Wayland/wlroots): the floating layer.
+    Floating,
+    /// Compositor extension (bspwm): the `pseudo_tiled` node flag.
+    PseudoTiled,
+}
+
+impl StateBit {
+    /// This atom's bit position in a [`StateSet`] (stable, matches the loaded
+    /// vocabulary order).
+    fn index(self) -> u8 {
+        match self {
+            StateBit::Modal => 0,
+            StateBit::Sticky => 1,
+            StateBit::MaximizedVert => 2,
+            StateBit::MaximizedHorz => 3,
+            StateBit::Shaded => 4,
+            StateBit::SkipTaskbar => 5,
+            StateBit::SkipPager => 6,
+            StateBit::Hidden => 7,
+            StateBit::Fullscreen => 8,
+            StateBit::Above => 9,
+            StateBit::Below => 10,
+            StateBit::DemandsAttention => 11,
+            StateBit::Focused => 12,
+            StateBit::Floating => 13,
+            StateBit::PseudoTiled => 14,
+        }
+    }
+
+    /// The single-bit mask for this atom.
+    fn mask(self) -> u16 {
+        1u16 << self.index()
+    }
+}
+
+impl Concept for StateBit {
+    fn name(&self) -> &'static str {
+        match self {
+            StateBit::Modal => "modal",
+            StateBit::Sticky => "sticky",
+            StateBit::MaximizedVert => "maximized-vert",
+            StateBit::MaximizedHorz => "maximized-horz",
+            StateBit::Shaded => "shaded",
+            StateBit::SkipTaskbar => "skip-taskbar",
+            StateBit::SkipPager => "skip-pager",
+            StateBit::Hidden => "hidden",
+            StateBit::Fullscreen => "fullscreen",
+            StateBit::Above => "above",
+            StateBit::Below => "below",
+            StateBit::DemandsAttention => "demands-attention",
+            StateBit::Focused => "focused",
+            StateBit::Floating => "floating",
+            StateBit::PseudoTiled => "pseudo-tiled",
+        }
+    }
+}
+
+impl FinitelyGenerated for StateBit {
+    fn variants() -> Vec<Self> {
+        vec![
+            StateBit::Modal,
+            StateBit::Sticky,
+            StateBit::MaximizedVert,
+            StateBit::MaximizedHorz,
+            StateBit::Shaded,
+            StateBit::SkipTaskbar,
+            StateBit::SkipPager,
+            StateBit::Hidden,
+            StateBit::Fullscreen,
+            StateBit::Above,
+            StateBit::Below,
+            StateBit::DemandsAttention,
+            StateBit::Focused,
+            StateBit::Floating,
+            StateBit::PseudoTiled,
+        ]
+    }
+}
+
+/// How a [`StateBit`] is mutated — the EWMH `_NET_WM_STATE` action field, verbatim:
+/// `_NET_WM_STATE_REMOVE = 0`, `_NET_WM_STATE_ADD = 1`, `_NET_WM_STATE_TOGGLE = 2`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum StateOp {
+    Remove,
+    Add,
+    Toggle,
+}
+
+impl StateOp {
+    /// The EWMH numeric code for this action (`_NET_WM_STATE_{REMOVE,ADD,TOGGLE}`).
+    pub fn ewmh_code(self) -> i64 {
+        match self {
+            StateOp::Remove => 0,
+            StateOp::Add => 1,
+            StateOp::Toggle => 2,
+        }
+    }
+}
+
+impl Concept for StateOp {
+    fn name(&self) -> &'static str {
+        match self {
+            StateOp::Remove => "remove",
+            StateOp::Add => "add",
+            StateOp::Toggle => "toggle",
+        }
+    }
+}
+
+impl FinitelyGenerated for StateOp {
+    fn variants() -> Vec<Self> {
+        vec![StateOp::Remove, StateOp::Add, StateOp::Toggle]
+    }
+}
+
+/// An atomic window-state mutation — apply [`StateOp`] to [`StateBit`]. This is
+/// the parameter of the `State` window-action: e.g. `StateDelta { Toggle,
+/// Fullscreen }` is "toggle fullscreen", `StateDelta { Remove, MaximizedVert }`
+/// is the restore that a flat verb set could not express.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StateDelta {
+    pub op: StateOp,
+    pub bit: StateBit,
+}
+
+impl StateDelta {
+    pub fn new(op: StateOp, bit: StateBit) -> Self {
+        Self { op, bit }
+    }
+
+    /// The finite generating set — every `(op, bit)` pair. Used to seed property
+    /// tests and the lattice-law axioms.
+    pub fn representative_deltas() -> Vec<StateDelta> {
+        let mut v = Vec::new();
+        for op in StateOp::variants() {
+            for bit in StateBit::variants() {
+                v.push(StateDelta::new(op, bit));
+            }
+        }
+        v
+    }
+}
+
+impl Concept for StateDelta {
+    fn name(&self) -> &'static str {
+        // The op names the mutation kind; the bit is the parameter.
+        self.op.name()
+    }
+}
+
+// ── The state set (the 2^StateBit Boolean algebra) ───────────────────────────
+
+/// A window's state — a subset of [`StateBit`], i.e. an element of the Boolean
+/// algebra `2^StateBit`. Represented as a bitset over the 15 atoms.
+///
+/// This is the **model** the state operations act on, and the layer at which the
+/// involution / idempotence laws are *observable and provable* (unlike the
+/// realized compositor string, where `togglefloating ; togglefloating` is a
+/// two-element word, not the identity).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct StateSet(u16);
+
+impl StateSet {
+    /// The empty state (no atoms set).
+    pub fn empty() -> Self {
+        StateSet(0)
+    }
+
+    /// Is `bit` present in this state?
+    pub fn contains(self, bit: StateBit) -> bool {
+        self.0 & bit.mask() != 0
+    }
+
+    /// `Add` — set `bit` (idempotent join: `σ ↦ σ ∪ {bit}`).
+    pub fn with(self, bit: StateBit) -> Self {
+        StateSet(self.0 | bit.mask())
+    }
+
+    /// `Remove` — clear `bit` (idempotent: `σ ↦ σ \ {bit}`).
+    pub fn without(self, bit: StateBit) -> Self {
+        StateSet(self.0 & !bit.mask())
+    }
+
+    /// `Toggle` — flip `bit` (involution: `σ ↦ σ △ {bit}`).
+    pub fn toggled(self, bit: StateBit) -> Self {
+        StateSet(self.0 ^ bit.mask())
+    }
+
+    /// Apply one [`StateDelta`] — the action of the state operations on the set.
+    pub fn apply(self, delta: StateDelta) -> Self {
+        match delta.op {
+            StateOp::Add => self.with(delta.bit),
+            StateOp::Remove => self.without(delta.bit),
+            StateOp::Toggle => self.toggled(delta.bit),
+        }
+    }
+
+    /// Build a state from a raw bitset (exhaustive-iteration helper). Only the
+    /// 15 defined atom bits are meaningful; higher bits are masked off.
+    fn from_bits(b: u16) -> Self {
+        StateSet(b & STATE_MASK)
+    }
+}
+
+/// The mask of all defined atom bits (15 atoms → low 15 bits).
+const STATE_MASK: u16 = (1u16 << 15) - 1;
+
+/// The size of the full state space `2^StateBit` (32768) — the domain the laws
+/// are checked over EXHAUSTIVELY (every reachable state).
+const STATE_SPACE: u32 = 1 << 15;
+
+// ── The Boolean-algebra laws (exhaustively proven over the model) ────────────
+
+/// Toggling a bit twice is the identity — the **involution** law, proven
+/// exhaustively over every state in `2^StateBit` and every atom: `apply(Toggle,
+/// apply(Toggle, σ)) = σ`. True because toggle is symmetric-difference `△` in the
+/// elementary abelian 2-group `(2^StateBit, △)`, where every element is its own
+/// inverse. This is the law that makes a single `Toggle` binding correct.
+pub struct StateToggleInvolutive;
+
+impl Axiom for StateToggleInvolutive {
+    fn verify(&self) -> Verdict {
+        for bit in StateBit::variants() {
+            let d = StateDelta::new(StateOp::Toggle, bit);
+            for b in 0..STATE_SPACE {
+                let s = StateSet::from_bits(b as u16);
+                if s.apply(d).apply(d) != s {
+                    return Err(Box::new(SimpleCounterexample::new(self.meta())));
+                }
+            }
+        }
+        Ok(Box::new(SimpleProof::new(self.meta())))
+    }
+
+    pr4xis::axiom_meta!(
+        "StateToggleInvolutive",
+        "toggling a window-state atom twice is the identity (involution), for every state",
+        "EWMH v1.5 (2013) §5 _NET_WM_STATE_TOGGLE; Boolean algebra — symmetric difference makes 2^S the elementary abelian 2-group where every element is self-inverse"
+    );
+}
+
+/// Adding an atom already present, or removing one already absent, changes
+/// nothing — **idempotence** of `Add` and `Remove`, proven exhaustively over the
+/// state space. `Add` is set-union with a singleton (a join), `Remove` is
+/// set-difference; both are idempotent in the lattice.
+pub struct StateAddRemoveIdempotent;
+
+impl Axiom for StateAddRemoveIdempotent {
+    fn verify(&self) -> Verdict {
+        for bit in StateBit::variants() {
+            let add = StateDelta::new(StateOp::Add, bit);
+            let remove = StateDelta::new(StateOp::Remove, bit);
+            for b in 0..STATE_SPACE {
+                let s = StateSet::from_bits(b as u16);
+                if s.apply(add).apply(add) != s.apply(add) {
+                    return Err(Box::new(SimpleCounterexample::new(self.meta())));
+                }
+                if s.apply(remove).apply(remove) != s.apply(remove) {
+                    return Err(Box::new(SimpleCounterexample::new(self.meta())));
+                }
+            }
+        }
+        Ok(Box::new(SimpleProof::new(self.meta())))
+    }
+
+    pr4xis::axiom_meta!(
+        "StateAddRemoveIdempotent",
+        "adding a present atom or removing an absent atom is a no-op (idempotence), for every state",
+        "EWMH v1.5 (2013) §5 _NET_WM_STATE_ADD/_REMOVE; Boolean algebra — join/meet with a fixed element is idempotent"
+    );
+}
+
+/// `Add` then `Remove` (or vice-versa) of the same atom leaves the atom in the
+/// expected definite state, independent of the starting state — `Add` and
+/// `Remove` are the two **constant** maps on that atom's coordinate (set it,
+/// clear it), so `Remove ∘ Add = Remove` and `Add ∘ Remove = Add` on that bit.
+/// This is what makes `Remove` the genuine inverse-direction (restore) operator.
+pub struct StateAddRemoveComplementary;
+
+impl Axiom for StateAddRemoveComplementary {
+    fn verify(&self) -> Verdict {
+        for bit in StateBit::variants() {
+            let add = StateDelta::new(StateOp::Add, bit);
+            let remove = StateDelta::new(StateOp::Remove, bit);
+            for b in 0..STATE_SPACE {
+                let s = StateSet::from_bits(b as u16);
+                // After Add, the bit is set; after Remove, it is clear — regardless of s.
+                if !s.apply(add).contains(bit) {
+                    return Err(Box::new(SimpleCounterexample::new(self.meta())));
+                }
+                if s.apply(remove).contains(bit) {
+                    return Err(Box::new(SimpleCounterexample::new(self.meta())));
+                }
+                // Add then Remove == Remove (the bit ends clear); Remove then Add == Add.
+                if s.apply(add).apply(remove) != s.apply(remove) {
+                    return Err(Box::new(SimpleCounterexample::new(self.meta())));
+                }
+                if s.apply(remove).apply(add) != s.apply(add) {
+                    return Err(Box::new(SimpleCounterexample::new(self.meta())));
+                }
+            }
+        }
+        Ok(Box::new(SimpleProof::new(self.meta())))
+    }
+
+    pr4xis::axiom_meta!(
+        "StateAddRemoveComplementary",
+        "add forces the atom present and remove forces it absent, independent of prior state (the inverse-direction operators)",
+        "EWMH v1.5 (2013) §5 — _NET_WM_STATE_ADD and _NET_WM_STATE_REMOVE are definite set/clear; Boolean algebra complement"
+    );
+}
+
+/// The [`StateBit`] enum is exactly the loaded EWMH-plus-extensions vocabulary —
+/// **sound** (every variant has a loaded definition) and **complete** (every
+/// loaded atom has a variant). This is what makes "loaded, not hand-encoded"
+/// real: the typed alphabet cannot drift from the cited source without this
+/// axiom failing.
+pub struct VocabularyComplete;
+
+impl Axiom for VocabularyComplete {
+    fn verify(&self) -> Verdict {
+        let loaded = wm_state_vocabulary();
+        let variants = StateBit::variants();
+        // Same cardinality.
+        if loaded.len() != variants.len() {
+            return Err(Box::new(SimpleCounterexample::new(self.meta())));
+        }
+        // Sound + complete: every variant name appears in the loaded vocabulary,
+        // and every loaded name is a variant (bijection on names).
+        for v in &variants {
+            if !loaded.iter().any(|d| d.name == v.name()) {
+                return Err(Box::new(SimpleCounterexample::new(self.meta())));
+            }
+        }
+        for d in &loaded {
+            if !variants.iter().any(|v| v.name() == d.name) {
+                return Err(Box::new(SimpleCounterexample::new(self.meta())));
+            }
+        }
+        Ok(Box::new(SimpleProof::new(self.meta())))
+    }
+
+    pr4xis::axiom_meta!(
+        "VocabularyComplete",
+        "the StateBit alphabet is exactly the loaded EWMH _NET_WM_STATE vocabulary (sound and complete)",
+        "EWMH v1.5 (2013) §5 — the _NET_WM_STATE atom set is the controlled source; the typed enum is checked against the loaded vocabulary, not merely cited"
+    );
+}
+
+/// All window-state model axioms — the Boolean-algebra laws plus the
+/// loaded-vocabulary correspondence.
+pub fn window_state_axioms() -> Vec<Box<dyn Axiom>> {
+    vec![
+        Box::new(StateToggleInvolutive),
+        Box::new(StateAddRemoveIdempotent),
+        Box::new(StateAddRemoveComplementary),
+        Box::new(VocabularyComplete),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn vocabulary_loads_15_atoms() {
+        let v = wm_state_vocabulary();
+        assert_eq!(v.len(), 15, "13 EWMH + 2 compositor extensions");
+        // EWMH atoms carry their spec atom name.
+        assert!(v.iter().any(|d| d.atom == "_NET_WM_STATE_FULLSCREEN"));
+        assert!(
+            v.iter()
+                .any(|d| d.name == "fullscreen" && d.source.contains("EWMH"))
+        );
+    }
+
+    #[test]
+    fn enum_matches_loaded_vocabulary() {
+        VocabularyComplete
+            .verify()
+            .unwrap_or_else(|c| panic!("{}", c.meta().name.as_str()));
+    }
+
+    #[test]
+    fn restore_is_expressible() {
+        // The whole point: a flat `Maximize` verb has no inverse; here the
+        // remove-direction IS the restore.
+        let maximized = StateSet::empty()
+            .with(StateBit::MaximizedVert)
+            .with(StateBit::MaximizedHorz);
+        let restored = maximized
+            .apply(StateDelta::new(StateOp::Remove, StateBit::MaximizedVert))
+            .apply(StateDelta::new(StateOp::Remove, StateBit::MaximizedHorz));
+        assert_eq!(restored, StateSet::empty());
+    }
+
+    #[test]
+    fn toggle_involution_holds_exhaustively() {
+        StateToggleInvolutive
+            .verify()
+            .unwrap_or_else(|c| panic!("{}", c.meta().name.as_str()));
+    }
+
+    #[test]
+    fn add_remove_idempotent_holds_exhaustively() {
+        StateAddRemoveIdempotent
+            .verify()
+            .unwrap_or_else(|c| panic!("{}", c.meta().name.as_str()));
+    }
+
+    #[test]
+    fn add_remove_complementary_holds_exhaustively() {
+        StateAddRemoveComplementary
+            .verify()
+            .unwrap_or_else(|c| panic!("{}", c.meta().name.as_str()));
+    }
+
+    #[test]
+    fn all_axioms_pass() {
+        for ax in window_state_axioms() {
+            ax.verify()
+                .unwrap_or_else(|c| panic!("axiom failed: {}", c.meta().name.as_str()));
+        }
+    }
+
+    fn arb_bit() -> impl Strategy<Value = StateBit> {
+        proptest::sample::select(StateBit::variants())
+    }
+
+    fn arb_set() -> impl Strategy<Value = StateSet> {
+        any::<u16>().prop_map(StateSet::from_bits)
+    }
+
+    proptest! {
+        /// Toggle is its own inverse on any state (the involution, on random states).
+        #[test]
+        fn prop_toggle_involutive(s in arb_set(), bit in arb_bit()) {
+            let d = StateDelta::new(StateOp::Toggle, bit);
+            prop_assert_eq!(s.apply(d).apply(d), s);
+        }
+
+        /// Add then Remove of the same bit clears it; the result is what Remove
+        /// alone gives (Add/Remove are the definite set/clear maps).
+        #[test]
+        fn prop_add_then_remove_is_remove(s in arb_set(), bit in arb_bit()) {
+            let add = StateDelta::new(StateOp::Add, bit);
+            let remove = StateDelta::new(StateOp::Remove, bit);
+            prop_assert_eq!(s.apply(add).apply(remove), s.apply(remove));
+            prop_assert!(!s.apply(add).apply(remove).contains(bit));
+        }
+
+        /// Distinct atoms are independent coordinates: mutating one never changes
+        /// another (the state space is a product of bits).
+        #[test]
+        fn prop_bits_independent(s in arb_set(), a in arb_bit(), b in arb_bit()) {
+            prop_assume!(a != b);
+            let before = s.contains(b);
+            let after = s.apply(StateDelta::new(StateOp::Toggle, a)).contains(b);
+            prop_assert_eq!(before, after);
+        }
+
+        /// Only the low 15 atom bits are ever set (the state space is 2^15).
+        #[test]
+        fn prop_state_space_bounded(s in arb_set()) {
+            prop_assert_eq!(s.0 & !STATE_MASK, 0);
+        }
+    }
+}

--- a/crates/domains/src/applied/hmi/input/wm_action.rs
+++ b/crates/domains/src/applied/hmi/input/wm_action.rs
@@ -66,6 +66,7 @@ use pr4xis::logic::proof::{SimpleCounterexample, SimpleProof, Verdict, combine_v
 use pr4xis::ontology::meta::{Citation, Label, ModulePath, OntologyName, Provenance};
 
 use super::modes::ModeId;
+use super::window_state::{StateBit, StateDelta, StateOp};
 
 // ── Layer 2: typed parameters ────────────────────────────────────────────────
 
@@ -246,23 +247,14 @@ pub enum WmAction {
     Resize(Direction, u16),
     /// Close / kill the focused window (Myers "delete"; EWMH `CLOSE`).
     Close,
-    /// Toggle true fullscreen (EWMH `_NET_WM_ACTION_FULLSCREEN`; Myers
-    /// "make-full-screen"). Realized by the bare `fullscreen` dispatcher.
-    Fullscreen,
-    /// Maximize — fill the work area but keep the layout's reserved space. A
-    /// *distinct* EWMH action (`_NET_WM_ACTION_MAXIMIZE_*`) and Myers operation,
-    /// realized on Hyprland by the `fullscreen` dispatcher's mode 1.
-    Maximize,
-    /// Minimize / iconify the focused window (EWMH `_NET_WM_ACTION_MINIMIZE`;
-    /// Myers "shrink-to-icon"). Hyprland has no native minimize, so the functor
-    /// emulates it with a silent move to a dedicated special workspace.
-    Minimize,
-    /// Toggle floating (tiled ⇄ floating).
-    ToggleFloat,
-    /// Pin the window above others / across workspaces (EWMH `ABOVE`/`STICK`).
-    Pin,
-    /// Toggle pseudo-tiling for the focused window (Hyprland dwindle).
-    Pseudotile,
+    /// Mutate one window-state atom — the EWMH `_NET_WM_STATE` add/remove/toggle
+    /// on a [`StateBit`] (see [`window_state`](super::window_state)). This single
+    /// constructor subsumes the former flat fullscreen / maximize / minimize /
+    /// float / pin / pseudotile verbs (the convenience constructors
+    /// [`WmAction::fullscreen`] … preserve their names) **and** makes the inverse
+    /// direction — restore / unmaximize — expressible as `State { Remove, … }`,
+    /// which a flat verb set could not name.
+    State(StateDelta),
     /// Toggle the split orientation of the layout (Hyprland `layoutmsg
     /// togglesplit`).
     ToggleSplit,
@@ -289,6 +281,47 @@ pub enum WmAction {
 }
 
 impl WmAction {
+    /// Toggle true fullscreen — `State{Toggle, Fullscreen}` (EWMH
+    /// `_NET_WM_STATE_FULLSCREEN`). Convenience for the common window-state verb.
+    pub fn fullscreen() -> Self {
+        WmAction::State(StateDelta::new(StateOp::Toggle, StateBit::Fullscreen))
+    }
+
+    /// Maximize — fill the work area keeping reserved space. The canonical
+    /// maximize toggles the (representative) `MaximizedVert` bit; the Hyprland
+    /// realization lowers both `MaximizedVert` and `MaximizedHorz` to the single
+    /// `fullscreen, 1` dispatcher (Hyprland has no per-axis maximize). A backend
+    /// with independent axes realizes them distinctly, and "maximize both axes"
+    /// is the `[Vert, Horz]` composite there.
+    pub fn maximize() -> Self {
+        WmAction::State(StateDelta::new(StateOp::Toggle, StateBit::MaximizedVert))
+    }
+
+    /// Minimize / iconify — `State{Add, Hidden}` (EWMH `_NET_WM_STATE_HIDDEN`,
+    /// the canonical minimize). Hyprland has no native iconify, so the functor
+    /// emulates it with a silent move to a dedicated special workspace.
+    pub fn minimize() -> Self {
+        WmAction::State(StateDelta::new(StateOp::Add, StateBit::Hidden))
+    }
+
+    /// Toggle floating — `State{Toggle, Floating}` (the tiled ⇄ floating layer).
+    pub fn toggle_float() -> Self {
+        WmAction::State(StateDelta::new(StateOp::Toggle, StateBit::Floating))
+    }
+
+    /// Pin above / across workspaces — `State{Toggle, Above}` (EWMH `ABOVE`;
+    /// Hyprland's `pin` realizes above+sticky together, so `Sticky` lowers
+    /// identically below the functor).
+    pub fn pin() -> Self {
+        WmAction::State(StateDelta::new(StateOp::Toggle, StateBit::Above))
+    }
+
+    /// Toggle pseudo-tiling — `State{Toggle, PseudoTiled}` (bspwm's node state;
+    /// Hyprland dwindle's `pseudo`).
+    pub fn pseudotile() -> Self {
+        WmAction::State(StateDelta::new(StateOp::Toggle, StateBit::PseudoTiled))
+    }
+
     /// The finite generating set — one representative of every variant. Used to
     /// machine-check the realization functor (totality, the functor laws) and to
     /// seed property tests. This is a *generating* set, not the (open-world) whole
@@ -305,12 +338,14 @@ impl WmAction {
             WmAction::Resize(Left, 30),
             WmAction::Resize(Down, 30),
             WmAction::Close,
-            WmAction::Fullscreen,
-            WmAction::Maximize,
-            WmAction::Minimize,
-            WmAction::ToggleFloat,
-            WmAction::Pin,
-            WmAction::Pseudotile,
+            WmAction::fullscreen(),
+            WmAction::maximize(),
+            // The inverse direction a flat verb set could not name — restore.
+            WmAction::State(StateDelta::new(StateOp::Remove, StateBit::MaximizedVert)),
+            WmAction::minimize(),
+            WmAction::toggle_float(),
+            WmAction::pin(),
+            WmAction::pseudotile(),
             WmAction::ToggleSplit,
             WmAction::ToggleGroup,
             WmAction::CycleGroup(Cycle::Forward),
@@ -344,12 +379,7 @@ impl Concept for WmAction {
             WmAction::SwapWindow(_) => "swap-window",
             WmAction::Resize(_, _) => "resize",
             WmAction::Close => "close",
-            WmAction::Fullscreen => "fullscreen",
-            WmAction::Maximize => "maximize",
-            WmAction::Minimize => "minimize",
-            WmAction::ToggleFloat => "toggle-float",
-            WmAction::Pin => "pin",
-            WmAction::Pseudotile => "pseudotile",
+            WmAction::State(_) => "state",
             WmAction::ToggleSplit => "toggle-split",
             WmAction::ToggleGroup => "toggle-group",
             WmAction::CycleGroup(_) => "cycle-group",
@@ -622,16 +652,7 @@ fn lower(action: &WmAction) -> Vec<Dispatch> {
             vec![Dispatch::ResizeActive(dx, dy)]
         }
         WmAction::Close => vec![Dispatch::KillActive],
-        WmAction::Fullscreen => vec![Dispatch::Fullscreen(0)],
-        WmAction::Maximize => vec![Dispatch::Fullscreen(1)],
-        // Hyprland has no native iconify — emulate minimize with a silent move to a
-        // dedicated special (scratchpad) workspace.
-        WmAction::Minimize => vec![Dispatch::MoveToWorkspaceSilent(WorkspaceTarget::Special(
-            "minimized".to_string(),
-        ))],
-        WmAction::ToggleFloat => vec![Dispatch::ToggleFloating],
-        WmAction::Pin => vec![Dispatch::Pin],
-        WmAction::Pseudotile => vec![Dispatch::Pseudo],
+        WmAction::State(d) => lower_state(d),
         WmAction::ToggleSplit => vec![Dispatch::LayoutMsg("togglesplit")],
         WmAction::ToggleGroup => vec![Dispatch::ToggleGroup],
         WmAction::CycleGroup(c) => vec![Dispatch::ChangeGroupActive(match c {
@@ -648,6 +669,53 @@ fn lower(action: &WmAction) -> Vec<Dispatch> {
         WmAction::Exec(cmd) => vec![Dispatch::Exec(cmd.clone())],
         WmAction::Submap(t) => vec![Dispatch::Submap(t.render())],
     }
+}
+
+/// Lower a window-state mutation to its Hyprland dispatcher(s).
+///
+/// Hyprland exposes only TOGGLE dispatchers for window states, so the EWMH
+/// add/remove/toggle distinction ([`StateOp`]) is not observable in the Hyprland
+/// realization (a directed backend such as X11 honours it via `_NET_WM_STATE`
+/// client messages). The states Hyprland gives a user dispatcher are its
+/// window-state CAPABILITY ([`hyprland_state_capability`]); EWMH states outside
+/// it (app-set hints, the below layer, shading) have no Hyprland user action and
+/// lower to the empty word — they are never *generated* for a Hyprland binding
+/// (`representative_actions` excludes them; [`StateLoweringMatchesCapability`]
+/// witnesses the boundary, so the empty arm is intentional, not a silent drop).
+fn lower_state(d: &StateDelta) -> Vec<Dispatch> {
+    match d.bit {
+        StateBit::Fullscreen => vec![Dispatch::Fullscreen(0)],
+        StateBit::MaximizedVert | StateBit::MaximizedHorz => vec![Dispatch::Fullscreen(1)],
+        StateBit::Hidden => vec![Dispatch::MoveToWorkspaceSilent(WorkspaceTarget::Special(
+            "minimized".to_string(),
+        ))],
+        StateBit::Floating => vec![Dispatch::ToggleFloating],
+        StateBit::Above | StateBit::Sticky => vec![Dispatch::Pin],
+        StateBit::PseudoTiled => vec![Dispatch::Pseudo],
+        StateBit::Shaded
+        | StateBit::Below
+        | StateBit::SkipTaskbar
+        | StateBit::SkipPager
+        | StateBit::Modal
+        | StateBit::DemandsAttention
+        | StateBit::Focused => Vec::new(),
+    }
+}
+
+/// The window states Hyprland exposes a user dispatcher for — its window-state
+/// CAPABILITY. The EWMH atoms outside this set have no Hyprland user action and
+/// are excluded from Hyprland's generating set.
+fn hyprland_state_capability() -> [StateBit; 8] {
+    [
+        StateBit::Fullscreen,
+        StateBit::MaximizedVert,
+        StateBit::MaximizedHorz,
+        StateBit::Hidden,
+        StateBit::Floating,
+        StateBit::Above,
+        StateBit::Sticky,
+        StateBit::PseudoTiled,
+    ]
 }
 
 /// The realization functor `HyprlandRealization : ActionAlgebra → DispatchAlgebra`.
@@ -725,9 +793,9 @@ pub struct WindowStateActionsDistinct;
 
 impl Axiom for WindowStateActionsDistinct {
     fn verify(&self) -> Verdict {
-        let fs = realize(&WmAction::Fullscreen);
-        let mx = realize(&WmAction::Maximize);
-        let mn = realize(&WmAction::Minimize);
+        let fs = realize(&WmAction::fullscreen());
+        let mx = realize(&WmAction::maximize());
+        let mn = realize(&WmAction::minimize());
         if fs != mx && mx != mn && fs != mn {
             Ok(Box::new(SimpleProof::new(self.meta())))
         } else {
@@ -750,8 +818,8 @@ pub struct CompositeSequencePreserved;
 impl Axiom for CompositeSequencePreserved {
     fn verify(&self) -> Verdict {
         let w = HyprlandRealization::map_morphism(&ActionWord(vec![
-            WmAction::ToggleFloat,
-            WmAction::Pin,
+            WmAction::toggle_float(),
+            WmAction::pin(),
         ]));
         if w.0 == vec![Dispatch::ToggleFloating, Dispatch::Pin] {
             Ok(Box::new(SimpleProof::new(self.meta())))
@@ -764,6 +832,68 @@ impl Axiom for CompositeSequencePreserved {
         "CompositeSequencePreserved",
         "a composite action (float+pin) realizes to a two-dispatcher sequence, not a single opaque command",
         "Plotkin & Power (2003) Algebraic Operations and Generic Effects — sequenced effects compose in the free monoid"
+    );
+}
+
+/// The window-state mutations Hyprland realizes are **exactly** its declared
+/// window-state capability: `lower_state` is non-empty for a [`StateBit`] iff the
+/// bit is in [`hyprland_state_capability`]. This makes the empty-lowering arm an
+/// intentional, checked capability boundary (the EWMH hints / layers Hyprland has
+/// no user action for), never an accidental silent drop.
+pub struct StateLoweringMatchesCapability;
+
+impl Axiom for StateLoweringMatchesCapability {
+    fn verify(&self) -> Verdict {
+        let cap = hyprland_state_capability();
+        for bit in <StateBit as FinitelyGenerated>::variants() {
+            let realizable = !lower_state(&StateDelta::new(StateOp::Toggle, bit)).is_empty();
+            if realizable != cap.contains(&bit) {
+                return Err(Box::new(SimpleCounterexample::new(self.meta())));
+            }
+        }
+        Ok(Box::new(SimpleProof::new(self.meta())))
+    }
+
+    pr4xis::axiom_meta!(
+        "StateLoweringMatchesCapability",
+        "a window-state atom lowers to a non-empty Hyprland dispatcher exactly when it is in Hyprland's declared window-state capability",
+        "EWMH v1.5 (2013) §5 _NET_WM_STATE — the full state set; a backend realizes the subset its dispatchers expose (a capability), the rest are tracked gaps not silent drops"
+    );
+}
+
+/// The restructure into the window-state lattice is **byte-faithful**: each
+/// pre-restructure window-state verb still realizes to the exact Hyprland string
+/// it emitted before. The frozen golden corpus is the v1 contract; if any
+/// re-expression drifts a single byte, this axiom fails loudly (the migration
+/// gate the design demanded).
+pub struct MigrationFaithful;
+
+impl Axiom for MigrationFaithful {
+    fn verify(&self) -> Verdict {
+        // (the frozen v1 Hyprland string, the restructured term that must still emit it)
+        let golden: [(&str, WmAction); 6] = [
+            ("fullscreen", WmAction::fullscreen()),
+            ("fullscreen, 1", WmAction::maximize()),
+            (
+                "movetoworkspacesilent, special:minimized",
+                WmAction::minimize(),
+            ),
+            ("togglefloating,", WmAction::toggle_float()),
+            ("pin,", WmAction::pin()),
+            ("pseudo,", WmAction::pseudotile()),
+        ];
+        for (expected, action) in &golden {
+            if realize(action) != *expected {
+                return Err(Box::new(SimpleCounterexample::new(self.meta())));
+            }
+        }
+        Ok(Box::new(SimpleProof::new(self.meta())))
+    }
+
+    pr4xis::axiom_meta!(
+        "MigrationFaithful",
+        "every pre-restructure window-state verb realizes byte-for-byte to its frozen v1 Hyprland string",
+        "the v1 realized-string corpus is the migration contract; the state-lattice restructure is a behaviour-preserving re-expression of the source signature"
     );
 }
 
@@ -787,6 +917,8 @@ impl WindowActionOntology {
         all.push(Box::new(LoweringTotal));
         all.push(Box::new(WindowStateActionsDistinct));
         all.push(Box::new(CompositeSequencePreserved));
+        all.push(Box::new(StateLoweringMatchesCapability));
+        all.push(Box::new(MigrationFaithful));
         all
     }
 
@@ -884,10 +1016,10 @@ mod tests {
     fn fullscreen_maximize_minimize_are_distinct_verbs() {
         // Three distinct intents → three distinct dispatchers. Maximize is
         // fullscreen mode 1; minimize is the special-workspace emulation.
-        assert_eq!(realize(&WmAction::Fullscreen), "fullscreen");
-        assert_eq!(realize(&WmAction::Maximize), "fullscreen, 1");
+        assert_eq!(realize(&WmAction::fullscreen()), "fullscreen");
+        assert_eq!(realize(&WmAction::maximize()), "fullscreen, 1");
         assert_eq!(
-            realize(&WmAction::Minimize),
+            realize(&WmAction::minimize()),
             "movetoworkspacesilent, special:minimized"
         );
     }
@@ -895,8 +1027,8 @@ mod tests {
     #[test]
     fn fix_float_pin_is_two_dispatch_exec_batch() {
         let cmd = HyprlandRealization::map_morphism(&ActionWord(vec![
-            WmAction::ToggleFloat,
-            WmAction::Pin,
+            WmAction::toggle_float(),
+            WmAction::pin(),
         ]))
         .command();
         assert_eq!(

--- a/crates/domains/src/applied/hmi/input/wm_action.rs
+++ b/crates/domains/src/applied/hmi/input/wm_action.rs
@@ -290,6 +290,9 @@ pub enum WorkspaceTarget {
     /// A special / scratchpad workspace. Empty name = the default `special`
     /// scratchpad; a name = `special:hidden`, `special:minimized`, …
     Special(String),
+    /// The most-recently-used workspace (i3 `back_and_forth`; Hyprland
+    /// `workspace, previous`). Distinct from `Relative(±1)` adjacency.
+    Last,
 }
 
 impl WorkspaceTarget {
@@ -305,8 +308,40 @@ impl WorkspaceTarget {
                 }
             }
             WorkspaceTarget::Named(s) => s.clone(),
+            WorkspaceTarget::Last => "previous".to_string(),
             WorkspaceTarget::Special(s) if s.is_empty() => "special".to_string(),
             WorkspaceTarget::Special(s) => format!("special:{s}"),
+        }
+    }
+}
+
+/// A monitor / output selector — the parameter of the monitor focus/move
+/// operations (i3/sway `focus output` / `move container to output`; Hyprland
+/// `focusmonitor` / `movewindow mon:`). The multihead dimension EWMH names with
+/// `_NET_DESKTOP_VIEWPORT` / `_NET_DESKTOP_GEOMETRY`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum OutputSel {
+    /// The monitor in a spatial direction (`focusmonitor, l`).
+    Direction(Direction),
+    /// A named monitor / output (`focusmonitor, DP-1`).
+    Named(String),
+    /// A relative step in the monitor list (`focusmonitor, +1`).
+    Relative(i32),
+}
+
+impl OutputSel {
+    /// The Hyprland monitor argument.
+    fn render(&self) -> String {
+        match self {
+            OutputSel::Direction(d) => d.hypr().to_string(),
+            OutputSel::Named(s) => s.clone(),
+            OutputSel::Relative(k) => {
+                if *k >= 0 {
+                    format!("+{k}")
+                } else {
+                    k.to_string()
+                }
+            }
         }
     }
 }
@@ -384,6 +419,12 @@ pub enum WmAction {
     MoveToWorkspace(WorkspaceTarget, Follow),
     /// Toggle a special / scratchpad workspace overlay (e.g. an overview).
     ToggleSpecialWorkspace(String),
+    /// Move keyboard focus to another monitor / output (i3 `focus output`;
+    /// Hyprland `focusmonitor`).
+    FocusMonitor(OutputSel),
+    /// Send the focused window to another monitor / output (i3 `move container to
+    /// output`; Hyprland `movewindow mon:`).
+    MoveToMonitor(OutputSel),
     /// Run an external command. The **one blessed wire boundary**: the command
     /// line is genuine external data, not a vocabulary praxis controls — the
     /// reason [`WmAction`] is open-world (Reiter 1978).
@@ -464,6 +505,18 @@ impl WmAction {
         WmAction::Focus(FocusBy::Layer)
     }
 
+    /// Move keyboard focus to a monitor / output — `FocusMonitor(OutputSel)`
+    /// (Hyprland `focusmonitor`).
+    pub fn focus_monitor(sel: OutputSel) -> Self {
+        WmAction::FocusMonitor(sel)
+    }
+
+    /// Send the focused window to a monitor / output — `MoveToMonitor(OutputSel)`
+    /// (Hyprland `movewindow mon:`).
+    pub fn move_to_monitor(sel: OutputSel) -> Self {
+        WmAction::MoveToMonitor(sel)
+    }
+
     /// The finite generating set — one representative of every variant. Used to
     /// machine-check the realization functor (totality, the functor laws) and to
     /// seed property tests. This is a *generating* set, not the (open-world) whole
@@ -501,6 +554,9 @@ impl WmAction {
             WmAction::focus_parent(),
             WmAction::focus_layer(),
             WmAction::State(StateDelta::new(StateOp::Toggle, StateBit::Shaded)),
+            WmAction::focus_monitor(OutputSel::Direction(Left)),
+            WmAction::move_to_monitor(OutputSel::Direction(Right)),
+            WmAction::Workspace(WorkspaceTarget::Last),
             WmAction::Workspace(WorkspaceTarget::Index(1)),
             WmAction::Workspace(WorkspaceTarget::Relative(1)),
             WmAction::Workspace(WorkspaceTarget::Relative(-1)),
@@ -536,6 +592,8 @@ impl Concept for WmAction {
             WmAction::Workspace(_) => "workspace",
             WmAction::MoveToWorkspace(_, _) => "move-to-workspace",
             WmAction::ToggleSpecialWorkspace(_) => "toggle-special-workspace",
+            WmAction::FocusMonitor(_) => "focus-monitor",
+            WmAction::MoveToMonitor(_) => "move-to-monitor",
             WmAction::Exec(_) => "exec",
             WmAction::Submap(_) => "submap",
         }
@@ -574,6 +632,10 @@ pub enum Dispatch {
     MoveToWorkspace(WorkspaceTarget),
     MoveToWorkspaceSilent(WorkspaceTarget),
     ToggleSpecialWorkspace(String),
+    /// `focusmonitor, <sel>`.
+    FocusMonitor(OutputSel),
+    /// `movewindow, mon:<sel>`.
+    MoveToMonitor(OutputSel),
     /// `cyclenext,` or `cyclenext, prev`.
     CycleNext(bool),
     Exec(String),
@@ -607,6 +669,8 @@ impl Dispatch {
                 format!("movetoworkspacesilent, {}", w.render())
             }
             Dispatch::ToggleSpecialWorkspace(n) => format!("togglespecialworkspace, {n}"),
+            Dispatch::FocusMonitor(s) => format!("focusmonitor, {}", s.render()),
+            Dispatch::MoveToMonitor(s) => format!("movewindow, mon:{}", s.render()),
             Dispatch::CycleNext(prev) => {
                 if *prev {
                     "cyclenext, prev".to_string()
@@ -823,6 +887,8 @@ fn lower(action: &WmAction) -> Vec<Dispatch> {
             vec![Dispatch::MoveToWorkspaceSilent(w.clone())]
         }
         WmAction::ToggleSpecialWorkspace(n) => vec![Dispatch::ToggleSpecialWorkspace(n.clone())],
+        WmAction::FocusMonitor(s) => vec![Dispatch::FocusMonitor(s.clone())],
+        WmAction::MoveToMonitor(s) => vec![Dispatch::MoveToMonitor(s.clone())],
         WmAction::Exec(cmd) => vec![Dispatch::Exec(cmd.clone())],
         WmAction::Submap(t) => vec![Dispatch::Submap(t.render())],
     }
@@ -1216,6 +1282,28 @@ mod tests {
                 Follow::Silent
             )),
             "movetoworkspacesilent, special"
+        );
+    }
+
+    #[test]
+    fn realize_monitor_and_mru_workspace() {
+        // The monitor/output dimension Hyprland realizes natively.
+        assert_eq!(
+            realize(&WmAction::focus_monitor(OutputSel::Direction(
+                Direction::Left
+            ))),
+            "focusmonitor, l"
+        );
+        assert_eq!(
+            realize(&WmAction::move_to_monitor(OutputSel::Direction(
+                Direction::Right
+            ))),
+            "movewindow, mon:r"
+        );
+        // MRU / back-and-forth workspace.
+        assert_eq!(
+            realize(&WmAction::Workspace(WorkspaceTarget::Last)),
+            "workspace, previous"
         );
     }
 

--- a/crates/domains/src/applied/hmi/input/wm_action.rs
+++ b/crates/domains/src/applied/hmi/input/wm_action.rs
@@ -171,16 +171,54 @@ impl FinitelyGenerated for Orientation {
     }
 }
 
+/// A selector into the container TREE — the axis a tree-focus moves along
+/// (i3/sway `focus parent|child`; bspwm `@parent`/`@brother`). There is NO
+/// spatial direction here, which is exactly why tree-ascent cannot be a
+/// [`Direction`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TreeAxis {
+    Parent,
+    Child,
+    Sibling(Cycle),
+}
+
+impl Concept for TreeAxis {
+    fn name(&self) -> &'static str {
+        match self {
+            TreeAxis::Parent => "parent",
+            TreeAxis::Child => "child",
+            TreeAxis::Sibling(_) => "sibling",
+        }
+    }
+}
+impl FinitelyGenerated for TreeAxis {
+    fn variants() -> Vec<Self> {
+        vec![
+            TreeAxis::Parent,
+            TreeAxis::Child,
+            TreeAxis::Sibling(Cycle::Forward),
+            TreeAxis::Sibling(Cycle::Backward),
+        ]
+    }
+}
+
 /// How focus is selected — the parameter of the focus operation. A focus is
-/// always "move keyboard focus", but BY what: a spatial direction, or a cycle
-/// through the stack (Alt-Tab). (The container-tree and tiling/floating-layer
-/// selectors arrive with the capability framework.)
+/// always "move keyboard focus", but BY what: a spatial direction, a cycle
+/// through the stack (Alt-Tab), the container tree, or the tiling/floating layer.
+/// The tree and layer selectors are realized by backends that model a container
+/// tree / a focus-layer toggle (Sway); Hyprland exposes neither, so they fall
+/// outside its capability ([`hyprland_realizes`]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FocusBy {
     /// The spatial neighbour in a direction (`movefocus`).
     Direction(Direction),
     /// Cycle through windows in stacking order (Alt-Tab; `cyclenext`).
     Cycle(Cycle),
+    /// Along the container tree (i3 `focus parent|child`). No Hyprland dispatcher.
+    Tree(TreeAxis),
+    /// Toggle focus between the tiling and floating layers (i3 `focus
+    /// mode_toggle`). No Hyprland dispatcher.
+    Layer,
 }
 
 impl Concept for FocusBy {
@@ -188,6 +226,8 @@ impl Concept for FocusBy {
         match self {
             FocusBy::Direction(_) => "direction",
             FocusBy::Cycle(_) => "cycle",
+            FocusBy::Tree(_) => "tree",
+            FocusBy::Layer => "layer",
         }
     }
 }
@@ -200,6 +240,10 @@ impl FinitelyGenerated for FocusBy {
         for c in Cycle::variants() {
             v.push(FocusBy::Cycle(c));
         }
+        for t in TreeAxis::variants() {
+            v.push(FocusBy::Tree(t));
+        }
+        v.push(FocusBy::Layer);
         v
     }
 }
@@ -407,6 +451,19 @@ impl WmAction {
         WmAction::Focus(FocusBy::Cycle(cycle))
     }
 
+    /// Focus the parent container (tree-ascent) — `Focus(FocusBy::Tree(Parent))`.
+    /// No spatial direction; a container-tree backend (Sway `focus parent`)
+    /// realizes it, Hyprland does not (capability gap).
+    pub fn focus_parent() -> Self {
+        WmAction::Focus(FocusBy::Tree(TreeAxis::Parent))
+    }
+
+    /// Toggle focus between the tiling and floating layers —
+    /// `Focus(FocusBy::Layer)` (i3 `focus mode_toggle`). Hyprland capability gap.
+    pub fn focus_layer() -> Self {
+        WmAction::Focus(FocusBy::Layer)
+    }
+
     /// The finite generating set — one representative of every variant. Used to
     /// machine-check the realization functor (totality, the functor laws) and to
     /// seed property tests. This is a *generating* set, not the (open-world) whole
@@ -438,6 +495,12 @@ impl WmAction {
             WmAction::CycleGroup(Cycle::Forward),
             WmAction::cycle_window(Cycle::Forward),
             WmAction::cycle_window(Cycle::Backward),
+            // Capability-gap representatives: the generalized ontology expresses
+            // these, Hyprland realizes none (they lower to the empty word, witnessed
+            // by RealizationMatchesCapability; Sway realizes the two focus gaps).
+            WmAction::focus_parent(),
+            WmAction::focus_layer(),
+            WmAction::State(StateDelta::new(StateOp::Toggle, StateBit::Shaded)),
             WmAction::Workspace(WorkspaceTarget::Index(1)),
             WmAction::Workspace(WorkspaceTarget::Relative(1)),
             WmAction::Workspace(WorkspaceTarget::Relative(-1)),
@@ -728,6 +791,10 @@ fn lower(action: &WmAction) -> Vec<Dispatch> {
         WmAction::Focus(FocusBy::Cycle(c)) => {
             vec![Dispatch::CycleNext(matches!(c, Cycle::Backward))]
         }
+        // Hyprland has no container tree and no tiling/floating focus-layer toggle
+        // — outside its capability; lowers to the empty word (Sway realizes
+        // `focus parent` / `focus mode_toggle` — see lower_sway).
+        WmAction::Focus(FocusBy::Tree(_)) | WmAction::Focus(FocusBy::Layer) => Vec::new(),
         WmAction::MoveWindow(d) => vec![Dispatch::MoveWindow(*d)],
         WmAction::SwapWindow(d) => vec![Dispatch::SwapWindow(*d)],
         WmAction::Resize(d, amt) => {
@@ -808,6 +875,22 @@ fn hyprland_state_capability() -> [StateBit; 8] {
     ]
 }
 
+/// Whether Hyprland has a user realization for an action — its CAPABILITY. The
+/// generalized ontology can express operations Hyprland exposes no dispatcher for
+/// (container-tree focus, the tiling/floating focus-layer toggle, the EWMH window
+/// states outside [`hyprland_state_capability`]); those lower to the empty word
+/// and are excluded from Hyprland's generating set. A backend that DOES expose
+/// them (Sway) declares a wider capability. [`LoweringTotal`] proves the lowering
+/// is total ON this capability; [`RealizationMatchesCapability`] proves the empty
+/// arms are EXACTLY its complement — the gaps are checked, never silent drops.
+pub fn hyprland_realizes(action: &WmAction) -> bool {
+    match action {
+        WmAction::State(d) => hyprland_state_capability().contains(&d.bit),
+        WmAction::Focus(FocusBy::Tree(_)) | WmAction::Focus(FocusBy::Layer) => false,
+        _ => true,
+    }
+}
+
 /// The realization functor `HyprlandRealization : ActionAlgebra → DispatchAlgebra`.
 ///
 /// On the single object it is the identity; on morphisms it lowers each action
@@ -859,6 +942,11 @@ pub struct LoweringTotal;
 impl Axiom for LoweringTotal {
     fn verify(&self) -> Verdict {
         for a in WmAction::representative_actions() {
+            if !hyprland_realizes(&a) {
+                // Outside Hyprland's capability — the empty lowering is intentional
+                // and checked by RealizationMatchesCapability, not asserted here.
+                continue;
+            }
             let w = HyprlandRealization::map_morphism(&ActionWord::from(a));
             if w.0.is_empty() {
                 return Err(Box::new(SimpleCounterexample::new(self.meta())));
@@ -869,8 +957,8 @@ impl Axiom for LoweringTotal {
 
     pr4xis::axiom_meta!(
         "LoweringTotal",
-        "every abstract action realizes to a non-empty dispatcher sequence (total projection)",
-        "Goguen, Thatcher & Wagner (1978) An Initial Algebra Approach to ADTs — the initial algebra has a unique (total) homomorphism into any algebra of the signature; Card, Moran & Newell (1983) GOMS — every goal has a method"
+        "every action within Hyprland's capability realizes to a non-empty dispatcher sequence (total on the capability)",
+        "Goguen, Thatcher & Wagner (1978) An Initial Algebra Approach to ADTs — a unique homomorphism on the signature; Card, Moran & Newell (1983) GOMS — every goal has a method; a backend realizes the operations within its capability (the rest are tracked gaps)"
     );
 }
 
@@ -988,6 +1076,35 @@ impl Axiom for MigrationFaithful {
     );
 }
 
+/// Every action realizes to the empty word **exactly** when it is outside
+/// Hyprland's capability ([`hyprland_realizes`]). The capability gaps (the
+/// container-tree / focus-layer selectors, the EWMH states with no Hyprland user
+/// dispatcher) are therefore a checked boundary across the whole generating set:
+/// no in-capability action silently drops, and no out-of-capability action is
+/// silently faked. The dual of [`LoweringTotal`] (total ON the capability).
+pub struct RealizationMatchesCapability;
+
+impl Axiom for RealizationMatchesCapability {
+    fn verify(&self) -> Verdict {
+        for a in WmAction::representative_actions() {
+            let empty = HyprlandRealization::map_morphism(&ActionWord::from(a.clone()))
+                .0
+                .is_empty();
+            // empty <=> !realizes; a mismatch (silent drop or phantom realization) fails.
+            if empty == hyprland_realizes(&a) {
+                return Err(Box::new(SimpleCounterexample::new(self.meta())));
+            }
+        }
+        Ok(Box::new(SimpleProof::new(self.meta())))
+    }
+
+    pr4xis::axiom_meta!(
+        "RealizationMatchesCapability",
+        "an action lowers to the empty word exactly when it is outside the backend's capability (checked gaps, never silent drops)",
+        "EWMH v1.5 (2013) / i3 & sway — backends realize a subset of the general operation set (a capability); ext-workspace-v1's capabilities enum makes unsupported operations explicit rather than silently inert"
+    );
+}
+
 // ── The ontology ──────────────────────────────────────────────────────────────
 
 /// The window-action ontology. Validating it discharges the realization functor
@@ -1010,6 +1127,7 @@ impl WindowActionOntology {
         all.push(Box::new(CompositeSequencePreserved));
         all.push(Box::new(StateLoweringMatchesCapability));
         all.push(Box::new(MigrationFaithful));
+        all.push(Box::new(RealizationMatchesCapability));
         all
     }
 
@@ -1206,6 +1324,9 @@ mod tests {
         /// dispatcher — there are no unbound placeholders left in the wire form.
         #[test]
         fn prop_single_action_realizes_nonempty(a in arb_action()) {
+            // Only in-capability actions realize non-empty; the capability gaps
+            // (tree/layer focus, unsupported states) intentionally lower to empty.
+            prop_assume!(hyprland_realizes(&a));
             let w = HyprlandRealization::map_morphism(&ActionWord::from(a));
             prop_assert!(!w.0.is_empty());
             let cmd = w.command();

--- a/crates/domains/src/applied/hmi/input/wm_action.rs
+++ b/crates/domains/src/applied/hmi/input/wm_action.rs
@@ -74,8 +74,9 @@ use super::window_state::{StateBit, StateDelta, StateOp};
 ///
 /// A strongly-typed variable over a small closed value-set (Payne & Green 1986);
 /// the value domain is EWMH's `_NET_WM_MOVERESIZE` direction family restricted to
-/// the four cardinals the presets use (diagonals are deferred — see the pack
-/// README). Hyprland names them `l`/`r`/`u`/`d`.
+/// the four cardinals the presets use (diagonals are out of the four-cardinal
+/// set — a diagonal extension is a tracked follow-up, not a hidden default).
+/// Hyprland names them `l`/`r`/`u`/`d`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Direction {
     Left,
@@ -167,6 +168,42 @@ impl FinitelyGenerated for Orientation {
             Orientation::Horizontal,
             Orientation::Vertical,
             Orientation::Toggle,
+        ]
+    }
+}
+
+/// A container DISPLAY layout — the parameter of the layout operation (i3/sway
+/// `layout default|stacking|tabbed`). The split-orientation layouts (`splith`/
+/// `splitv`) are the separate [`Split`](WmAction::Split) operation, not duplicated
+/// here. A backend without named layouts (Hyprland) realizes only `tabbed` (via
+/// its window-group mechanism) and gaps the rest.
+///
+/// Source: i3 User's Guide "Manipulating layout"; sway(5) `layout`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LayoutKind {
+    /// The workspace's default tiling layout.
+    Default,
+    /// A stacked container (one window shown, titles listed).
+    Stacking,
+    /// A tabbed container (one window shown, tabs across the top).
+    Tabbed,
+}
+
+impl Concept for LayoutKind {
+    fn name(&self) -> &'static str {
+        match self {
+            LayoutKind::Default => "default",
+            LayoutKind::Stacking => "stacking",
+            LayoutKind::Tabbed => "tabbed",
+        }
+    }
+}
+impl FinitelyGenerated for LayoutKind {
+    fn variants() -> Vec<Self> {
+        vec![
+            LayoutKind::Default,
+            LayoutKind::Stacking,
+            LayoutKind::Tabbed,
         ]
     }
 }
@@ -409,6 +446,10 @@ pub enum WmAction {
     Split(Orientation),
     /// Toggle grouping (tabbed group) for the focused window.
     ToggleGroup,
+    /// Set the container's display layout (i3/sway `layout default|stacking|
+    /// tabbed`). Hyprland realizes only `tabbed` (its window groups); `stacking`
+    /// and `default` are gaps there (Sway realizes all three).
+    Layout(LayoutKind),
     /// Cycle the active window *within* the current group.
     CycleGroup(Cycle),
     /// Switch to a workspace (Henderson & Card 1986 *Rooms*; EWMH
@@ -417,6 +458,12 @@ pub enum WmAction {
     /// Send the focused window to a workspace, optionally following it (EWMH
     /// `_NET_WM_DESKTOP`).
     MoveToWorkspace(WorkspaceTarget, Follow),
+    /// Rename a workspace — the one explicit workspace-lifecycle op (i3/sway
+    /// `rename workspace`; Hyprland `renameworkspace`). Workspace CREATE is
+    /// implicit (switching to a non-existent target via [`Workspace`](WmAction::Workspace)
+    /// creates it) and DESTROY is implicit (empty workspaces auto-reap) on both
+    /// backends — neither is a distinct keybind action.
+    RenameWorkspace(WorkspaceTarget, String),
     /// Toggle a special / scratchpad workspace overlay (e.g. an overview).
     ToggleSpecialWorkspace(String),
     /// Move keyboard focus to another monitor / output (i3 `focus output`;
@@ -517,6 +564,18 @@ impl WmAction {
         WmAction::MoveToMonitor(sel)
     }
 
+    /// Set the container display layout — `Layout(LayoutKind)` (i3/sway
+    /// `layout …`).
+    pub fn layout(kind: LayoutKind) -> Self {
+        WmAction::Layout(kind)
+    }
+
+    /// Rename a workspace — `RenameWorkspace` (Hyprland `renameworkspace`; sway
+    /// `rename workspace to`).
+    pub fn rename_workspace(target: WorkspaceTarget, name: impl Into<String>) -> Self {
+        WmAction::RenameWorkspace(target, name.into())
+    }
+
     /// The finite generating set — one representative of every variant. Used to
     /// machine-check the realization functor (totality, the functor laws) and to
     /// seed property tests. This is a *generating* set, not the (open-world) whole
@@ -545,6 +604,8 @@ impl WmAction {
             WmAction::Split(Orientation::Horizontal),
             WmAction::Split(Orientation::Vertical),
             WmAction::ToggleGroup,
+            WmAction::Layout(LayoutKind::Tabbed),
+            WmAction::Layout(LayoutKind::Stacking),
             WmAction::CycleGroup(Cycle::Forward),
             WmAction::cycle_window(Cycle::Forward),
             WmAction::cycle_window(Cycle::Backward),
@@ -569,6 +630,7 @@ impl WmAction {
                 Follow::Silent,
             ),
             WmAction::MoveToWorkspace(WorkspaceTarget::Special(String::new()), Follow::Silent),
+            WmAction::RenameWorkspace(WorkspaceTarget::Index(1), "work".to_string()),
             WmAction::ToggleSpecialWorkspace("overview".to_string()),
             WmAction::Exec("$TERMINAL".to_string()),
             WmAction::Submap(SubmapTarget::Enter(ModeId::new("resize"))),
@@ -588,9 +650,11 @@ impl Concept for WmAction {
             WmAction::State(_) => "state",
             WmAction::Split(_) => "split",
             WmAction::ToggleGroup => "toggle-group",
+            WmAction::Layout(_) => "layout",
             WmAction::CycleGroup(_) => "cycle-group",
             WmAction::Workspace(_) => "workspace",
             WmAction::MoveToWorkspace(_, _) => "move-to-workspace",
+            WmAction::RenameWorkspace(_, _) => "rename-workspace",
             WmAction::ToggleSpecialWorkspace(_) => "toggle-special-workspace",
             WmAction::FocusMonitor(_) => "focus-monitor",
             WmAction::MoveToMonitor(_) => "move-to-monitor",
@@ -631,6 +695,8 @@ pub enum Dispatch {
     Workspace(WorkspaceTarget),
     MoveToWorkspace(WorkspaceTarget),
     MoveToWorkspaceSilent(WorkspaceTarget),
+    /// `renameworkspace, <id> <name>`.
+    RenameWorkspace(WorkspaceTarget, String),
     ToggleSpecialWorkspace(String),
     /// `focusmonitor, <sel>`.
     FocusMonitor(OutputSel),
@@ -667,6 +733,9 @@ impl Dispatch {
             Dispatch::MoveToWorkspace(w) => format!("movetoworkspace, {}", w.render()),
             Dispatch::MoveToWorkspaceSilent(w) => {
                 format!("movetoworkspacesilent, {}", w.render())
+            }
+            Dispatch::RenameWorkspace(w, name) => {
+                format!("renameworkspace, {} {name}", w.render())
             }
             Dispatch::ToggleSpecialWorkspace(n) => format!("togglespecialworkspace, {n}"),
             Dispatch::FocusMonitor(s) => format!("focusmonitor, {}", s.render()),
@@ -877,6 +946,10 @@ fn lower(action: &WmAction) -> Vec<Dispatch> {
         // here (Sway realizes split horizontal/vertical distinctly — see lower_sway).
         WmAction::Split(_) => vec![Dispatch::LayoutMsg("togglesplit")],
         WmAction::ToggleGroup => vec![Dispatch::ToggleGroup],
+        // Hyprland realizes the tabbed layout via its window groups; stacking and
+        // the default tiling layout have no dispatcher (Sway realizes all three).
+        WmAction::Layout(LayoutKind::Tabbed) => vec![Dispatch::ToggleGroup],
+        WmAction::Layout(LayoutKind::Stacking | LayoutKind::Default) => Vec::new(),
         WmAction::CycleGroup(c) => vec![Dispatch::ChangeGroupActive(match c {
             Cycle::Forward => 'f',
             Cycle::Backward => 'b',
@@ -885,6 +958,9 @@ fn lower(action: &WmAction) -> Vec<Dispatch> {
         WmAction::MoveToWorkspace(w, Follow::Follow) => vec![Dispatch::MoveToWorkspace(w.clone())],
         WmAction::MoveToWorkspace(w, Follow::Silent) => {
             vec![Dispatch::MoveToWorkspaceSilent(w.clone())]
+        }
+        WmAction::RenameWorkspace(w, name) => {
+            vec![Dispatch::RenameWorkspace(w.clone(), name.clone())]
         }
         WmAction::ToggleSpecialWorkspace(n) => vec![Dispatch::ToggleSpecialWorkspace(n.clone())],
         WmAction::FocusMonitor(s) => vec![Dispatch::FocusMonitor(s.clone())],
@@ -953,6 +1029,8 @@ pub fn hyprland_realizes(action: &WmAction) -> bool {
     match action {
         WmAction::State(d) => hyprland_state_capability().contains(&d.bit),
         WmAction::Focus(FocusBy::Tree(_)) | WmAction::Focus(FocusBy::Layer) => false,
+        WmAction::Layout(LayoutKind::Tabbed) => true,
+        WmAction::Layout(_) => false,
         _ => true,
     }
 }
@@ -1195,6 +1273,7 @@ fn lower_sway(action: &WmAction) -> Vec<SwayCmd> {
             Orientation::Toggle => "split toggle",
         }),
         WmAction::ToggleGroup => one("layout toggle split tabbed"),
+        WmAction::Layout(k) => one(&format!("layout {}", k.name())),
         WmAction::CycleGroup(c) => one(match c {
             Cycle::Forward => "focus next",
             Cycle::Backward => "focus prev",
@@ -1213,6 +1292,7 @@ fn lower_sway(action: &WmAction) -> Vec<SwayCmd> {
                 SwayCmd::new(format!("workspace {ws}")),
             ]
         }
+        WmAction::RenameWorkspace(_, name) => one(&format!("rename workspace to {name}")),
         WmAction::ToggleSpecialWorkspace(_) => one("scratchpad show"),
         WmAction::FocusMonitor(s) => one(&format!("focus output {}", sway_output(s))),
         WmAction::MoveToMonitor(s) => one(&format!("move container to output {}", sway_output(s))),

--- a/crates/domains/src/applied/hmi/input/wm_action.rs
+++ b/crates/domains/src/applied/hmi/input/wm_action.rs
@@ -978,9 +978,12 @@ fn lower(action: &WmAction) -> Vec<Dispatch> {
 /// client messages). The states Hyprland gives a user dispatcher are its
 /// window-state CAPABILITY (`hyprland_state_capability`); EWMH states outside
 /// it (app-set hints, the below layer, shading) have no Hyprland user action and
-/// lower to the empty word — they are never *generated* for a Hyprland binding
-/// (`representative_actions` excludes them; [`StateLoweringMatchesCapability`]
-/// witnesses the boundary, so the empty arm is intentional, not a silent drop).
+/// lower to the empty word. That empty arm is INTENTIONAL and checked, not a
+/// silent drop: [`StateLoweringMatchesCapability`] proves it fires exactly outside
+/// the capability. (`representative_actions` deliberately includes a few
+/// out-of-capability witnesses — e.g. `Shaded` — to exercise that proof; a
+/// Hyprland-targeting preset is expected to bind only in-capability actions, a
+/// consumer gating on [`hyprland_realizes`].)
 fn lower_state(d: &StateDelta) -> Vec<Dispatch> {
     match d.bit {
         StateBit::Fullscreen => vec![Dispatch::Fullscreen(0)],

--- a/crates/domains/src/applied/hmi/input/wm_action.rs
+++ b/crates/domains/src/applied/hmi/input/wm_action.rs
@@ -138,6 +138,39 @@ impl FinitelyGenerated for Cycle {
     }
 }
 
+/// The orientation of a tiling split — the parameter of the split operation
+/// (i3/sway `split horizontal|vertical|toggle`).
+///
+/// A strongly-typed variable over i3's split value-set (Payne & Green 1986).
+/// `Toggle` flips the current orientation — the third value, not a separate verb.
+/// Hyprland exposes only the toggle, so the absolute orientations collapse to it
+/// there; a directed backend (Sway `split horizontal`) realizes them distinctly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Orientation {
+    Horizontal,
+    Vertical,
+    Toggle,
+}
+
+impl Concept for Orientation {
+    fn name(&self) -> &'static str {
+        match self {
+            Orientation::Horizontal => "horizontal",
+            Orientation::Vertical => "vertical",
+            Orientation::Toggle => "toggle",
+        }
+    }
+}
+impl FinitelyGenerated for Orientation {
+    fn variants() -> Vec<Self> {
+        vec![
+            Orientation::Horizontal,
+            Orientation::Vertical,
+            Orientation::Toggle,
+        ]
+    }
+}
+
 /// Whether moving a window to a workspace **follows** it (focus travels) or is
 /// **silent** (window leaves, focus stays).
 ///
@@ -255,9 +288,11 @@ pub enum WmAction {
     /// direction — restore / unmaximize — expressible as `State { Remove, … }`,
     /// which a flat verb set could not name.
     State(StateDelta),
-    /// Toggle the split orientation of the layout (Hyprland `layoutmsg
-    /// togglesplit`).
-    ToggleSplit,
+    /// Set or toggle the split orientation of the tiling layout — i3/sway
+    /// `split h|v|toggle`. Hyprland exposes only the toggle (`layoutmsg
+    /// togglesplit`), so all orientations collapse to it there; a backend with
+    /// absolute split (Sway `split horizontal`) realizes them distinctly.
+    Split(Orientation),
     /// Toggle grouping (tabbed group) for the focused window.
     ToggleGroup,
     /// Cycle the active window *within* the current group.
@@ -322,6 +357,12 @@ impl WmAction {
         WmAction::State(StateDelta::new(StateOp::Toggle, StateBit::PseudoTiled))
     }
 
+    /// Toggle the tiling split orientation — `Split(Orientation::Toggle)` (i3
+    /// `split toggle`; Hyprland `layoutmsg togglesplit`).
+    pub fn toggle_split() -> Self {
+        WmAction::Split(Orientation::Toggle)
+    }
+
     /// The finite generating set — one representative of every variant. Used to
     /// machine-check the realization functor (totality, the functor laws) and to
     /// seed property tests. This is a *generating* set, not the (open-world) whole
@@ -346,7 +387,9 @@ impl WmAction {
             WmAction::toggle_float(),
             WmAction::pin(),
             WmAction::pseudotile(),
-            WmAction::ToggleSplit,
+            WmAction::Split(Orientation::Toggle),
+            WmAction::Split(Orientation::Horizontal),
+            WmAction::Split(Orientation::Vertical),
             WmAction::ToggleGroup,
             WmAction::CycleGroup(Cycle::Forward),
             WmAction::CycleWindow(Cycle::Forward),
@@ -380,7 +423,7 @@ impl Concept for WmAction {
             WmAction::Resize(_, _) => "resize",
             WmAction::Close => "close",
             WmAction::State(_) => "state",
-            WmAction::ToggleSplit => "toggle-split",
+            WmAction::Split(_) => "split",
             WmAction::ToggleGroup => "toggle-group",
             WmAction::CycleGroup(_) => "cycle-group",
             WmAction::CycleWindow(_) => "cycle-window",
@@ -653,7 +696,9 @@ fn lower(action: &WmAction) -> Vec<Dispatch> {
         }
         WmAction::Close => vec![Dispatch::KillActive],
         WmAction::State(d) => lower_state(d),
-        WmAction::ToggleSplit => vec![Dispatch::LayoutMsg("togglesplit")],
+        // Hyprland exposes only the split toggle; all orientations collapse to it
+        // here (Sway realizes split horizontal/vertical distinctly — see lower_sway).
+        WmAction::Split(_) => vec![Dispatch::LayoutMsg("togglesplit")],
         WmAction::ToggleGroup => vec![Dispatch::ToggleGroup],
         WmAction::CycleGroup(c) => vec![Dispatch::ChangeGroupActive(match c {
             Cycle::Forward => 'f',
@@ -871,7 +916,7 @@ pub struct MigrationFaithful;
 impl Axiom for MigrationFaithful {
     fn verify(&self) -> Verdict {
         // (the frozen v1 Hyprland string, the restructured term that must still emit it)
-        let golden: [(&str, WmAction); 6] = [
+        let golden: [(&str, WmAction); 7] = [
             ("fullscreen", WmAction::fullscreen()),
             ("fullscreen, 1", WmAction::maximize()),
             (
@@ -881,6 +926,7 @@ impl Axiom for MigrationFaithful {
             ("togglefloating,", WmAction::toggle_float()),
             ("pin,", WmAction::pin()),
             ("pseudo,", WmAction::pseudotile()),
+            ("layoutmsg, togglesplit", WmAction::toggle_split()),
         ];
         for (expected, action) in &golden {
             if realize(action) != *expected {

--- a/crates/domains/src/applied/hmi/input/wm_action.rs
+++ b/crates/domains/src/applied/hmi/input/wm_action.rs
@@ -999,6 +999,268 @@ pub fn realize(action: &WmAction) -> String {
     HyprlandRealization::map_morphism(&ActionWord::from(action.clone())).command()
 }
 
+// ── A second backend: SwayRealization (the generality is load-bearing) ────────
+
+/// A single sway command — the realization atom for the [`SwayRealization`]
+/// backend. Unlike Hyprland's typed [`Dispatch`], sway's command language is a
+/// flat string vocabulary (i3-inherited), so the atom carries the exact, CITED
+/// sway(5) command text; [`SwayCmd::render`] is its (identity) wire form.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SwayCmd(pub String);
+
+impl SwayCmd {
+    fn new(s: impl Into<String>) -> Self {
+        SwayCmd(s.into())
+    }
+    /// The wire form — the sway command string.
+    pub fn render(&self) -> String {
+        self.0.clone()
+    }
+}
+
+/// A word in the free monoid of sway commands — the realization of an action word.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SwayWord(pub Vec<SwayCmd>);
+
+impl SwayWord {
+    /// The command string a single keybind emits; a composite chains with `; `
+    /// (sway's command separator).
+    pub fn command(&self) -> String {
+        self.0
+            .iter()
+            .map(SwayCmd::render)
+            .collect::<Vec<_>>()
+            .join("; ")
+    }
+}
+
+impl Arrow for SwayWord {
+    type Object = WmSurface;
+    type Kind = ();
+    fn source(&self) -> WmSurface {
+        WmSurface::Compositor
+    }
+    fn target(&self) -> WmSurface {
+        WmSurface::Compositor
+    }
+    fn kind(&self) {}
+}
+
+/// The free monoid on [`SwayCmd`] — the [`SwayRealization`] functor target.
+pub struct SwayAlgebra;
+
+impl Category for SwayAlgebra {
+    type Object = WmSurface;
+    type Morphism = SwayWord;
+    fn identity(_: &WmSurface) -> SwayWord {
+        SwayWord(Vec::new())
+    }
+    fn compose(f: &SwayWord, g: &SwayWord) -> Option<SwayWord> {
+        let mut w = f.0.clone();
+        w.extend(g.0.iter().cloned());
+        Some(SwayWord(w))
+    }
+    fn morphisms() -> Vec<SwayWord> {
+        let mut ms = vec![SwayWord(Vec::new())];
+        ms.extend(
+            WmAction::representative_actions()
+                .iter()
+                .map(|a| SwayWord(lower_sway(a))),
+        );
+        ms
+    }
+}
+
+/// The window states sway exposes a command for — its window-state capability.
+/// Sway lacks a distinct maximize, pseudo-tiling, shading, the below layer, and
+/// the EWMH hints; its `sticky` realizes above/pin (for floating windows).
+fn sway_state_capability() -> [StateBit; 5] {
+    [
+        StateBit::Fullscreen,
+        StateBit::Hidden,
+        StateBit::Floating,
+        StateBit::Above,
+        StateBit::Sticky,
+    ]
+}
+
+/// Whether sway has a command for an action — its CAPABILITY. Distinct from
+/// Hyprland's: sway realizes the container-tree / focus-layer / named-layout /
+/// split-orientation operations Hyprland lacks, but lacks the maximize / pseudo-
+/// tile / shade / directional-swap that Hyprland has. The capability sets
+/// DIFFERING per backend is exactly what makes the source backend-independent.
+pub fn sway_realizes(action: &WmAction) -> bool {
+    match action {
+        WmAction::State(d) => sway_state_capability().contains(&d.bit),
+        // sway `swap container with` targets a mark/id, never a bare direction.
+        WmAction::SwapWindow(_) => false,
+        _ => true,
+    }
+}
+
+/// The sway workspace argument for a non-special target (`number N` / `next` /
+/// `prev` / a name / `back_and_forth`).
+fn sway_ws(t: &WorkspaceTarget) -> String {
+    match t {
+        WorkspaceTarget::Index(n) => format!("number {n}"),
+        WorkspaceTarget::Relative(k) => {
+            if *k >= 0 {
+                "next".to_string()
+            } else {
+                "prev".to_string()
+            }
+        }
+        WorkspaceTarget::Named(s) => s.clone(),
+        WorkspaceTarget::Last => "back_and_forth".to_string(),
+        // Special is a Hyprland concept; sway's analogue is the scratchpad,
+        // handled at the call site.
+        WorkspaceTarget::Special(_) => "scratchpad".to_string(),
+    }
+}
+
+/// The sway monitor argument (`left|right|up|down` / a name / `next`|`prev`).
+fn sway_output(s: &OutputSel) -> String {
+    match s {
+        OutputSel::Direction(d) => d.name().to_string(),
+        OutputSel::Named(n) => n.clone(),
+        OutputSel::Relative(k) => {
+            if *k >= 0 {
+                "next".to_string()
+            } else {
+                "prev".to_string()
+            }
+        }
+    }
+}
+
+/// Lower a window-state mutation to sway. Sway exposes only toggles (the EWMH
+/// add/remove/toggle distinction is not observable, as on Hyprland). The states
+/// sway lacks (maximize / pseudo / shade / below / hints) lower to the empty word.
+fn lower_sway_state(d: &StateDelta) -> Vec<SwayCmd> {
+    match d.bit {
+        StateBit::Fullscreen => vec![SwayCmd::new("fullscreen toggle")],
+        StateBit::Hidden => vec![SwayCmd::new("move scratchpad")],
+        StateBit::Floating => vec![SwayCmd::new("floating toggle")],
+        // sway `sticky` pins floating windows across workspaces — its above/pin analogue.
+        StateBit::Above | StateBit::Sticky => vec![SwayCmd::new("sticky toggle")],
+        StateBit::MaximizedVert
+        | StateBit::MaximizedHorz
+        | StateBit::PseudoTiled
+        | StateBit::Shaded
+        | StateBit::Below
+        | StateBit::SkipTaskbar
+        | StateBit::SkipPager
+        | StateBit::Modal
+        | StateBit::DemandsAttention
+        | StateBit::Focused => Vec::new(),
+    }
+}
+
+/// Lower one abstract action to its sway command(s) — the cited per-action rule
+/// for the sway backend (sway(5) / i3 User's Guide). Operations sway has no
+/// command for (maximize, pseudo-tile, shade, directional swap) lower to the
+/// empty word, excluded from sway's generating set by [`sway_realizes`].
+fn lower_sway(action: &WmAction) -> Vec<SwayCmd> {
+    let one = |s: &str| vec![SwayCmd::new(s)];
+    match action {
+        WmAction::Focus(FocusBy::Direction(d)) => one(&format!("focus {}", d.name())),
+        WmAction::Focus(FocusBy::Cycle(c)) => one(match c {
+            Cycle::Forward => "focus next",
+            Cycle::Backward => "focus prev",
+        }),
+        WmAction::Focus(FocusBy::Tree(axis)) => one(match axis {
+            TreeAxis::Parent => "focus parent",
+            TreeAxis::Child => "focus child",
+            TreeAxis::Sibling(Cycle::Forward) => "focus next sibling",
+            TreeAxis::Sibling(Cycle::Backward) => "focus prev sibling",
+        }),
+        WmAction::Focus(FocusBy::Layer) => one("focus mode_toggle"),
+        WmAction::MoveWindow(d) => one(&format!("move {}", d.name())),
+        // sway swap requires a mark/id target — no directional form (capability gap).
+        WmAction::SwapWindow(_) => Vec::new(),
+        WmAction::Resize(d, amt) => {
+            let (verb, axis) = match d {
+                Direction::Left => ("shrink", "width"),
+                Direction::Right => ("grow", "width"),
+                Direction::Up => ("shrink", "height"),
+                Direction::Down => ("grow", "height"),
+            };
+            one(&format!("resize {verb} {axis} {amt} px"))
+        }
+        WmAction::Close => one("kill"),
+        WmAction::State(d) => lower_sway_state(d),
+        WmAction::Split(o) => one(match o {
+            Orientation::Horizontal => "split horizontal",
+            Orientation::Vertical => "split vertical",
+            Orientation::Toggle => "split toggle",
+        }),
+        WmAction::ToggleGroup => one("layout toggle split tabbed"),
+        WmAction::CycleGroup(c) => one(match c {
+            Cycle::Forward => "focus next",
+            Cycle::Backward => "focus prev",
+        }),
+        WmAction::Workspace(WorkspaceTarget::Special(_)) => one("scratchpad show"),
+        WmAction::Workspace(t) => one(&format!("workspace {}", sway_ws(t))),
+        WmAction::MoveToWorkspace(WorkspaceTarget::Special(_), _) => one("move scratchpad"),
+        WmAction::MoveToWorkspace(t, Follow::Silent) => {
+            one(&format!("move container to workspace {}", sway_ws(t)))
+        }
+        WmAction::MoveToWorkspace(t, Follow::Follow) => {
+            // sway has no move-and-follow flag — chain the move and the switch.
+            let ws = sway_ws(t);
+            vec![
+                SwayCmd::new(format!("move container to workspace {ws}")),
+                SwayCmd::new(format!("workspace {ws}")),
+            ]
+        }
+        WmAction::ToggleSpecialWorkspace(_) => one("scratchpad show"),
+        WmAction::FocusMonitor(s) => one(&format!("focus output {}", sway_output(s))),
+        WmAction::MoveToMonitor(s) => one(&format!("move container to output {}", sway_output(s))),
+        WmAction::Exec(cmd) => one(&format!("exec {cmd}")),
+        WmAction::Submap(SubmapTarget::Enter(m)) => one(&format!("mode {}", m.0)),
+        WmAction::Submap(SubmapTarget::Reset) => one("mode default"),
+    }
+}
+
+/// The realization functor `SwayRealization : ActionAlgebra → SwayAlgebra` — a
+/// SECOND backend over the SAME source, proving the source is backend-independent
+/// (the generality is load-bearing, not YAGNI). Sway realizes natively the
+/// container-tree / focus-layer / named-layout / split-orientation operations
+/// Hyprland gaps; Hyprland realizes the maximize / pseudo-tile / directional-swap
+/// sway gaps. Both are total monoid homomorphisms on their respective capability.
+pub struct SwayRealization;
+
+impl Functor for SwayRealization {
+    type Source = ActionAlgebra;
+    type Target = SwayAlgebra;
+
+    fn map_object(_: &WmSurface) -> WmSurface {
+        WmSurface::Compositor
+    }
+
+    fn map_morphism(word: &ActionWord) -> SwayWord {
+        SwayWord(word.0.iter().flat_map(lower_sway).collect())
+    }
+
+    fn meta() -> Provenance {
+        Provenance {
+            name: OntologyName::new_static("SwayRealization"),
+            description: Label::new_static(
+                "abstract WM actions → sway command sequences (a second backend realization)",
+            ),
+            citation: Citation::parse_static(
+                "sway(5) — the sway command language (i3-inherited); a second algebra of the WM-action signature, so the projection is the forced unique homomorphism (Goguen-Thatcher-Wagner 1978)",
+            ),
+            module_path: ModulePath::new_static(module_path!()),
+        }
+    }
+}
+
+/// Convenience: the sway command string a single action emits.
+pub fn sway_realize(action: &WmAction) -> String {
+    SwayRealization::map_morphism(&ActionWord::from(action.clone())).command()
+}
+
 // ── Domain axioms ─────────────────────────────────────────────────────────────
 
 /// Every abstract action realizes to at least one dispatcher — the projection is
@@ -1307,6 +1569,79 @@ mod tests {
         );
     }
 
+    // ── The second backend: SwayRealization (generality is load-bearing) ──
+
+    #[test]
+    fn sway_realization_is_a_functor() {
+        assert_functor_laws::<SwayRealization>();
+    }
+
+    #[test]
+    fn sway_realizes_the_hyprland_gaps_and_vice_versa() {
+        // The SAME source action Hyprland gaps, sway realizes NATIVELY — the proof
+        // that the generality is load-bearing, not YAGNI. Container-tree focus and
+        // focus-layer have no Hyprland dispatcher; sway has "focus parent" /
+        // "focus mode_toggle".
+        for a in [WmAction::focus_parent(), WmAction::focus_layer()] {
+            assert!(!hyprland_realizes(&a), "Hyprland should gap {a:?}");
+            assert!(realize(&a).is_empty(), "Hyprland must gap {a:?} to empty");
+            assert!(sway_realizes(&a), "sway should realize {a:?}");
+            assert!(
+                !sway_realize(&a).is_empty(),
+                "sway must emit a command for {a:?}"
+            );
+        }
+        // Split(Vertical) is realized on BOTH but DIFFERENTLY: Hyprland collapses
+        // every orientation to togglesplit; sway distinguishes "split vertical".
+        assert_eq!(
+            realize(&WmAction::Split(Orientation::Vertical)),
+            "layoutmsg, togglesplit"
+        );
+        assert_eq!(
+            sway_realize(&WmAction::Split(Orientation::Vertical)),
+            "split vertical"
+        );
+        // Conversely: Hyprland realizes the maximize / pseudo-tile sway gaps.
+        for a in [WmAction::maximize(), WmAction::pseudotile()] {
+            assert!(hyprland_realizes(&a), "Hyprland should realize {a:?}");
+            assert!(!sway_realizes(&a), "sway should gap {a:?}");
+        }
+    }
+
+    #[test]
+    fn sway_realize_strings() {
+        assert_eq!(sway_realize(&WmAction::focus_parent()), "focus parent");
+        assert_eq!(sway_realize(&WmAction::focus_layer()), "focus mode_toggle");
+        assert_eq!(
+            sway_realize(&WmAction::focus(Direction::Left)),
+            "focus left"
+        );
+        assert_eq!(
+            sway_realize(&WmAction::Split(Orientation::Vertical)),
+            "split vertical"
+        );
+        assert_eq!(
+            sway_realize(&WmAction::Resize(Direction::Left, 30)),
+            "resize shrink width 30 px"
+        );
+        assert_eq!(
+            sway_realize(&WmAction::Workspace(WorkspaceTarget::Index(3))),
+            "workspace number 3"
+        );
+        assert_eq!(
+            sway_realize(&WmAction::Workspace(WorkspaceTarget::Last)),
+            "workspace back_and_forth"
+        );
+        assert_eq!(
+            sway_realize(&WmAction::focus_monitor(OutputSel::Direction(
+                Direction::Left
+            ))),
+            "focus output left"
+        );
+        // A sway capability gap lowers to the empty command.
+        assert_eq!(sway_realize(&WmAction::maximize()), "");
+    }
+
     // ── The three fixes ──
 
     #[test]
@@ -1395,6 +1730,18 @@ mod tests {
             let ra = HyprlandRealization::map_morphism(&a);
             let rb = HyprlandRealization::map_morphism(&b);
             let rhs = DispatchAlgebra::compose(&ra, &rb).unwrap();
+            prop_assert_eq!(lhs, rhs);
+        }
+
+        /// SwayRealization is likewise a monoid homomorphism — the second backend
+        /// is a genuine functor over the same source.
+        #[test]
+        fn prop_sway_is_homomorphism(a in arb_word(), b in arb_word()) {
+            let cat = ActionAlgebra::compose(&a, &b).unwrap();
+            let lhs = SwayRealization::map_morphism(&cat);
+            let ra = SwayRealization::map_morphism(&a);
+            let rb = SwayRealization::map_morphism(&b);
+            let rhs = SwayAlgebra::compose(&ra, &rb).unwrap();
             prop_assert_eq!(lhs, rhs);
         }
 

--- a/crates/domains/src/applied/hmi/input/wm_action.rs
+++ b/crates/domains/src/applied/hmi/input/wm_action.rs
@@ -976,7 +976,7 @@ fn lower(action: &WmAction) -> Vec<Dispatch> {
 /// add/remove/toggle distinction ([`StateOp`]) is not observable in the Hyprland
 /// realization (a directed backend such as X11 honours it via `_NET_WM_STATE`
 /// client messages). The states Hyprland gives a user dispatcher are its
-/// window-state CAPABILITY ([`hyprland_state_capability`]); EWMH states outside
+/// window-state CAPABILITY (`hyprland_state_capability`); EWMH states outside
 /// it (app-set hints, the below layer, shading) have no Hyprland user action and
 /// lower to the empty word — they are never *generated* for a Hyprland binding
 /// (`representative_actions` excludes them; [`StateLoweringMatchesCapability`]
@@ -1020,7 +1020,7 @@ fn hyprland_state_capability() -> [StateBit; 8] {
 /// Whether Hyprland has a user realization for an action — its CAPABILITY. The
 /// generalized ontology can express operations Hyprland exposes no dispatcher for
 /// (container-tree focus, the tiling/floating focus-layer toggle, the EWMH window
-/// states outside [`hyprland_state_capability`]); those lower to the empty word
+/// states outside `hyprland_state_capability`); those lower to the empty word
 /// and are excluded from Hyprland's generating set. A backend that DOES expose
 /// them (Sway) declares a wider capability. [`LoweringTotal`] proves the lowering
 /// is total ON this capability; [`RealizationMatchesCapability`] proves the empty
@@ -1423,7 +1423,7 @@ impl Axiom for CompositeSequencePreserved {
 
 /// The window-state mutations Hyprland realizes are **exactly** its declared
 /// window-state capability: `lower_state` is non-empty for a [`StateBit`] iff the
-/// bit is in [`hyprland_state_capability`]. This makes the empty-lowering arm an
+/// bit is in `hyprland_state_capability`. This makes the empty-lowering arm an
 /// intentional, checked capability boundary (the EWMH hints / layers Hyprland has
 /// no user action for), never an accidental silent drop.
 pub struct StateLoweringMatchesCapability;

--- a/crates/domains/src/applied/hmi/input/wm_action.rs
+++ b/crates/domains/src/applied/hmi/input/wm_action.rs
@@ -171,6 +171,39 @@ impl FinitelyGenerated for Orientation {
     }
 }
 
+/// How focus is selected — the parameter of the focus operation. A focus is
+/// always "move keyboard focus", but BY what: a spatial direction, or a cycle
+/// through the stack (Alt-Tab). (The container-tree and tiling/floating-layer
+/// selectors arrive with the capability framework.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FocusBy {
+    /// The spatial neighbour in a direction (`movefocus`).
+    Direction(Direction),
+    /// Cycle through windows in stacking order (Alt-Tab; `cyclenext`).
+    Cycle(Cycle),
+}
+
+impl Concept for FocusBy {
+    fn name(&self) -> &'static str {
+        match self {
+            FocusBy::Direction(_) => "direction",
+            FocusBy::Cycle(_) => "cycle",
+        }
+    }
+}
+impl FinitelyGenerated for FocusBy {
+    fn variants() -> Vec<Self> {
+        let mut v = Vec::new();
+        for d in Direction::variants() {
+            v.push(FocusBy::Direction(d));
+        }
+        for c in Cycle::variants() {
+            v.push(FocusBy::Cycle(c));
+        }
+        v
+    }
+}
+
 /// Whether moving a window to a workspace **follows** it (focus travels) or is
 /// **silent** (window leaves, focus stays).
 ///
@@ -268,9 +301,11 @@ impl SubmapTarget {
 /// full spine.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum WmAction {
-    /// Move keyboard focus to the neighbour in a direction (Myers
-    /// "change-listener"; EWMH input focus).
-    Focus(Direction),
+    /// Move keyboard focus — selected by a [`FocusBy`] (a spatial direction, a
+    /// stack cycle, and — with the capability framework — the container tree or
+    /// the tiling/floating layer). Subsumes the former `Focus(Direction)` and
+    /// `CycleWindow` verbs (Myers "change-listener"; EWMH input focus).
+    Focus(FocusBy),
     /// Move the focused window one slot in a direction (Myers "move").
     MoveWindow(Direction),
     /// Swap the focused window with its neighbour in a direction.
@@ -297,8 +332,6 @@ pub enum WmAction {
     ToggleGroup,
     /// Cycle the active window *within* the current group.
     CycleGroup(Cycle),
-    /// Cycle focus across windows (Alt-Tab; EWMH stacking order traversal).
-    CycleWindow(Cycle),
     /// Switch to a workspace (Henderson & Card 1986 *Rooms*; EWMH
     /// `_NET_CURRENT_DESKTOP`).
     Workspace(WorkspaceTarget),
@@ -363,6 +396,17 @@ impl WmAction {
         WmAction::Split(Orientation::Toggle)
     }
 
+    /// Move focus to the neighbour in a direction — `Focus(FocusBy::Direction)`.
+    pub fn focus(direction: Direction) -> Self {
+        WmAction::Focus(FocusBy::Direction(direction))
+    }
+
+    /// Cycle focus across windows in stacking order (Alt-Tab) —
+    /// `Focus(FocusBy::Cycle)`.
+    pub fn cycle_window(cycle: Cycle) -> Self {
+        WmAction::Focus(FocusBy::Cycle(cycle))
+    }
+
     /// The finite generating set — one representative of every variant. Used to
     /// machine-check the realization functor (totality, the functor laws) and to
     /// seed property tests. This is a *generating* set, not the (open-world) whole
@@ -370,10 +414,10 @@ impl WmAction {
     pub fn representative_actions() -> Vec<WmAction> {
         use Direction::*;
         vec![
-            WmAction::Focus(Left),
-            WmAction::Focus(Right),
-            WmAction::Focus(Up),
-            WmAction::Focus(Down),
+            WmAction::focus(Left),
+            WmAction::focus(Right),
+            WmAction::focus(Up),
+            WmAction::focus(Down),
             WmAction::MoveWindow(Left),
             WmAction::SwapWindow(Up),
             WmAction::Resize(Left, 30),
@@ -392,8 +436,8 @@ impl WmAction {
             WmAction::Split(Orientation::Vertical),
             WmAction::ToggleGroup,
             WmAction::CycleGroup(Cycle::Forward),
-            WmAction::CycleWindow(Cycle::Forward),
-            WmAction::CycleWindow(Cycle::Backward),
+            WmAction::cycle_window(Cycle::Forward),
+            WmAction::cycle_window(Cycle::Backward),
             WmAction::Workspace(WorkspaceTarget::Index(1)),
             WmAction::Workspace(WorkspaceTarget::Relative(1)),
             WmAction::Workspace(WorkspaceTarget::Relative(-1)),
@@ -426,7 +470,6 @@ impl Concept for WmAction {
             WmAction::Split(_) => "split",
             WmAction::ToggleGroup => "toggle-group",
             WmAction::CycleGroup(_) => "cycle-group",
-            WmAction::CycleWindow(_) => "cycle-window",
             WmAction::Workspace(_) => "workspace",
             WmAction::MoveToWorkspace(_, _) => "move-to-workspace",
             WmAction::ToggleSpecialWorkspace(_) => "toggle-special-workspace",
@@ -681,7 +724,10 @@ impl Category for DispatchAlgebra {
 /// genuine composites lower to a short sequence.
 fn lower(action: &WmAction) -> Vec<Dispatch> {
     match action {
-        WmAction::Focus(d) => vec![Dispatch::MoveFocus(*d)],
+        WmAction::Focus(FocusBy::Direction(d)) => vec![Dispatch::MoveFocus(*d)],
+        WmAction::Focus(FocusBy::Cycle(c)) => {
+            vec![Dispatch::CycleNext(matches!(c, Cycle::Backward))]
+        }
         WmAction::MoveWindow(d) => vec![Dispatch::MoveWindow(*d)],
         WmAction::SwapWindow(d) => vec![Dispatch::SwapWindow(*d)],
         WmAction::Resize(d, amt) => {
@@ -704,7 +750,6 @@ fn lower(action: &WmAction) -> Vec<Dispatch> {
             Cycle::Forward => 'f',
             Cycle::Backward => 'b',
         })],
-        WmAction::CycleWindow(c) => vec![Dispatch::CycleNext(matches!(c, Cycle::Backward))],
         WmAction::Workspace(w) => vec![Dispatch::Workspace(w.clone())],
         WmAction::MoveToWorkspace(w, Follow::Follow) => vec![Dispatch::MoveToWorkspace(w.clone())],
         WmAction::MoveToWorkspace(w, Follow::Silent) => {
@@ -996,10 +1041,10 @@ mod tests {
 
     #[test]
     fn realize_focus_directions() {
-        assert_eq!(realize(&WmAction::Focus(Direction::Left)), "movefocus, l");
-        assert_eq!(realize(&WmAction::Focus(Direction::Right)), "movefocus, r");
-        assert_eq!(realize(&WmAction::Focus(Direction::Up)), "movefocus, u");
-        assert_eq!(realize(&WmAction::Focus(Direction::Down)), "movefocus, d");
+        assert_eq!(realize(&WmAction::focus(Direction::Left)), "movefocus, l");
+        assert_eq!(realize(&WmAction::focus(Direction::Right)), "movefocus, r");
+        assert_eq!(realize(&WmAction::focus(Direction::Up)), "movefocus, u");
+        assert_eq!(realize(&WmAction::focus(Direction::Down)), "movefocus, d");
     }
 
     #[test]


### PR DESCRIPTION
The keybinding paradigms weren't really finished. #214 gave the actions a proper model, but it only spoke Hyprland, a couple of presets were broken (cua swallowed app shortcuts like Ctrl+S; tmux's prefix couldn't be reached), and some window actions had no way back — you couldn't un-maximize.

This rounds it out: the same actions can now drive a second window manager (Sway) — which is what proves the model isn't just Hyprland in disguise — window state gains its missing inverses, and the broken presets are fixed.

Honest scope: most of the second-backend work is groundwork for Sway and later, not the Hyprland you run today; there the felt changes are smaller — cross-monitor focus/move, last-workspace, and tmux working again. vim/emacs/macos come next with the vogix side that gives them their modes. dev-ci green.
