### PR TITLE
fix(ci): deploy Pages on every green master push, not only on releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,11 +459,26 @@ jobs:
           exit $fail
 
 
+  # Deploy the docs site (chatbot / decks / the `.prx.gz` ontologies under
+  # /ontologies/) on EVERY green master push — NOT gated on a release. It used to
+  # be `needs: [release-plz-release]` + `if: releases_created == 'true'`, so the
+  # public site only refreshed when a version was cut and went stale between
+  # releases (and skipped entirely on a no-release push, e.g. when the workspace
+  # is already up to date). Decoupled: it deploys whenever the build/test/wasm/
+  # lint gates pass on master, the same success gate the release jobs use.
   pages:
     name: Deploy Pages
     runs-on: ubuntu-latest
-    needs: [release-plz-release]
-    if: needs.release-plz-release.outputs.releases_created == 'true'
+    needs: [lint-docs, test, wasm, format, no-ignored-doctests]
+    if: |
+      always() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/master' &&
+      needs.lint-docs.result == 'success' &&
+      needs.test.result == 'success' &&
+      needs.wasm.result == 'success' &&
+      needs.format.result == 'success' &&
+      needs.no-ignored-doctests.result == 'success'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
The Deploy Pages job was gated on a release being cut (`needs: [release-plz-release]` + `if: releases_created == 'true'`), so the public docs site — chatbot, decks, and the `.prx.gz` ontologies under `/ontologies/` — only refreshed when a version was released, and **skipped entirely on a no-release push** (which is what happened after the 0.25.5 manual-bootstrap publish: the workspace was already up to date, so no release was cut, so Pages skipped). The site went stale between releases.

This decouples it: Pages deploys whenever the build/test/wasm/lint gates pass on a master push — the same success gate the release jobs already use. The job's own steps are unchanged (it self-contains its wasm build + `.prx.gz` emit), and the release-asset upload that referenced release-plz-release's output was already removed in the Pages-422 fix, so there's no remaining coupling to drop.

After merge, Pages deploys on this push and every green master push going forward.