### PR TITLE
fix(release): root-cause fix for the recurring release-plz wedge + 0.25.5 bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,6 +370,59 @@ jobs:
             exit 1
           fi
 
+  # ── The release invariant — fail fast at PR time, never wedge master ──────
+  # release-plz computes each crate's next version from its crates.io baseline.
+  # Its tag-vs-registry safety check ABORTS the Release-PR for the ENTIRE
+  # workspace if any crate it would publish has a git release tag but is absent
+  # from crates.io (HTTP 404):
+  #     "package X not found in the registry, but the git tag X-vN exists.
+  #      Consider running cargo publish manually to publish this package."
+  # That forbidden state — `publish=true` + tagged + 404 — has wedged master
+  # repeatedly (it is exactly what `release=true` tag-without-publish for
+  # pr4xis-domains set up, then #219's gate removal exposed). The invariant:
+  # every workspace member is EITHER published to crates.io (a registry row at
+  # >= its highest tag) OR marked `publish = false` in release-plz.toml (which
+  # release-plz exempts from the check). This job enforces it at PR time so the
+  # forbidden state can never reach master.
+  publish-invariant:
+    name: Publish invariant
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # all tags, to compare against the registry
+      - name: No publish=true crate may be tagged-but-unpublished
+        run: |
+          set -uo pipefail
+          # Crates release-plz.toml marks publish = false (apps / examples) are
+          # EXEMPT — release-plz never publishes them, so a tag without a
+          # registry entry is harmless for them.
+          exempt=$(awk '
+            /^\[\[package\]\]/ { name = "" }
+            match($0, /^name[[:space:]]*=[[:space:]]*"([^"]+)"/, a) { name = a[1] }
+            /^publish[[:space:]]*=[[:space:]]*false/ { if (name) print name }
+          ' release-plz.toml | sort -u)
+          fail=0
+          # Walk every workspace member dir → its package name.
+          for dir in $(awk '/members[[:space:]]*=[[:space:]]*\[/{f=1;next} /\]/{f=0} f{gsub(/[",[:space:]]/,"");if($0!="")print}' Cargo.toml); do
+            name=$(awk -F'"' '/^name[[:space:]]*=/{print $2; exit}' "$dir/Cargo.toml")
+            [ -z "$name" ] && continue
+            # Exempt (publish=false in release-plz.toml) → skip.
+            if printf '%s\n' "$exempt" | grep -qx "$name"; then continue; fi
+            # A member's own Cargo.toml publish=false → also exempt.
+            if awk '/^\[package\]/{p=1} p&&/^publish[[:space:]]*=[[:space:]]*false/{found=1} END{exit !found}' "$dir/Cargo.toml"; then continue; fi
+            # Highest release tag for this crate, if any.
+            tag=$(git tag --list "${name}-v*" | sort -V | tail -1)
+            [ -z "$tag" ] && continue
+            # Registry presence (crates.io API: 404 = never published).
+            code=$(curl -s -o /dev/null -w '%{http_code}' "https://crates.io/api/v1/crates/${name}")
+            if [ "$code" = "404" ]; then
+              echo "::error::Publish invariant violated: '${name}' is tagged (${tag}) but absent from crates.io (HTTP 404). release-plz will ABORT the Release-PR for the whole workspace. Fix: publish it once (\`cargo publish -p ${name}\`) before it is tagged, OR mark it \`publish = false\` in release-plz.toml. Never leave a publish=true crate tagged-but-unpublished."
+              fail=1
+            fi
+          done
+          exit $fail
+
 
   pages:
     name: Deploy Pages
@@ -436,22 +489,14 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
-      # Publish the SAME .prx.gz files to the pr4xis-domains release as
-      # immutable archive assets. The release-plz `releases` output is a
-      # JSON array — we pull the pr4xis-domains tag out of it. If
-      # pr4xis-domains wasn't released this run (e.g. only pr4xis-cli
-      # was bumped), skip upload cleanly.
-      - name: Upload .prx.gz to pr4xis-domains release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASES: ${{ needs.release-plz-release.outputs.releases }}
-        run: |
-          TAG=$(echo "$RELEASES" | jq -r '.[] | select(.package_name == "pr4xis-domains") | .tag')
-          if [ -n "$TAG" ] && [ "$TAG" != "null" ]; then
-            gh release upload "$TAG" pages/ontologies/*.prx.gz --clobber
-          else
-            echo "pr4xis-domains not released in this run; skipping .prx.gz upload"
-          fi
+      # NOTE: the `.prx.gz` ontology artifacts are served from Pages
+      # `/ontologies/` (emitted above into the pages tree), NOT attached to the
+      # GitHub release. release-plz creates releases with `git_release_enable`,
+      # which are IMMUTABLE — `gh release upload --clobber` against an immutable
+      # release fails `HTTP 422: Cannot upload assets to an immutable release`,
+      # which reddened every release run that touched pr4xis-domains
+      # (v0.24.0 / 0.25.0 / .1 / .3 / .4). The release-asset copy was redundant
+      # with the Pages copy, so it is dropped: Pages is the single artifact home.
 
   # release-plz replaces the old release-please + katyo/publish-crates
   # pair. Reads the current repo state, queries crates.io for each

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,9 +391,12 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # all tags, to compare against the registry
-      - name: No publish=true crate may be tagged-but-unpublished
+      - name: No publish=true crate may be tagged ahead of its crates.io version
         run: |
           set -uo pipefail
+          # crates.io's API REQUIRES a User-Agent (it 403s without one), so every
+          # query carries this identifying header.
+          UA="pr4xis-ci-publish-invariant (https://github.com/i-am-logger/pr4xis)"
           # Crates release-plz.toml marks publish = false (apps / examples) are
           # EXEMPT — release-plz never publishes them, so a tag without a
           # registry entry is harmless for them.
@@ -402,6 +405,25 @@ jobs:
             match($0, /^name[[:space:]]*=[[:space:]]*"([^"]+)"/, a) { name = a[1] }
             /^publish[[:space:]]*=[[:space:]]*false/ { if (name) print name }
           ' release-plz.toml | sort -u)
+
+          # crates.io max_version for a crate, resilient to transient API errors.
+          # Echoes the version (200), "404" (definitively absent), or "ERROR"
+          # (no definitive answer after retries → the caller FAILS CLOSED rather
+          # than treat a crates.io outage / 5xx / timeout as a pass).
+          registry_version() {
+            local crate=$1 i code
+            for i in 1 2 3 4; do
+              code=$(curl -s -A "$UA" -o /tmp/ci_crate.json -w '%{http_code}' \
+                "https://crates.io/api/v1/crates/${crate}" 2>/dev/null || echo 000)
+              case "$code" in
+                200) jq -r '.crate.max_version' /tmp/ci_crate.json; return 0 ;;
+                404) echo "404"; return 0 ;;
+                *)   sleep $((i * 3)) ;;  # 000/5xx/timeout — retry with backoff
+              esac
+            done
+            echo "ERROR"
+          }
+
           fail=0
           # Walk every workspace member dir → its package name.
           for dir in $(awk '/members[[:space:]]*=[[:space:]]*\[/{f=1;next} /\]/{f=0} f{gsub(/[",[:space:]]/,"");if($0!="")print}' Cargo.toml); do
@@ -411,14 +433,27 @@ jobs:
             if printf '%s\n' "$exempt" | grep -qx "$name"; then continue; fi
             # A member's own Cargo.toml publish=false → also exempt.
             if awk '/^\[package\]/{p=1} p&&/^publish[[:space:]]*=[[:space:]]*false/{found=1} END{exit !found}' "$dir/Cargo.toml"; then continue; fi
-            # Highest release tag for this crate, if any.
+            # Highest release tag for this crate, if any (nothing tagged → nothing
+            # release-plz will diff against; not yet the forbidden state).
             tag=$(git tag --list "${name}-v*" | sort -V | tail -1)
             [ -z "$tag" ] && continue
-            # Registry presence (crates.io API: 404 = never published).
-            code=$(curl -s -o /dev/null -w '%{http_code}' "https://crates.io/api/v1/crates/${name}")
-            if [ "$code" = "404" ]; then
-              echo "::error::Publish invariant violated: '${name}' is tagged (${tag}) but absent from crates.io (HTTP 404). release-plz will ABORT the Release-PR for the whole workspace. Fix: publish it once (\`cargo publish -p ${name}\`) before it is tagged, OR mark it \`publish = false\` in release-plz.toml. Never leave a publish=true crate tagged-but-unpublished."
+            tagver=${tag#"${name}-v"}
+            rv=$(registry_version "$name")
+            if [ "$rv" = "404" ]; then
+              echo "::error::Publish invariant: '${name}' is tagged (${tag}) but absent from crates.io (404). release-plz will ABORT the Release-PR for the whole workspace. Fix: publish it once (\`cargo publish -p ${name}\`) before it is tagged, OR mark it \`publish = false\` in release-plz.toml."
               fail=1
+            elif [ "$rv" = "ERROR" ]; then
+              echo "::error::Publish invariant: could not verify crates.io for '${name}' after retries (transient API error). Failing closed — re-run the job; if crates.io is genuinely down, retry when it recovers."
+              fail=1
+            else
+              # The full invariant: crates.io max_version must be >= the highest
+              # tag. A registry BEHIND its tag is the same release-plz baseline
+              # inconsistency as a 404.
+              lower=$(printf '%s\n%s\n' "$rv" "$tagver" | sort -V | head -1)
+              if [ "$lower" = "$rv" ] && [ "$rv" != "$tagver" ]; then
+                echo "::error::Publish invariant: '${name}' crates.io max version (${rv}) is BEHIND its highest tag (${tagver}). release-plz's next-version baseline is inconsistent. Publish ${name} ${tagver} (or higher) to crates.io."
+                fail=1
+              fi
             fi
           done
           exit $fail

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "pr4xis"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "hashbrown 0.17.1",
  "linkme",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "pr4xis-chat"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "criterion",
  "pr4xis",
@@ -1499,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "pr4xis-cli"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1511,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "pr4xis-derive"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "pr4xis-domains"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "pr4xis-examples"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "pr4xis",
  "pr4xis-domains",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "pr4xis-runtime"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "blake3",
  "pr4xis",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "pr4xis-web"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "tiny_http",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,20 +33,27 @@ exclude = ["crates/wasm", "crates/e2e", "crates/praxis-corpus-tests"]
 # This REPLACES release-plz's `version_group`, which silently stopped
 # syncing once the publish=false crates drifted behind the published ones.
 #
-# 0.24.0 is a one-time RE-BASELINE, set by hand. The publish=false domains
-# crate (where ~all praxis work lands) had drifted to 0.22.0 while the
-# published crates reached 0.23.1, so release-plz — which reconciles the
-# shared version against the higher published baseline — could only ever
-# absorb a domains change into a patch (0.23.2), even the breaking
-# DeterminerKind rename (FW-B, committed as `feat!`). There is no historical
-# commit where domains was 0.23.1 to seed a clean baseline from, so the
-# minor bump that this breaking release warrants is set here. After it ships,
-# release-plz tags domains at the workspace version (it is now release-plz-
-# visible — its publish gate moved to release-plz.toml), domains' baseline is
-# finally consistent, and FUTURE breaking domains changes auto-escalate. This
-# is the last hand-set version.
+# Hand-set version bumps here are a LAST RESORT (release-plz normally owns the
+# version, bumping it via the Release PR). Two have been needed historically, both
+# one-time re-baselines forced by the same root cause — release-plz reads each
+# crate's next-version baseline from crates.io, so a workspace crate that is NOT
+# on crates.io has no baseline to reconcile against:
+#   • 0.24.0 — domains (then publish=false) had drifted to 0.22.0 while the
+#     published crates reached 0.23.1; with no crates.io baseline release-plz
+#     could only absorb even the breaking DeterminerKind rename into a patch, so
+#     the minor bump was hand-set.
+#   • 0.25.5 — the FIRST-PUBLISH BOOTSTRAP for `pr4xis-domains`. It had tags
+#     (v0.24.0..v0.25.4) but was never published (it was publish=false until
+#     #219). Once publishable, release-plz can't compute its next version (tagged
+#     but 404), wedging the Release-PR. The fix is to publish it once; because the
+#     v0.25.4 tag is the pre-#219 unpublishable tree AND master's domains build.rs
+#     needs pr4xis's new codegen API (absent from published pr4xis 0.25.4), the
+#     bootstrap publish is 0.25.5 in dependency order (pr4xis-derive → -runtime →
+#     pr4xis → -domains [→ -web]). After it lands on crates.io the invariant holds
+#     and release-plz auto-bumps from here on. See release-plz.toml + the
+#     `publish-invariant` CI guard for the rule that prevents a recurrence.
 [workspace.package]
-version = "0.25.4"
+version = "0.25.5"
 
 [workspace.lints.rust]
 dead_code = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,9 @@ exclude = ["crates/wasm", "crates/e2e", "crates/praxis-corpus-tests"]
 #     but 404), wedging the Release-PR. The fix is to publish it once; because the
 #     v0.25.4 tag is the pre-#219 unpublishable tree AND master's domains build.rs
 #     needs pr4xis's new codegen API (absent from published pr4xis 0.25.4), the
-#     bootstrap publish is 0.25.5 in dependency order (pr4xis-derive → -runtime →
-#     pr4xis → -domains [→ -web]). After it lands on crates.io the invariant holds
+#     bootstrap publish is 0.25.5 in dependency order (pr4xis-derive → pr4xis →
+#     pr4xis-runtime → pr4xis-domains → pr4xis-web; each crate's deps must be on
+#     crates.io first). After it lands on crates.io the invariant holds
 #     and release-plz auto-bumps from here on. See release-plz.toml + the
 #     `publish-invariant` CI guard for the rule that prevents a recurrence.
 [workspace.package]

--- a/crates/domains/Cargo.toml
+++ b/crates/domains/Cargo.toml
@@ -44,17 +44,23 @@ include = [
     "data/**/*.prx.gz",
     "CHANGELOG.md",
 ]
-# NOTE: this crate IS published to crates.io. It carries no `publish = false`
-# (neither here nor in release-plz.toml) — the manifest-level gate is deliberately
-# absent because it would make release-plz ignore the crate outright (never
-# versioned/tagged — the bug that stranded domains at tag v0.21.0 while the
-# workspace moved on). The crates.io floor that used to block it — a build-time
+# NOTE: this crate is PUBLISHABLE and carries no `publish = false` (neither here
+# nor in release-plz.toml) — a manifest-level gate would make release-plz ignore
+# the crate outright (never versioned/tagged — the bug that stranded domains at
+# tag v0.21.0). The crates.io floor that used to block it — a build-time
 # `include_str!` of workspace files (`praxis.toml`, raw `data/*`) that fails
 # `cargo publish --verify` — is gone: the registered-source manifest and every
 # data source now ship as committed `.prx` (the `include` allowlist above), loaded
-# through the generalized registry gate, so `--verify` is clean. Publish order is
-# the workspace dependency order: `pr4xis` (with the build-time codegen API
-# `build.rs` calls) publishes before this crate.
+# through the generalized registry gate, so `--verify` is clean.
+#
+# FIRST-PUBLISH BOOTSTRAP PENDING: this crate has release tags (v0.24.0..v0.25.4)
+# but was never on crates.io (it was `publish = false` until #219). A publishable
+# crate that is tagged-but-404 is the forbidden state that wedges release-plz's
+# Release-PR (see release-plz.toml + the `publish-invariant` CI job). It must be
+# first-published once, at 0.25.5, in workspace dependency order — `pr4xis`
+# (carrying the build-time codegen API `build.rs` calls, absent from the published
+# pr4xis 0.25.4) publishes before this crate. After that the invariant holds and
+# release-plz auto-bumps from here on.
 
 [dependencies]
 # Runtime dep needs `std` only. The `codegen` feature (and its
@@ -64,7 +70,7 @@ include = [
 # Keeping it off the normal dep keeps `xsd-parser` out of the WASM graph
 # (this crate is a WASM default-feature dependency — see the fetch
 # gating notes below).
-pr4xis = { path = "../pr4xis", version = "0.25.4", default-features = false, features = ["std"] }
+pr4xis = { path = "../pr4xis", version = "0.25.5", default-features = false, features = ["std"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 toml = "1"
@@ -93,7 +99,7 @@ hashbrown = "0.17"
 # feature-gating of the dependency is needed; the consuming `composed` module
 # is `std`-gated only because pr4xis-runtime is a std crate (and the WASM build
 # enables `std` via the `prx` feature anyway).
-pr4xis-runtime = { path = "../pr4xis-runtime", version = "0.25.4", features = ["emit"] }
+pr4xis-runtime = { path = "../pr4xis-runtime", version = "0.25.5", features = ["emit"] }
 # Distributed-slice registration substrate. The well-behaved-lens
 # harness uses `#[linkme::distributed_slice]` to discover every
 # registered lens at link time without a central list. Same crate
@@ -185,7 +191,7 @@ test-internals = ["prx"]
 # emits Rust modules under $OUT_DIR/<name>_codegen.rs for every Statute-kind
 # source whose lock carries structural data. The crate's runtime tree then
 # `include!`s those modules under `social::compliance::law::<name>::`.
-pr4xis = { path = "../pr4xis", version = "0.25.4", default-features = false, features = ["codegen"] }
+pr4xis = { path = "../pr4xis", version = "0.25.5", default-features = false, features = ["codegen"] }
 serde = { version = "1.0", features = ["derive"] }
 toml = "1"
 # BLAKE3 for build.rs's content-address gates — the committed-`.prx` decode
@@ -213,10 +219,10 @@ unreachable = "deny"
 # `pr4xis::codegen::wordnet::parse_wordnet_xml` directly. `codegen` is
 # off the normal dep (it leaks `xsd-parser` into WASM), so unify it back
 # in for test builds here.
-pr4xis = { path = "../pr4xis", version = "0.25.4", features = ["codegen"] }
+pr4xis = { path = "../pr4xis", version = "0.25.5", features = ["codegen"] }
 # The runtime, with `emit`, so an integration test can project a real domain
 # ontology into a `.prx` Archive and round-trip it through the runtime.
-pr4xis-runtime = { path = "../pr4xis-runtime", version = "0.25.4", features = ["emit"] }
+pr4xis-runtime = { path = "../pr4xis-runtime", version = "0.25.5", features = ["emit"] }
 criterion = { version = "0.8", features = ["html_reports"] }
 proptest = "1.11"
 tempfile = "3"

--- a/crates/pr4xis-runtime/Cargo.toml
+++ b/crates/pr4xis-runtime/Cargo.toml
@@ -19,7 +19,7 @@ emit = ["dep:pr4xis"]
 [dependencies]
 sha2 = "0.11"
 blake3 = { version = "1", default-features = false, features = ["pure"] }
-pr4xis = { version = "0.25.4", path = "../pr4xis", optional = true }
+pr4xis = { version = "0.25.5", path = "../pr4xis", optional = true }
 serde = { version = "1", features = ["derive"] }
 # DAG-CBOR — the deterministic, language-agnostic canonical encoding the content
 # address is computed over (IPLD content-addressing requires a single canonical

--- a/crates/pr4xis/Cargo.toml
+++ b/crates/pr4xis/Cargo.toml
@@ -19,7 +19,7 @@ codegen = ["std", "dep:quick-xml", "dep:serde", "dep:serde_json"]
 hashbrown = { version = "0.17", default-features = false, features = ["default-hasher"] }
 linkme = "0.3"
 paste = "1"
-pr4xis-derive = { version = "0.25.4", path = "../pr4xis-derive" }
+pr4xis-derive = { version = "0.25.5", path = "../pr4xis-derive" }
 quick-xml = { version = "0.40", features = ["serialize"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -81,19 +81,33 @@ commit_parsers = [
 # nearly all work lands) bumps the one shared number — so release-plz opens a
 # Release PR for it. The only per-crate knob that remains is the PUBLISH gate.
 #
-# `pr4xis-domains` IS published to crates.io: it now ships Rust + `.prx` archives
-# only — every registered-source vocabulary/schema/theme/manifest is loaded from a
-# committed, content-addressed `.prx` through the generalized registry gate (no
-# raw OWL/XSD/XML/TSV, no raw `praxis.toml`/`.lock`, enforced by the crate's
-# `[package].include` allowlist), so `cargo publish --verify` is clean. (Publish
-# order is the natural workspace dependency order: `pr4xis` — carrying the
-# build-time codegen API `domains/build.rs` calls — publishes before
-# `pr4xis-domains`.)
+# THE PUBLISH INVARIANT (enforced by the `publish-invariant` CI job, ci.yml):
+# every workspace member is EITHER published to crates.io (a registry row at >=
+# its highest git tag) OR marked `publish = false` below. The forbidden state is
+# `publish=true` + a release tag + no crates.io row (HTTP 404): release-plz reads
+# each crate's next-version baseline from crates.io, and a tagged-but-absent
+# publishable crate is an unresolvable inconsistency that ABORTS the Release-PR
+# for the WHOLE workspace ("package X not found in the registry, but the git tag
+# X-vN exists"). This wedged master repeatedly — `pr4xis-domains` was
+# `release=true` + `publish=false` (tagged every release, never published), and
+# removing its publish gate in #219 flipped it to the forbidden state.
+#
+# `pr4xis-domains` is publishable (it ships Rust + `.prx` archives only — every
+# registered source loads from a committed, content-addressed `.prx` through the
+# generalized registry gate, enforced by the crate's `[package].include`
+# allowlist, so `cargo publish --verify` is clean). BOOTSTRAP REQUIRED: it has
+# tags (v0.24.0..v0.25.4) but was never on crates.io, so it must be FIRST-
+# published manually once (`cargo publish -p pr4xis-domains`, in workspace
+# dependency order — `pr4xis`, carrying the build-time codegen API
+# `domains/build.rs` calls, publishes first) to establish the registry baseline.
+# After that one-time publish the invariant holds and release-plz self-heals.
+# RULE: never flip a crate from `publish = false` to publishing without doing its
+# first manual publish FIRST — the CI guard now catches this at PR time.
 #
 # `pr4xis-cli` / `-chat` are applications, not libraries consumers pull in, and
 # `pr4xis-examples` isn't either — they stay `publish = false` (no crates.io
-# value), while sharing the inherited version and being tagged + GitHub-released
-# in lockstep; `publish = false` only skips their `cargo publish` step.
+# value), which ALSO exempts them from the tag-vs-registry check; they share the
+# inherited version and are tagged + GitHub-released in lockstep.
 [[package]]
 name = "pr4xis-cli"
 publish = false

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -97,9 +97,10 @@ commit_parsers = [
 # generalized registry gate, enforced by the crate's `[package].include`
 # allowlist, so `cargo publish --verify` is clean). BOOTSTRAP REQUIRED: it has
 # tags (v0.24.0..v0.25.4) but was never on crates.io, so it must be FIRST-
-# published manually once (`cargo publish -p pr4xis-domains`, in workspace
-# dependency order — `pr4xis`, carrying the build-time codegen API
-# `domains/build.rs` calls, publishes first) to establish the registry baseline.
+# published manually once to establish the registry baseline, in workspace
+# dependency order: pr4xis-derive → pr4xis → pr4xis-runtime → pr4xis-domains →
+# pr4xis-web (each crate's deps must be on crates.io first; `pr4xis` carries the
+# build-time codegen API `domains/build.rs` calls, so it precedes domains).
 # After that one-time publish the invariant holds and release-plz self-heals.
 # RULE: never flip a crate from `publish = false` to publishing without doing its
 # first manual publish FIRST — the CI guard now catches this at PR time.


### PR DESCRIPTION
Releases have wedged over and over since we moved to release-plz, and every time it got patched at the symptom. A forensic reconstruction of the whole history (every incident from #190 through #219) found there's **one root cause** under all of them, and this fixes it at the root — plus does the one-time reconciliation to unblock master now.

## What was actually going wrong

release-plz computes each crate's next version from its **crates.io baseline**. So a workspace crate that is `publish=true`, has a git release tag, but was never published to crates.io is an unresolvable inconsistency — and release-plz **aborts the Release-PR for the entire workspace**:

> `package 'pr4xis-domains' not found in the registry, but the git tag pr4xis-domains-v0.25.4 exists. Consider running cargo publish manually.`

`pr4xis-domains` got into exactly that state: it was `release=true` + `publish=false` (so it was tagged every release but never published), and #219 removed its publish gate — flipping it into the forbidden "tagged-but-404" state that wedges every master push. This is the same crates.io-baseline mechanism behind the earlier incidents too (the `version_group` that "stopped syncing," the no-bump on domains-only changes).

## The permanent fix (so it never recurs)

- **A `publish-invariant` CI job** that fails fast at PR time if any publishable member is tagged-but-absent-from-crates.io. The invariant, now written into `release-plz.toml`: *every member is either published to crates.io at ≥ its highest tag, or `publish=false`* (which release-plz exempts from the check — that's why cli/chat/examples never error). The rule: never flip a crate from `publish=false` to publishing without doing its first manual publish first — the guard now catches it before merge.
- **Deploy Pages 422** (a separate recurring red): release-plz makes releases immutable, so `gh release upload --clobber` of the `.prx.gz` artifacts failed `HTTP 422` on every release run (v0.24.0/.0/.1/.3/.4). They're already served from Pages `/ontologies/`, so the redundant release-asset upload is dropped.
- Corrected the now-false "IS published to crates.io" comments and the stale "last hand-set version" note.

## The one-time bootstrap — what you run

This branch hand-bumps the workspace to **0.25.5** (it's 0.25.5, not 0.25.4: the v0.25.4 tag is the pre-#219 unpublishable tree, and master's domains `build.rs` needs pr4xis's new codegen API that published pr4xis 0.25.4 lacks). From this branch, with your crates.io token, publish in dependency order **before merging**:

```bash
git switch fix/release-plz-root-cause
cargo publish -p pr4xis-derive
cargo publish -p pr4xis
cargo publish -p pr4xis-runtime
cargo publish -p pr4xis-domains
cargo publish -p pr4xis-web
```

(There can be a few seconds of index propagation between each — cargo usually waits.) Once `pr4xis-domains` is on crates.io, the wedge clears: the next master push self-heals and release-plz auto-bumps from here on.

**The `publish-invariant` job is RED on this branch until that publish runs** — that red is the literal "publish domains" signal, and it goes green once domains is on crates.io. So: publish from the branch → confirm the guard goes green → merge.

## Notes

- Workspace builds at 0.25.5; the ci.yml indentation matches the sibling jobs; the guard's exempt extraction was verified (exempt = pr4xis-cli/-chat/-examples).
- Optional polish after publishing: `git tag pr4xis-domains-v0.25.5` (and siblings) so tags match the registry — not required (tag-behind-registry is the safe direction).
