### PR TITLE
feat(runtime)!: mint lexical surfaces on every ontology so the chat answers about any loaded ontology

### DIFF
--- a/crates/chat/src/lib.rs
+++ b/crates/chat/src/lib.rs
@@ -544,7 +544,10 @@ pub fn answer_question(
                         return trace_impls::ResponseResult {
                             response: build_taxonomy_response(
                                 en,
-                                en.surface_for_relation(&kind).as_deref(),
+                                AnsweredRelation {
+                                    connective: en.surface_for_relation(&kind).as_deref(),
+                                    kind_name: &kind.name,
+                                },
                                 en.relation_chain(cid, pid, &kind),
                                 child,
                                 parent,
@@ -695,6 +698,22 @@ pub fn define_word(en: &dyn LexicalReasoner, word: &str) -> String {
     realize::realize(&content)
 }
 
+/// The answered relation, as the taxonomy realizer needs it: its loaded natural
+/// surface (the `connective`) and its typed kind name. Bundled so the realizer
+/// takes the relation as ONE argument (both fields describe the same relation).
+struct AnsweredRelation<'a> {
+    /// The relation's loaded surface ("part of" for Parthood), already resolved by
+    /// the caller from the typed kind — so the affirmation phrases "X is part of
+    /// Y", not "X is a Y". `None` (Subsumption / is-a) keeps the copula "is a".
+    /// Loaded data, never a hardcoded relation string.
+    connective: Option<&'a str>,
+    /// The answered relation's TYPED kind name (e.g. "Subsumption" / "Parthood"),
+    /// used to read the licensing transitivity rule + citation from the Relations
+    /// ontology when the chain spans more than one hop (Fix 2). Loaded data (the
+    /// kind the closure was keyed on), never a hardcoded relation string.
+    kind_name: &'a str,
+}
+
 /// Build a taxonomy response following the NLG pipeline.
 ///
 /// Reiter & Dale (2000):
@@ -704,11 +723,7 @@ pub fn define_word(en: &dyn LexicalReasoner, word: &str) -> String {
 /// 4. Realization — compose through grammar
 fn build_taxonomy_response(
     en: &dyn LexicalReasoner,
-    // The relation's loaded surface ("part of" for Parthood), already resolved by
-    // the caller from the typed kind — so the affirmation phrases "X is part of Y",
-    // not "X is a Y". `None` (Subsumption / is-a) keeps the copula "is a". Loaded
-    // data, never a hardcoded relation string.
-    connective: Option<&str>,
+    relation: AnsweredRelation<'_>,
     // The ORDERED evidence chain `[child, …, parent]` along the answered relation,
     // pre-resolved by the caller from the typed kind via `relation_chain` (the chat
     // cannot name a `ConceptRef`). For Subsumption it is the is-a chain, for
@@ -789,7 +804,7 @@ fn build_taxonomy_response(
     // ("a subsection is part of a section" for Parthood; "is a" for Subsumption).
     sections.push(format!(
         "Yes. {}.",
-        realize::sentence_relation(child_word, parent_word, connective)
+        realize::sentence_relation(child_word, parent_word, relation.connective)
     ));
 
     // Evidence: HOW — the relation chain explains the connection, each rung
@@ -802,10 +817,30 @@ fn build_taxonomy_response(
             evidence_parts.push(realize::sentence_relation(
                 chain_labels[i],
                 chain_labels[i + 1],
-                connective,
+                relation.connective,
             ));
         }
-        sections.push(evidence_parts.join(", and "));
+        let mut evidence = evidence_parts.join(", and ");
+
+        // The LICENSING rule (Fix 2): a chain of >1 hop is authorized by the
+        // relation's TRANSITIVITY — surface that rule AND its citation, read from
+        // the Relations ontology as DATA (never a hardcoded string here), so the
+        // answer shows the PROOF, not just the witness path. A single-hop (direct
+        // edge, chain length 2) invokes no transitivity, so this block is the only
+        // place it appends. A kind the ontology does not declare transitive yields
+        // no license, so the note is never fabricated. Realized through the NLG
+        // layer (`sentence_transitivity_license`), not a raw format! here.
+        use pr4xis_domains::formal::relations::ontology::transitivity_license;
+        if let Some(license) = transitivity_license(relation.kind_name) {
+            let relation_surface = relation.connective.unwrap_or("is-a");
+            evidence.push_str("; ");
+            evidence.push_str(&realize::sentence_transitivity_license(
+                relation_surface,
+                &license.property.to_lowercase(),
+                &license.citation,
+            ));
+        }
+        sections.push(evidence);
     }
 
     // Elaboration: WHAT each concept means
@@ -1900,8 +1935,8 @@ mod loaded_corpus_demo {
 // `from_ontology`, `reasoned_over`) so a regression that silently stops grounding
 // the label surfaces — or reintroduces a false negation from silence — fails here.
 //
-// The corpus is projected by `emit_with_forms::<LegalSourcesCategory>()` — the
-// SAME lexicalizing projection build.rs bakes into the wasm base — so a concept's
+// The corpus is projected by `emit::<LegalSourcesCategory>()` — the default,
+// lexicalizing projection build.rs bakes into the wasm base — so a concept's
 // ONTOLEX-Lemon label ("law", "case law", "legal document") grounds as a queryable
 // `ontolex:Form` surface, distinct from its Rust identifier. Nothing is hardcoded:
 // the Yes/No/Abstain each question yields is read off the loaded Subsumption
@@ -1913,7 +1948,7 @@ mod legal_sources_base {
     use pr4xis_domains::cognitive::linguistics::composed::ComposedReasoner;
     use pr4xis_domains::formal::information::diagnostics::trace_functors::TraceOntology;
     use pr4xis_domains::social::judicial::legal_sources::ontology::LegalSourcesCategory;
-    use pr4xis_runtime::emit::emit_with_forms;
+    use pr4xis_runtime::emit::emit;
     use pr4xis_runtime::ontology::{RuntimeOntology, materialize};
 
     /// Materialize the LegalSources ontology into a `RuntimeOntology` through the
@@ -1922,7 +1957,7 @@ mod legal_sources_base {
     /// `LegalDocument`) rides as an `ontolex:Form` surface the composed reasoner
     /// indexes, exactly as the wasm base does.
     fn legal_corpus() -> RuntimeOntology {
-        let archive = emit_with_forms::<LegalSourcesCategory>();
+        let archive = emit::<LegalSourcesCategory>();
         materialize(archive, OntologyName::new_static("LegalSources"))
             .expect("LegalSources corpus materializes")
     }
@@ -1985,8 +2020,58 @@ mod legal_sources_base {
     #[test]
     fn a_statute_is_a_law() {
         // THE headline: Statute ⊑ LegalDocument ⊑ LegalSource(label "law"). The label
-        // surface "law" grounds (emit_with_forms), so the closure query answers Yes.
+        // surface "law" grounds (default lexicalizing emit), so the closure query answers Yes.
         assert_yes("is a statute a law");
+    }
+
+    #[test]
+    fn a_multi_hop_answer_renders_labels_and_the_transitivity_license() {
+        // Fix 1 + Fix 2 on the headline, multi-hop path Statute ⊑ LegalDocument ⊑
+        // LegalSource: the evidence chain renders the NATURAL LABELS ("legal
+        // document", "law") read from each concept's `canonicalForm` Form — NEVER
+        // the Rust identifiers "LegalDocument"/"LegalSource" — and the answer
+        // appends the LICENSING rule (is-a is transitive) with its citation, read
+        // from the Relations ontology as data.
+        let r = process_with_reasoner(&English::sample(), &reasoner(), "is a statute a law");
+        assert!(
+            r.response.contains("legal document"),
+            "the middle rung renders its label 'legal document'; got {:?}",
+            r.response
+        );
+        assert!(
+            !r.response.contains("LegalDocument") && !r.response.contains("LegalSource"),
+            "no Rust identifier may leak into the rendered answer; got {:?}",
+            r.response
+        );
+        // The transitivity licensing note — the RULE, not just the path.
+        assert!(
+            r.response.contains("is transitive"),
+            "a multi-hop is-a answer names the transitivity that licensed it; got {:?}",
+            r.response
+        );
+        assert!(
+            r.response.contains("Tarski"),
+            "the transitivity note carries its citation, read from the Relations \
+             ontology; got {:?}",
+            r.response
+        );
+    }
+
+    #[test]
+    fn a_single_hop_answer_invokes_no_transitivity() {
+        // The direct edge Statute ⊑ LegalDocument is a SINGLE hop — no transitivity
+        // is invoked, so the answer states the direct relation only (no licensing note).
+        let r = process_with_reasoner(
+            &English::sample(),
+            &reasoner(),
+            "is a statute a legal document",
+        );
+        assert!(r.response.to_lowercase().contains("yes"));
+        assert!(
+            !r.response.contains("is transitive"),
+            "a single-hop (direct edge) answer must not append a transitivity note; got {:?}",
+            r.response
+        );
     }
 
     #[test]
@@ -2159,5 +2244,123 @@ mod legal_sources_base {
             without, with.response,
             "loading the base must change the answer (it is not hardcoded)"
         );
+    }
+}
+
+// =========================================================================
+// Non-legal guardrail — the Dependability demo through the SAME chat path
+// =========================================================================
+//
+// The three fixes are NOT legal-specific: any compiled ontology, grounded into
+// English, must render its natural labels and surface the transitivity rule. The
+// Avizienis et al. (2004) Dependability taxonomy is the non-legal witness — a
+// `DormantFault ⊑ Fault ⊑ Threat` chain whose multi-word label "dormant fault"
+// (its `canonicalForm` Form) must print in place of the identifier "DormantFault".
+#[cfg(test)]
+mod dependability_demo {
+    use super::*;
+    use pr4xis::ontology::meta::OntologyName;
+    use pr4xis_domains::applied::dependability::ontology::DependabilityCategory;
+    use pr4xis_domains::cognitive::linguistics::composed::ComposedReasoner;
+    use pr4xis_domains::formal::information::diagnostics::trace_functors::TraceOntology;
+    use pr4xis_runtime::emit::emit;
+    use pr4xis_runtime::ontology::{RuntimeOntology, materialize};
+
+    /// The Dependability ontology through the default lexicalizing projection, so
+    /// each concept's label ("Dormant fault", "Threat") rides as an `ontolex:Form`.
+    fn dependability_corpus() -> RuntimeOntology {
+        materialize(
+            emit::<DependabilityCategory>(),
+            OntologyName::new_static("Dependability"),
+        )
+        .expect("Dependability corpus materializes")
+    }
+
+    fn reasoner() -> ComposedReasoner {
+        ComposedReasoner::new(English::sample(), vec![dependability_corpus()])
+    }
+
+    fn credits_dependability(r: &ProcessResult) -> bool {
+        r.trace.reasoned_over().iter().any(|(o, ok)| {
+            matches!(o, TraceOntology::Loaded(n) if n.as_str() == "Dependability") && *ok
+        })
+    }
+
+    #[test]
+    fn is_a_dormant_fault_a_fault_renders_the_label_not_the_identifier() {
+        // Fix 1 (non-legal): the multi-word surface "dormant fault" resolves and
+        // the answer renders it — never the Rust identifier "DormantFault". A
+        // direct edge DormantFault ⊑ Fault, so a Yes crediting the loaded corpus.
+        let r = process_with_reasoner(
+            &English::sample(),
+            &reasoner(),
+            "is a dormant fault a fault",
+        );
+        assert_eq!(
+            r.outcome,
+            ChatOutcome::Answered,
+            "a dormant fault IS a fault; got {:?} / {:?}",
+            r.outcome,
+            r.response
+        );
+        assert!(r.response.to_lowercase().contains("yes"));
+        assert!(
+            r.response.contains("dormant fault"),
+            "the answer renders the natural label 'dormant fault'; got {:?}",
+            r.response
+        );
+        assert!(
+            !r.response.contains("DormantFault"),
+            "the Rust identifier 'DormantFault' must never print; got {:?}",
+            r.response
+        );
+        assert!(
+            credits_dependability(&r),
+            "the answer credits the loaded Dependability ontology it reasoned over"
+        );
+    }
+
+    #[test]
+    fn a_multi_hop_dependability_answer_carries_the_transitivity_note() {
+        // Fix 2 (non-legal): DormantFault ⊑ Fault ⊑ Threat is a multi-hop is-a
+        // chain, so the SAME transitivity licensing note appears — the rule is a
+        // property of the relation, not of the legal domain.
+        let r = process_with_reasoner(
+            &English::sample(),
+            &reasoner(),
+            "is a dormant fault a threat",
+        );
+        assert_eq!(r.outcome, ChatOutcome::Answered, "got {:?}", r.response);
+        assert!(r.response.to_lowercase().contains("yes"));
+        assert!(
+            r.response.contains("is transitive") && r.response.contains("Tarski"),
+            "a multi-hop answer names the transitivity rule + its citation; got {:?}",
+            r.response
+        );
+        // The intermediate whole renders by label, not identifier.
+        assert!(
+            !r.response.contains("DormantFault"),
+            "no identifier leaks in the chain; got {:?}",
+            r.response
+        );
+    }
+
+    #[test]
+    fn what_is_a_dormant_fault_answers_from_the_avizienis_gloss() {
+        // The definitional path reads the loaded Avizienis gloss for the concept.
+        let r = process_with_reasoner(&English::sample(), &reasoner(), "what is a dormant fault");
+        assert_eq!(r.outcome, ChatOutcome::Answered);
+        assert!(r.from_ontology, "the gloss comes from the loaded ontology");
+        assert!(
+            r.response.to_lowercase().contains("dormant fault"),
+            "the answer names the queried concept by label; got {:?}",
+            r.response
+        );
+        assert!(
+            r.response.contains("not yet been activated"),
+            "the answer surfaces the loaded Avizienis gloss; got {:?}",
+            r.response
+        );
+        assert!(credits_dependability(&r));
     }
 }

--- a/crates/chat/src/lib.rs
+++ b/crates/chat/src/lib.rs
@@ -165,19 +165,30 @@ pub fn process_with_reasoner(
         },
     );
 
-    // Single-word LOADED entity → offer a proper-noun (NP) reading too, so
-    // "is <one-word-loaded-X> part of Y" parses (collapse only NP-types MULTI-word
-    // spans). Gated on LOADED-corpus membership — NOT the union lookup — so English
-    // function words (which never resolve to a loaded ontology) keep their copula/
-    // determiner/wh types; the parse is not disturbed. NP is ADDED as an
-    // alternative, never replacing the base type, so a determiner case ("a title")
-    // still reduces via the noun reading and the chart keeps whichever derives S.
+    // A LOADED ontology surface is a noun the chat reasons over. Offer it BOTH
+    // readings so it parses in either syntactic role, gated on LOADED-corpus
+    // membership — NOT the union lookup — so English function words (which never
+    // resolve to a loaded ontology) keep their copula/determiner/wh types:
+    //   - a proper-noun NP reading, so it stands alone as a subject/complement
+    //     ("is <loaded-X> part of Y", "is case law a law"); and
+    //   - a common-noun N reading, so a determiner attaches ("a legal document").
+    // A single-word loaded surface already carries N from tokenize; a COLLAPSED
+    // multi-word surface (a §9 citation/label span) arrives typed NP-only, so
+    // without the N reading "a <multi-word-label>" could not reduce (the determiner
+    // NP/N finds no N). Both are ADDED as alternatives, never replacing the base
+    // type, so the chart keeps whichever derives S.
     {
         use pr4xis_domains::cognitive::linguistics::lambek::types::svo;
         let np = svo::proper_noun();
+        let n = svo::noun();
         for (i, tok) in tokens.iter().enumerate() {
-            if reasoner.is_loaded_surface(&tok.word) && !type_sets[i].contains(&np) {
-                type_sets[i].push(np.clone());
+            if reasoner.is_loaded_surface(&tok.word) {
+                if !type_sets[i].contains(&np) {
+                    type_sets[i].push(np.clone());
+                }
+                if !type_sets[i].contains(&n) {
+                    type_sets[i].push(n.clone());
+                }
             }
         }
     }
@@ -484,6 +495,9 @@ pub fn answer_question(
     use pr4xis_domains::cognitive::linguistics::pragmatics::realize::{self, ResponseContent};
     use pr4xis_domains::cognitive::linguistics::pragmatics::response::ResponseFrame;
     use pr4xis_domains::cognitive::linguistics::relation_lexicon::subsumption_kind;
+    use pr4xis_domains::formal::relations::ontology::{
+        antisymmetric_relation_kinds, opposition_relation_kind,
+    };
 
     let all_entities: Vec<String> = arguments.iter().map(extract_entity_name).collect();
 
@@ -545,16 +559,53 @@ pub fn answer_question(
                     }
                 }
             }
-            // The negation still TRAVERSED the loaded closure — record it. The
-            // denial phrases with the relation's loaded surface ("is not part of"),
-            // not "is not a".
+            // No forward path child→parent along `kind`. Assert a negation ONLY
+            // when it is PROVABLE — absence of a path is not a disproof, and a
+            // closed-world "No" is dishonest ("a statute is not a law" was exactly
+            // such a false negative). Two positive grounds, both read from LOADED
+            // relation properties (never a hardcoded match):
+            //   1. `kind` is antisymmetric AND the reverse holds (parent→child):
+            //      A ⊑ B ∧ A ≠ B ⇒ ¬(B ⊑ A) — this keeps the real directional
+            //      negations answering No ("is a law a statute"; "is a section
+            //      part of its subsection").
+            //   2. a direct Opposition edge declares child and parent disjoint.
+            // Otherwise the turn ABSTAINS (typed `Abstained`), naming the pair,
+            // rather than fabricating a negation.
+            let kind_is_antisymmetric = antisymmetric_relation_kinds().contains(&kind);
+            let opposition = opposition_relation_kind();
+            let provably_not = child_ids.iter().any(|&cid| {
+                parent_ids.iter().any(|&pid| {
+                    (kind_is_antisymmetric && en.reaches(pid, cid, &kind))
+                        || en.reaches(cid, pid, &opposition)
+                        || en.reaches(pid, cid, &opposition)
+                })
+            });
             let traversed: Vec<ConceptId> = child_ids.iter().chain(parent_ids).copied().collect();
-            let connective = en.surface_for_relation(&kind);
+            if provably_not {
+                // A real, derived answer: the denial phrases with the relation's
+                // loaded surface ("is not part of"), not "is not a".
+                let connective = en.surface_for_relation(&kind);
+                return trace_impls::ResponseResult {
+                    response: realize::realize_negation(child, parent, connective.as_deref()),
+                    entities_found: entities.clone(),
+                    taxonomy_checked: Some((child.clone(), parent.clone(), false)),
+                    from_ontology: true,
+                    reasoned_over: loaded_ontologies_of(en, &traversed),
+                };
+            }
+            // Not derivable and not disprovable → abstain honestly (§4.1). The
+            // reasoner traversed the loaded closure but found neither a path nor a
+            // disproof; `from_ontology: false` makes the caller emit
+            // `ChatOutcome::Abstained { unresolved: [child, parent] }`.
+            let content = ResponseContent::new(ResponseFrame::AcknowledgeGap)
+                .with_predicate(predicate)
+                .with_entity(child)
+                .with_entity(parent);
             return trace_impls::ResponseResult {
-                response: realize::realize_negation(child, parent, connective.as_deref()),
+                response: realize::realize(&content),
                 entities_found: entities.clone(),
                 taxonomy_checked: Some((child.clone(), parent.clone(), false)),
-                from_ontology: true,
+                from_ontology: false,
                 reasoned_over: loaded_ontologies_of(en, &traversed),
             };
         }
@@ -1832,6 +1883,281 @@ mod loaded_corpus_demo {
             answer_question(&composed, "is", &args).taxonomy_checked,
             Some(("subsection".to_string(), "section".to_string(), false)),
             "is → Subsumption fallback → false (the edge is Parthood, not is-a)"
+        );
+    }
+}
+
+// =========================================================================
+// LegalSources base — the guardrail spec-lock: real statute questions over
+// the reasoner
+// =========================================================================
+//
+// The always-loaded LegalSources base (LKIF-Core formal sources of law) wired
+// into the wasm chat is exercised HERE at the chat entry (`process_with_reasoner`
+// / `answer_question`), on the same `ComposedReasoner` the wasm builds. These are
+// the guardrail: they ask the questions a person actually types ("is a statute a
+// law") and lock the TYPED outcomes (`ChatOutcome`, `taxonomy_checked`,
+// `from_ontology`, `reasoned_over`) so a regression that silently stops grounding
+// the label surfaces — or reintroduces a false negation from silence — fails here.
+//
+// The corpus is projected by `emit_with_forms::<LegalSourcesCategory>()` — the
+// SAME lexicalizing projection build.rs bakes into the wasm base — so a concept's
+// ONTOLEX-Lemon label ("law", "case law", "legal document") grounds as a queryable
+// `ontolex:Form` surface, distinct from its Rust identifier. Nothing is hardcoded:
+// the Yes/No/Abstain each question yields is read off the loaded Subsumption
+// closure through the composed reasoner, never a `match` on the question text.
+#[cfg(test)]
+mod legal_sources_base {
+    use super::*;
+    use pr4xis::ontology::meta::OntologyName;
+    use pr4xis_domains::cognitive::linguistics::composed::ComposedReasoner;
+    use pr4xis_domains::formal::information::diagnostics::trace_functors::TraceOntology;
+    use pr4xis_domains::social::judicial::legal_sources::ontology::LegalSourcesCategory;
+    use pr4xis_runtime::emit::emit_with_forms;
+    use pr4xis_runtime::ontology::{RuntimeOntology, materialize};
+
+    /// Materialize the LegalSources ontology into a `RuntimeOntology` through the
+    /// lexicalizing projection — so each concept's Lemon label ("law" for
+    /// `LegalSource`, "case law" for `Precedent`, "legal document" for
+    /// `LegalDocument`) rides as an `ontolex:Form` surface the composed reasoner
+    /// indexes, exactly as the wasm base does.
+    fn legal_corpus() -> RuntimeOntology {
+        let archive = emit_with_forms::<LegalSourcesCategory>();
+        materialize(archive, OntologyName::new_static("LegalSources"))
+            .expect("LegalSources corpus materializes")
+    }
+
+    fn reasoner() -> ComposedReasoner {
+        ComposedReasoner::new(English::sample(), vec![legal_corpus()])
+    }
+
+    /// Two `Sem::Concept` (NP) arguments naming the entities of a relational
+    /// question — what `answer_question` reads via `extract_entity_name`.
+    fn entity_args(child: &str, parent: &str) -> [montague::Sem; 2] {
+        [
+            montague::Sem::Concept {
+                word: child.to_string(),
+                concepts: Vec::new(),
+            },
+            montague::Sem::Concept {
+                word: parent.to_string(),
+                concepts: Vec::new(),
+            },
+        ]
+    }
+
+    /// Whether a turn's provenance names the loaded LegalSources ontology,
+    /// success-marked — the "answered FROM the base" evidence.
+    fn credits_legal_sources(result: &ProcessResult) -> bool {
+        result.trace.reasoned_over().iter().any(|(o, ok)| {
+            matches!(o, TraceOntology::Loaded(n) if n.as_str() == "LegalSources") && *ok
+        })
+    }
+
+    /// Assert a natural-language question answers YES from the base: the typed
+    /// outcome is `Answered`, the answer is from the ontology, the prose affirms,
+    /// and the provenance credits LegalSources.
+    fn assert_yes(question: &str) {
+        let r = process_with_reasoner(&English::sample(), &reasoner(), question);
+        assert_eq!(
+            r.outcome,
+            ChatOutcome::Answered,
+            "{question:?} must be Answered; got {:?} / {:?}",
+            r.outcome,
+            r.response
+        );
+        assert!(
+            r.from_ontology,
+            "{question:?} must answer from the ontology; got {:?}",
+            r.response
+        );
+        assert!(
+            r.response.to_lowercase().contains("yes"),
+            "{question:?} must affirm (Yes); got {:?}",
+            r.response
+        );
+        assert!(
+            credits_legal_sources(&r),
+            "{question:?} must credit the LegalSources base it reasoned over"
+        );
+    }
+
+    #[test]
+    fn a_statute_is_a_law() {
+        // THE headline: Statute ⊑ LegalDocument ⊑ LegalSource(label "law"). The label
+        // surface "law" grounds (emit_with_forms), so the closure query answers Yes.
+        assert_yes("is a statute a law");
+    }
+
+    #[test]
+    fn the_enacted_species_are_all_law() {
+        // Every enacted written instrument reaches the LegalSource genus.
+        assert_yes("is a regulation a law");
+        assert_yes("is a constitution a law");
+        assert_yes("is a treaty a law");
+    }
+
+    #[test]
+    fn a_statute_is_a_legal_document() {
+        // A MULTI-WORD label surface ("legal document") — the recognizer collapses
+        // it and the direct Subsumption Statute ⊑ LegalDocument answers Yes.
+        assert_yes("is a statute a legal document");
+    }
+
+    #[test]
+    fn subsumption_is_reflexive_a_statute_is_a_statute() {
+        // Subsumption is reflexive (per the Relations ontology), so a concept is-a
+        // itself — the reflexive short-circuit, not a fabricated edge.
+        assert_yes("is a statute a statute");
+    }
+
+    #[test]
+    fn case_law_is_a_law() {
+        // Precedent (label "case law") ⊑ LegalSource directly — a multi-word label
+        // on the resolved concept and the genus surface "law".
+        assert_yes("is case law a law");
+    }
+
+    #[test]
+    fn what_is_a_statute_answers_from_the_loaded_gloss() {
+        // A single-entity definitional question reads the LegalSources gloss.
+        let r = process_with_reasoner(&English::sample(), &reasoner(), "what is a statute");
+        assert_eq!(r.outcome, ChatOutcome::Answered);
+        assert!(r.from_ontology, "the gloss comes from the loaded ontology");
+        assert!(
+            r.response.to_lowercase().contains("statute"),
+            "the answer names the queried concept; got {:?}",
+            r.response
+        );
+        assert!(
+            r.response.contains("norm") || r.response.contains("legal person"),
+            "the answer surfaces the loaded LKIF gloss; got {:?}",
+            r.response
+        );
+        assert!(
+            credits_legal_sources(&r),
+            "the definition credits LegalSources"
+        );
+    }
+
+    #[test]
+    fn a_law_is_not_a_statute_provable_negation_from_antisymmetry() {
+        // Subsumption is antisymmetric: Statute ⊑ LegalSource holds AND Statute ≠
+        // LegalSource, so ¬(LegalSource ⊑ Statute) — a PROVABLE No, not silence. The
+        // denial reads "is not a", taxonomy_checked false, but STILL from_ontology
+        // (a derived disproof, the real directional negation the honesty fix keeps).
+        let no = answer_question(&reasoner(), "is", &entity_args("law", "statute"));
+        assert_eq!(
+            no.taxonomy_checked,
+            Some(("law".to_string(), "statute".to_string(), false)),
+            "a law is NOT a statute (antisymmetry); got {:?}",
+            no.taxonomy_checked
+        );
+        assert!(
+            no.from_ontology,
+            "a provable negation is still an ontology answer"
+        );
+        assert!(
+            no.response.to_lowercase().contains("not"),
+            "the denial must read as a negation; got {:?}",
+            no.response
+        );
+    }
+
+    #[test]
+    fn siblings_abstain_not_a_false_no() {
+        // Statute and Regulation are siblings under LegalDocument — no path either
+        // way, no antisymmetric reverse, no opposition. The honesty fix ABSTAINS
+        // (does not fabricate "a statute is not a regulation"): typed Abstained,
+        // from_ontology false, taxonomy_checked recorded false (traversed, no proof).
+        let r = process_with_reasoner(&English::sample(), &reasoner(), "is a statute a regulation");
+        assert!(
+            matches!(r.outcome, ChatOutcome::Abstained { .. }),
+            "siblings must abstain, not assert a false No; got {:?} / {:?}",
+            r.outcome,
+            r.response
+        );
+        assert!(!r.from_ontology, "an abstention is not an ontology answer");
+
+        // At the answer_question layer the abstention is explicit: taxonomy_checked
+        // records the (child, parent, false) it traversed, but from_ontology is false.
+        let a = answer_question(&reasoner(), "is", &entity_args("statute", "regulation"));
+        assert_eq!(
+            a.taxonomy_checked,
+            Some(("statute".to_string(), "regulation".to_string(), false))
+        );
+        assert!(
+            !a.from_ontology,
+            "no path + no disproof ⇒ abstain (from_ontology false), never a fabricated No"
+        );
+    }
+
+    #[test]
+    fn a_cross_universe_pair_abstains() {
+        // "is a statute an animal": `statute` is a loaded LegalSources concept,
+        // `animal` a WordNet (sample) concept — two disjoint identity universes with
+        // no edge between them. No path, no antisymmetric reverse, no opposition ⇒
+        // abstain, never a false No. (Both surfaces DO resolve — the contrast with a
+        // truly-unknown word that would collapse to a definition.)
+        let r = process_with_reasoner(&English::sample(), &reasoner(), "is a statute an animal");
+        assert!(
+            matches!(r.outcome, ChatOutcome::Abstained { .. }),
+            "a cross-universe pair must abstain; got {:?} / {:?}",
+            r.outcome,
+            r.response
+        );
+        assert!(!r.from_ontology);
+    }
+
+    #[test]
+    fn case_law_vs_legal_document_abstains_honestly() {
+        // LKIF places Precedent (case law) DIRECTLY under Legal_Source, NOT under
+        // Legal_Document — so there is no path Precedent ⊑ LegalDocument, no reverse
+        // path, and no declared opposition/disjointness between them. Per the honesty
+        // fix this is an ABSTENTION, not a provable No: "case law is not a legal
+        // document" would require a cited disjointness edge the ontology does not
+        // (yet) assert — a follow-up if a literature-grounded Precedent ⊥
+        // LegalDocument edge is later added.
+        let a = answer_question(
+            &reasoner(),
+            "is",
+            &entity_args("case law", "legal document"),
+        );
+        assert_eq!(
+            a.taxonomy_checked,
+            Some(("case law".to_string(), "legal document".to_string(), false)),
+            "no path Precedent ⊑ LegalDocument; got {:?}",
+            a.taxonomy_checked
+        );
+        assert!(
+            !a.from_ontology,
+            "no path + no disproof ⇒ honest abstention, not a fabricated No"
+        );
+    }
+
+    #[test]
+    fn without_the_base_the_yes_disappears_the_with_without_contrast() {
+        // The contrast that proves the Yes comes from the LOADED base, not a
+        // hardcoded branch: English-only (`process`, no LegalSources) cannot ground
+        // "statute"/"law" (the sample lexicon knows neither) and does NOT answer a
+        // hardcoded Yes; WITH the base the SAME question answers Yes crediting
+        // LegalSources.
+        let (without, _, _) = process(&English::sample(), "is a statute a law");
+        assert!(
+            !without.to_lowercase().contains("yes"),
+            "english-only must NOT answer a hardcoded Yes; got {without:?}"
+        );
+
+        let with = process_with_reasoner(&English::sample(), &reasoner(), "is a statute a law");
+        assert_eq!(with.outcome, ChatOutcome::Answered);
+        assert!(with.response.to_lowercase().contains("yes"));
+        assert!(
+            credits_legal_sources(&with),
+            "the Yes credits the loaded LegalSources base"
+        );
+        assert_ne!(
+            without, with.response,
+            "loading the base must change the answer (it is not hardcoded)"
         );
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -27,7 +27,23 @@ struct Cli {
 #[derive(Subcommand, Debug)]
 enum Command {
     /// Start an interactive chat session (default when no subcommand is given).
-    Chat,
+    Chat {
+        /// Load an additional ontology into the chat reasoner, so a NON-legal
+        /// (or any) loaded ontology is chattable interactively. Repeatable.
+        ///
+        /// Accepts, in resolution order:
+        ///   - a built-in demo ontology name — `dependability` (Avizienis et al.
+        ///     2004 fault taxonomy) or `legal-sources` — compiled in-process;
+        ///   - a registered OWL vocabulary name (e.g. `cito`, `doco`),
+        ///     materialised from its committed compact `.prx.gz` (run
+        ///     `pr4xis compile --compact` first if absent);
+        ///   - a path to a `.owl` file, parsed and grounded by its `rdfs:label`s.
+        ///
+        /// The LegalSources base is always loaded (parity with the wasm runtime),
+        /// so `is a statute a law` answers with no explicit `--load`.
+        #[arg(long = "load", value_name = "NAME-OR-PATH")]
+        load: Vec<String>,
+    },
     /// Fetch and verify external data dependencies declared by the
     /// `applied/data_provisioning/` ontology.
     Update {
@@ -141,8 +157,8 @@ enum Command {
 
 fn main() {
     let cli = Cli::parse();
-    match cli.command.unwrap_or(Command::Chat) {
-        Command::Chat => run_chat(),
+    match cli.command.unwrap_or(Command::Chat { load: Vec::new() }) {
+        Command::Chat { load } => run_chat(&load),
         Command::Update {
             name,
             check,
@@ -908,7 +924,7 @@ fn workspace_root() -> anyhow::Result<PathBuf> {
 // `pr4xis chat` — unchanged
 // --------------------------------------------------------------------------
 
-fn run_chat() {
+fn run_chat(load_specs: &[String]) {
     // The chat's English, through the single OWNED loader (`english_load_owned`,
     // content-addressed compact `.prx`, ms-cheap; XML fallback inside), honoring
     // the `WORDNET_XML` dev override. No `Box::leak` / `&'static`.
@@ -922,44 +938,74 @@ fn run_chat() {
         }
     }
 
+    // Assemble the LOADED knowledge set the chat reasons over — grounded into
+    // English by ONE `ComposedReasoner`, the SAME path the wasm runtime uses.
+    // Every loaded ontology carries its `ontolex:Form` label surfaces, so a
+    // concept is chattable by its natural language ("is a statute a law", "is a
+    // dormant fault a fault"). `loaded_names` mirrors it for the startup banner.
+    let mut loaded: Vec<pr4xis_runtime::ontology::RuntimeOntology> = Vec::new();
+    let mut loaded_names: Vec<String> = Vec::new();
+
+    // The always-loaded LegalSources BASE (parity with the wasm runtime): the
+    // LKIF-Core formal sources-of-law taxonomy, compiled in-process via the
+    // default lexicalizing `emit` so its labels ("law", "case law", "legal
+    // document") ride as queryable Form surfaces. So "is a statute a law" answers
+    // out of the box, no explicit `--load`.
+    match legal_sources_base() {
+        Ok(onto) => {
+            loaded_names.push(onto.id().as_str().to_string());
+            loaded.push(onto);
+        }
+        Err(e) => eprintln!("  [warn] LegalSources base unavailable: {e}"),
+    }
+
     // Materialise the U.S. Code corpus through the runtime loader: the
     // content-addressed compact `.prx` fast path when `pr4xis compile` has
-    // produced one (admitted through the fail-closed `praxis.lock` gate),
-    // the USLM XML otherwise. A title absent on disk is skipped, so on a
-    // fresh checkout `usc.section_count()` is honestly 0 — run
-    // `pr4xis update` then `pr4xis compile --compact` to provision it.
+    // produced one (admitted through the fail-closed `praxis.lock` gate), the
+    // USLM XML otherwise. A title absent on disk is skipped, so on a fresh
+    // checkout the USC contributes nothing — run `pr4xis update` then
+    // `pr4xis compile --compact` to provision it.
     let usc = pr4xis_domains::social::software::markup::xml::uslm::corpus::loaded();
-
-    // Reason over the LOADED U.S. Code, not just English: project the loaded
-    // corpus into a RuntimeOntology and compose it with English — the SAME path
-    // the wasm runtime uses (`install_runtime_ontology`) — so "what is section 1"
-    // answers from the loaded statute instead of abstaining. `None` when no title
-    // is on disk (English-only, exactly as before). Built BEFORE `language` so it
-    // owns the one English the tokenizer borrows.
-    let usc_reasoner: Option<ComposedReasoner> = (usc.section_count() > 0)
-        .then(|| usc_runtime_ontology(usc, OntologyName::new("usc")).ok())
-        .flatten()
-        .map(|onto| ComposedReasoner::new(load_chat_english(), vec![onto]));
-
-    // The tokenizer's English: the reasoner's OWN when a corpus is loaded (so the
-    // statute path loads English ONCE, not twice — `reasoner.english()`, the wasm
-    // pattern), else a standalone load. Both honor `WORDNET_XML` via the shared
-    // loader.
-    let standalone_english;
-    let language: &English = match usc_reasoner.as_ref() {
-        Some(reasoner) => reasoner.english(),
-        None => {
-            standalone_english = load_chat_english();
-            &standalone_english
+    if usc.section_count() > 0 {
+        match usc_runtime_ontology(usc, OntologyName::new("usc")) {
+            Ok(onto) => {
+                loaded_names.push(format!("usc ({} sections)", usc.section_count()));
+                loaded.push(onto);
+            }
+            Err(e) => eprintln!("  [warn] U.S. Code corpus unavailable: {e}"),
         }
-    };
+    }
+
+    // Each `--load` spec: a built-in demo, a registered OWL vocab, or an .owl file.
+    for spec in load_specs {
+        match load_chat_ontology(spec) {
+            Ok(onto) => {
+                loaded_names.push(onto.id().as_str().to_string());
+                loaded.push(onto);
+            }
+            Err(e) => eprintln!("  [warn] --load {spec}: {e}"),
+        }
+    }
+
+    // ONE reasoner over English + the whole loaded set. It owns the one English
+    // the tokenizer borrows (`reasoner.english()`, the wasm pattern), so English
+    // is loaded once.
+    let reasoner = ComposedReasoner::new(load_chat_english(), loaded);
+    let language: &English = reasoner.english();
 
     println!("pr4xis — axiomatic intelligence");
     println!(
-        "  {} concepts, {} words, {} USC sections",
+        "  {} concepts, {} words",
         language.concept_count(),
         language.word_count(),
-        usc.section_count(),
+    );
+    println!(
+        "  loaded ontologies: {}",
+        if loaded_names.is_empty() {
+            "(none)".to_string()
+        } else {
+            loaded_names.join(", ")
+        }
     );
     println!("  type 'quit' to exit");
     println!();
@@ -1003,16 +1049,13 @@ fn run_chat() {
         // Resolve anaphoric expressions via language lexicon + Centering Theory
         let resolved_input = resolve_pronouns(input, engine.situation(), language);
 
-        // Process through praxis-chat (shared logic — zero I/O)
-        // Route through the composed reasoner when a corpus is loaded (so loaded
-        // statutes answer), else the English-only path (abstains on an unloaded
-        // concept, exactly as before).
-        let (response_text, user_act, _sys_act) = match &usc_reasoner {
-            Some(reasoner) => {
-                let r = chat::process_with_reasoner(language, reasoner, &resolved_input);
-                (r.response, r.user_act, r.system_act)
-            }
-            None => chat::process(language, &resolved_input),
+        // Process through praxis-chat (shared logic — zero I/O). Always route
+        // through the composed reasoner: it grounds the LegalSources base plus
+        // every `--load`ed ontology into English, so a loaded concept answers and
+        // an unloaded one abstains — the same behavior the wasm runtime has.
+        let (response_text, user_act, _sys_act) = {
+            let r = chat::process_with_reasoner(language, &reasoner, &resolved_input);
+            (r.response, r.user_act, r.system_act)
         };
 
         // Extract referents for discourse tracking
@@ -1052,6 +1095,84 @@ fn run_chat() {
             Err(pr4xis::engine::EngineError::LogicalError { engine: e, .. }) => e,
         };
     }
+}
+
+/// The LegalSources base ontology, compiled in-process via the default
+/// lexicalizing `emit` (labels ride as `ontolex:Form` surfaces) and materialized.
+/// The CLI's always-loaded base — parity with the wasm runtime's embedded base.
+fn legal_sources_base() -> anyhow::Result<pr4xis_runtime::ontology::RuntimeOntology> {
+    use pr4xis_domains::social::judicial::legal_sources::ontology::LegalSourcesCategory;
+    use pr4xis_runtime::emit::emit;
+    use pr4xis_runtime::ontology::materialize;
+    materialize(
+        emit::<LegalSourcesCategory>(),
+        OntologyName::new_static("LegalSources"),
+    )
+    .map_err(|e| anyhow::anyhow!("LegalSources materialize failed: {e}"))
+}
+
+/// Resolve a `--load` spec to a [`RuntimeOntology`] the chat reasoner can ground.
+/// Resolution order: a built-in demo ontology name, then a registered OWL
+/// vocabulary name (from its committed compact `.prx.gz`), then an `.owl` file
+/// path. Reuses the existing loaders — no special-casing per source.
+fn load_chat_ontology(spec: &str) -> anyhow::Result<pr4xis_runtime::ontology::RuntimeOntology> {
+    use pr4xis_domains::applied::dependability::ontology::DependabilityCategory;
+    use pr4xis_domains::social::software::markup::xml::owl::bridge::owl_runtime_ontology;
+    use pr4xis_domains::social::software::markup::xml::owl::loaded_vocabularies::loaded_vocabularies;
+    use pr4xis_domains::social::software::markup::xml::owl::reader::read_owl;
+    use pr4xis_domains::social::software::markup::xml::owl::vocabulary::LoadedOwlVocabulary;
+    use pr4xis_runtime::emit::emit;
+    use pr4xis_runtime::ontology::materialize;
+
+    // 1. Built-in demo ontologies, compiled in-process (always available — no
+    //    disk artifacts). `dependability` is the non-legal demo Patrick asked for.
+    match spec.to_lowercase().as_str() {
+        "dependability" => {
+            return materialize(
+                emit::<DependabilityCategory>(),
+                OntologyName::new_static("Dependability"),
+            )
+            .map_err(|e| anyhow::anyhow!("Dependability materialize failed: {e}"));
+        }
+        "legal-sources" | "legalsources" | "legal" => return legal_sources_base(),
+        _ => {}
+    }
+
+    // 2. A registered OWL vocabulary by name (cito, doco, …), materialised from
+    //    its committed compact `.prx.gz` through the SAME registry-driven loader
+    //    every OWL-vocab consumer uses. Absent when the vocab has not been
+    //    compiled (`pr4xis compile --compact`).
+    if let Some(vocab) = loaded_vocabularies().get(spec) {
+        return owl_runtime_ontology(vocab, OntologyName::new(spec.to_string()))
+            .map_err(|e| anyhow::anyhow!("OWL vocab `{spec}` materialize failed: {e}"));
+    }
+
+    // 3. A filesystem path to a raw `.owl` file — parsed and grounded by its
+    //    `rdfs:label`s (the §9 OWL path). Lets a user point at any OWL vocabulary.
+    let path = Path::new(spec);
+    if path.exists()
+        && path
+            .extension()
+            .is_some_and(|e| e.eq_ignore_ascii_case("owl"))
+    {
+        let xml = std::fs::read_to_string(path)
+            .map_err(|e| anyhow::anyhow!("read {}: {e}", path.display()))?;
+        let ont = read_owl(&xml).map_err(|e| anyhow::anyhow!("parse {}: {e}", path.display()))?;
+        let vocab = LoadedOwlVocabulary::from_owl_ontology(&ont);
+        let name = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("owl")
+            .to_string();
+        return owl_runtime_ontology(&vocab, OntologyName::new(name))
+            .map_err(|e| anyhow::anyhow!("{}: materialize failed: {e}", path.display()));
+    }
+
+    anyhow::bail!(
+        "unknown ontology `{spec}` — expected a built-in demo (`dependability`, \
+         `legal-sources`), a registered OWL vocab name (compiled via \
+         `pr4xis compile --compact`), or a path to a `.owl` file"
+    )
 }
 
 /// Resolve anaphoric expressions using language lexicon + discourse state.

--- a/crates/domains/src/cognitive/linguistics/composed.rs
+++ b/crates/domains/src/cognitive/linguistics/composed.rs
@@ -49,6 +49,7 @@ use alloc::vec::Vec;
 use hashbrown::HashMap;
 
 use pr4xis::ontology::meta::OntologyName;
+use pr4xis_runtime::definition::CANONICAL_FORM_REL;
 use pr4xis_runtime::ontology::{ConceptRef, RuntimeOntology, subsumption_kind};
 
 use crate::cognitive::linguistics::english::bridge::FORM_KIND;
@@ -216,6 +217,27 @@ impl ComposedReasoner {
                     }
                 }
 
+                // The PRINTED lemma is the concept's `canonicalForm` Form surface —
+                // its ontolex:Form *writtenRep*, the natural label ("legal document",
+                // "dormant fault") — NOT its Rust identifier (`node.name`, kept below
+                // as the never-printed `original_id`). Frege: identity addresses
+                // (`node.name`), canonicalForm generates (the lemma). Fall back to the
+                // node name when the concept mints no canonicalForm (its label already
+                // equals its identifier case-insensitively, e.g. "Statute" — emit skips
+                // the redundant Form there, and the node name IS the natural word).
+                // GENERATION-only: every Form is still indexed above for LOOKUP, so
+                // this changes what prints, never what resolves.
+                let canonical_lemma = node
+                    .edges
+                    .iter()
+                    .find(|(role, target)| {
+                        role == CANONICAL_FORM_REL
+                            && target.local_name().is_some_and(|f| form_names.contains(f))
+                    })
+                    .and_then(|(_, target)| target.local_name())
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| node.name.clone());
+
                 // The synthesized Concept carries the loaded gloss as its
                 // definition, read straight from the materialized ontology
                 // (`RuntimeOntology::lexical`) — this is what `define_word`
@@ -225,7 +247,7 @@ impl ComposedReasoner {
                     id,
                     original_id: node.name.clone(),
                     pos: LmfPos::Noun,
-                    lemmas: alloc::vec![node.name.clone()],
+                    lemmas: alloc::vec![canonical_lemma],
                     definitions: gloss.into_iter().collect(),
                     examples: Vec::new(),
                 });

--- a/crates/domains/src/cognitive/linguistics/english/bridge.rs
+++ b/crates/domains/src/cognitive/linguistics/english/bridge.rs
@@ -89,10 +89,13 @@ pub const SYNSET_KIND: &str = "Synset";
 /// archive — the schema generator the praxis functor maps to `Subsumption`.
 pub const HYPERNYM_REL: &str = "hypernym";
 
-/// The praxis kind of a written-form atom — an `ontolex:Form` (its `writtenRep`),
-/// carrying NO sense. The honest target of the lexical `denotes` floor: a span
-/// grounds into "this written form occurred", never into a meaning.
-pub const FORM_KIND: &str = "Form";
+// The `ontolex:Form` wire primitives (`FORM_KIND`, `form_atom`) live in the
+// runtime crate beside [`Definition`], so the compiled-ontology emitter
+// (`pr4xis_runtime::emit`) mints Form atoms under the EXACT kind string this
+// bridge — and the composed reasoner — filter on. Re-exported here to keep the
+// `english::bridge::{FORM_KIND, form_atom}` path every downstream grounding site
+// already imports.
+pub use pr4xis_runtime::definition::{FORM_KIND, form_atom};
 
 /// Project the loaded [`English`] struct into a content-addressed source
 /// [`Archive`] — the functor `English → Archive`.
@@ -136,24 +139,6 @@ pub fn project_archive(english: &English) -> Archive {
     Archive {
         nodes,
         connections: Vec::new(),
-    }
-}
-
-/// The `ontolex:Form` atom for a written representation — a bare surface-form
-/// node carrying its `writtenRep` as both `name` and `lexical`, and NOTHING
-/// else: no sense, no synset edge. Its content [`address`](Definition::address)
-/// is what a lexical `denotes` floor edge points AT.
-///
-/// Sense-deferral is STRUCTURAL: a Form has no senses, so a pointer that resolves
-/// to one cannot have over-committed to a meaning (the written-form floor's
-/// honesty tripwire — a `denotes` edge must land on a `Form`, never a synset).
-pub fn form_atom(written_rep: &str) -> Definition {
-    Definition {
-        kind: FORM_KIND.to_string(),
-        name: written_rep.to_string(),
-        edges: Vec::new(),
-        axioms: Vec::new(),
-        lexical: Some(written_rep.to_string()),
     }
 }
 

--- a/crates/domains/src/cognitive/linguistics/pragmatics/realize.rs
+++ b/crates/domains/src/cognitive/linguistics/pragmatics/realize.rs
@@ -131,6 +131,26 @@ fn sentence_relation_neg(subject: &str, complement: &str, connective: Option<&st
     }
 }
 
+/// Realize the transitivity LICENSING clause of a multi-hop affirmative answer —
+/// the *rule* that authorized crossing two or more rungs, not the witness chain:
+/// "and is-a is transitive (Tarski (1941) …)". Every part is loaded data the
+/// caller read from the Relations ontology (the relation's surface, the
+/// `Transitive` structural-property label, its citation) — never composed here.
+/// When `citation` is empty (a transitive kind with no dedicated citation axiom
+/// yet), the property is still surfaced and the citation is silently omitted, so
+/// the caller can name the rule and treat the citation as a documented follow-up.
+pub fn sentence_transitivity_license(
+    relation_surface: &str,
+    property: &str,
+    citation: &str,
+) -> String {
+    if citation.is_empty() {
+        format!("and {relation_surface} is {property}")
+    } else {
+        format!("and {relation_surface} is {property} ({citation})")
+    }
+}
+
 /// Build a copula question: "is {subject} {complement}?"
 /// Inversion: (S[q]/NP)/NP + NP + NP → S[q]
 fn sentence_question(subject: &str, complement: &str) -> String {

--- a/crates/domains/src/formal/relations/ontology.rs
+++ b/crates/domains/src/formal/relations/ontology.rs
@@ -303,6 +303,53 @@ pub fn opposition_relation_kind() -> ConceptRef {
     relations_kind(RelationsConcept::Opposition.name())
 }
 
+/// The transitivity license for a relation kind — the *rule* that authorizes a
+/// multi-hop answer over that kind, read from THIS ontology as data: the ontolex
+/// label of the `Transitive` structural property, and the citation grounding the
+/// kind's transitivity. `Some` iff the kind declares `Transitive(R)` via its
+/// `(R, Transitive, HasProperty)` edge (so a single Similarity/Association hop —
+/// non-transitive — yields `None`, and a chain over it invokes no transitivity).
+///
+/// The citation is read off the kind's dedicated transitivity axiom
+/// ([`SubsumptionIsTransitive`] → Tarski 1941; [`ParthoodIsTransitive`] → Casati
+/// & Varzi 1999) — a first-class cited surface, never a literal in the caller. A
+/// transitive kind with no dedicated citation axiom yet returns the property name
+/// with an empty citation, so a caller can still surface "R is transitive" and
+/// treat the citation as a documented follow-up.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransitivityLicense {
+    /// The `Transitive` structural property's ontolex label ("Transitive").
+    pub property: String,
+    /// The citation grounding this kind's transitivity, from its axiom — empty
+    /// when no dedicated transitivity axiom cites this kind yet.
+    pub citation: String,
+}
+
+/// The transitivity license for the relation kind named `kind_name` (matched
+/// against the Relations concept names, e.g. `"Subsumption"` / `"Parthood"`).
+/// See [`TransitivityLicense`].
+pub fn transitivity_license(kind_name: &str) -> Option<TransitivityLicense> {
+    use pr4xis::category::{Concept, FinitelyGenerated};
+    let concept = RelationsConcept::variants()
+        .into_iter()
+        .find(|c| c.name() == kind_name)?;
+    if !relation_has_property(concept, RelationsConcept::Transitive) {
+        return None;
+    }
+    let property = RelationsConcept::Transitive
+        .lexical()
+        .map(|l| l.label.as_str().to_string())
+        .unwrap_or_else(|| RelationsConcept::Transitive.name().to_string());
+    let citation = match concept {
+        RelationsConcept::Subsumption => SubsumptionIsTransitive.citation().as_str().to_string(),
+        RelationsConcept::Parthood => ParthoodIsTransitive.citation().as_str().to_string(),
+        // Transitive per the catalog, but no dedicated citation axiom wired yet:
+        // surface the named property; the citation is a documented follow-up.
+        _ => String::new(),
+    };
+    Some(TransitivityLicense { property, citation })
+}
+
 fn kinded_edge_exists(
     from: RelationsConcept,
     to: RelationsConcept,
@@ -363,6 +410,51 @@ impl Axiom for SubsumptionIsAntisymmetric {
         "SubsumptionIsAntisymmetric",
         "RelationProperty catalog declares Subsumption as Antisymmetric (Tarski 1941): (A R B) \u{2227} (B R A) \u{21d2} A = B",
         "Guarino (2009) The Ontological Level; Tarski (1941) J. Symbolic Logic 6"
+    );
+}
+
+/// Guarino / Tarski — Subsumption is transitive. The structural property that
+/// LICENSES a multi-hop is-a chain: `A ⊑ B ∧ B ⊑ C ⇒ A ⊑ C`. Read by the chat
+/// engine (via [`transitivity_license`]) to surface the *rule* that authorized a
+/// transitive answer, not just the witness chain.
+pub struct SubsumptionIsTransitive;
+
+impl Axiom for SubsumptionIsTransitive {
+    fn verify(&self) -> pr4xis::logic::proof::Verdict {
+        use pr4xis::logic::proof::{SimpleCounterexample, SimpleProof};
+        if relation_has_property(RelationsConcept::Subsumption, RelationsConcept::Transitive) {
+            Ok(Box::new(SimpleProof::new(self.meta())))
+        } else {
+            Err(Box::new(SimpleCounterexample::new(self.meta())))
+        }
+    }
+
+    pr4xis::axiom_meta!(
+        "SubsumptionIsTransitive",
+        "RelationProperty catalog declares Subsumption as Transitive (Tarski 1941): (A R B) \u{2227} (B R C) \u{21d2} (A R C) — the property that licenses a multi-hop is-a chain",
+        "Tarski (1941) Calculus of Relations, J. Symbolic Logic 6"
+    );
+}
+
+/// Casati & Varzi / OBO-RO — Parthood is transitive. A part of a part is a part
+/// of the whole: `A part-of B ∧ B part-of C ⇒ A part-of C`. The licensing rule
+/// for a multi-hop mereological chain (`clause → section → title`).
+pub struct ParthoodIsTransitive;
+
+impl Axiom for ParthoodIsTransitive {
+    fn verify(&self) -> pr4xis::logic::proof::Verdict {
+        use pr4xis::logic::proof::{SimpleCounterexample, SimpleProof};
+        if relation_has_property(RelationsConcept::Parthood, RelationsConcept::Transitive) {
+            Ok(Box::new(SimpleProof::new(self.meta())))
+        } else {
+            Err(Box::new(SimpleCounterexample::new(self.meta())))
+        }
+    }
+
+    pr4xis::axiom_meta!(
+        "ParthoodIsTransitive",
+        "RelationProperty catalog declares Parthood as Transitive (Casati & Varzi 1999; OBO-RO): a part of a part is a part of the whole",
+        "Casati & Varzi (1999) Parts and Places; Smith et al. (2005) Genome Biology 6:R46 OBO-RO"
     );
 }
 
@@ -513,6 +605,8 @@ impl Ontology for RelationsOntology {
         let mut axioms = pr4xis::ontology::reasoning::structural_axioms_for::<Self::Cat>();
         axioms.push(Box::new(OppositionIsSymmetric));
         axioms.push(Box::new(SubsumptionIsAntisymmetric));
+        axioms.push(Box::new(SubsumptionIsTransitive));
+        axioms.push(Box::new(ParthoodIsTransitive));
         axioms.push(Box::new(CausationIsAsymmetric));
         axioms.push(Box::new(ParthoodIsDistinctFromSubsumption));
         axioms.push(Box::new(SubsumptionSpecialisationAreInverses));
@@ -590,6 +684,45 @@ mod tests {
         assert!(SubsumptionIsAntisymmetric.verify().is_ok());
     }
 
+    #[pr4xis::praxis_value(Verifiable)]
+    #[test]
+    fn subsumption_is_transitive_holds() {
+        assert!(SubsumptionIsTransitive.verify().is_ok());
+    }
+
+    #[pr4xis::praxis_value(Verifiable)]
+    #[test]
+    fn parthood_is_transitive_holds() {
+        assert!(ParthoodIsTransitive.verify().is_ok());
+    }
+
+    #[pr4xis::praxis_value(Verifiable)]
+    #[test]
+    fn transitivity_license_reads_the_property_and_citation_as_data() {
+        // The licensing rule surfaced for a multi-hop answer is READ from this
+        // ontology: Subsumption's transitivity carries the `Transitive` property
+        // label + the Tarski (1941) citation off its axiom; Parthood carries the
+        // Casati & Varzi citation; a non-transitive kind (Opposition) has no
+        // license — so the chat never fabricates a transitivity note.
+        let sub = super::transitivity_license("Subsumption").expect("Subsumption is transitive");
+        assert_eq!(sub.property, "Transitive");
+        assert!(
+            sub.citation.contains("Tarski"),
+            "Subsumption transitivity cites Tarski; got {:?}",
+            sub.citation
+        );
+        let part = super::transitivity_license("Parthood").expect("Parthood is transitive");
+        assert!(
+            part.citation.contains("Casati"),
+            "Parthood transitivity cites Casati & Varzi; got {:?}",
+            part.citation
+        );
+        assert!(
+            super::transitivity_license("Opposition").is_none(),
+            "Opposition is not transitive — no license"
+        );
+    }
+
     /// Regenerate the committed `relations_transitive_kinds.txt` caches that the
     /// `ontology!` macro (`pr4xis-derive`) and the kernel (`pr4xis-runtime`) read.
     /// `#[ignore]`d (it WRITES, asserting nothing) — the relation-kind analogue of
@@ -603,7 +736,7 @@ mod tests {
         use pr4xis::ontology::meta::OntologyName;
         use pr4xis_runtime::ontology::{materialize, transitive_kinds};
 
-        let archive = pr4xis_runtime::emit::emit::<RelationsCategory>();
+        let archive = pr4xis_runtime::emit::emit_kind_vocabulary::<RelationsCategory>();
         let relations =
             materialize(archive, OntologyName::new_static("Relations")).expect("materializes");
         let mut names: Vec<String> = transitive_kinds(&relations)
@@ -639,7 +772,7 @@ mod tests {
         use pr4xis::ontology::meta::OntologyName;
         use pr4xis_runtime::ontology::{materialize, transitive_kinds};
 
-        let archive = pr4xis_runtime::emit::emit::<RelationsCategory>();
+        let archive = pr4xis_runtime::emit::emit_kind_vocabulary::<RelationsCategory>();
         let relations =
             materialize(archive, OntologyName::new_static("Relations")).expect("materializes");
         let declared: alloc::collections::BTreeSet<String> = transitive_kinds(&relations)
@@ -684,7 +817,7 @@ mod tests {
     #[test]
     #[ignore]
     fn regenerate_morphism_kinds_prx() {
-        let archive = pr4xis_runtime::emit::emit::<RelationsCategory>();
+        let archive = pr4xis_runtime::emit::emit_kind_vocabulary::<RelationsCategory>();
         let bytes = pr4xis_runtime::load::emit(&archive).expect("emit morphism_kinds.prx bytes");
         std::fs::write(
             concat!(
@@ -703,13 +836,14 @@ mod tests {
     /// Drift guard (normal suite) for the committed `morphism_kinds.prx` — the
     /// relation-kind vocabulary the runtime's default morphism-kind vocab loads. The
     /// committed projection must deserialize, fail-closed against the LIVE Relations
-    /// root, to the SAME archive a fresh `emit::<RelationsCategory>()` produces; a
+    /// root, to the SAME archive a fresh `emit_kind_vocabulary::<RelationsCategory>()`
+    /// produces; a
     /// kind or a `HasProperty`/inter-kind edge changed without regenerating FAILS
     /// here (closing the rule-7 second-declaration gap, as the transitive cache does).
     #[pr4xis::praxis_value(Deterministic)]
     #[test]
     fn morphism_kinds_prx_matches_the_relations_ontology() {
-        let fresh = pr4xis_runtime::emit::emit::<RelationsCategory>();
+        let fresh = pr4xis_runtime::emit::emit_kind_vocabulary::<RelationsCategory>();
         let committed: &[u8] = include_bytes!("../../../../pr4xis-runtime/src/morphism_kinds.prx");
         let loaded = pr4xis_runtime::load::load(committed, fresh.root().expect("roots")).expect(
             "committed morphism_kinds.prx is STALE — regenerate with \
@@ -762,7 +896,7 @@ mod tests {
         use pr4xis_runtime::definition::EdgeTarget;
         use pr4xis_runtime::ontology::{ConceptRef, materialize, transitive_kinds};
 
-        let archive = pr4xis_runtime::emit::emit::<RelationsCategory>();
+        let archive = pr4xis_runtime::emit::emit_kind_vocabulary::<RelationsCategory>();
 
         // The loaded `.prx` data itself carries `(Subsumption, Transitive,
         // HasProperty)` — the assertion `RelationProperty::get` reads typed at

--- a/crates/domains/src/formal/relations/ontology.rs
+++ b/crates/domains/src/formal/relations/ontology.rs
@@ -280,6 +280,29 @@ pub fn reflexive_relation_kinds() -> BTreeSet<ConceptRef> {
         .collect()
 }
 
+/// The relation kinds carrying the `Antisymmetric` structural property (Tarski
+/// 1941; loaded from this ontology's `HasProperty` edges, never hardcoded).
+/// A reasoner uses this to license a *provable* negation: for an antisymmetric
+/// `R`, `A R B ∧ A ≠ B ⇒ ¬(B R A)` — so "is a law a statute" is a real No,
+/// not an abstention, once "a statute is a law" holds.
+pub fn antisymmetric_relation_kinds() -> BTreeSet<ConceptRef> {
+    use pr4xis::category::{Concept, FinitelyGenerated};
+    RelationsConcept::variants()
+        .into_iter()
+        .filter(|c| relation_has_property(*c, RelationsConcept::Antisymmetric))
+        .map(|c| relations_kind(c.name()))
+        .collect()
+}
+
+/// The `Opposition` relation kind (SKOS `related` with polarity; Saussure 1916;
+/// Cruse 1986) — symmetric and irreflexive, so a *direct* opposition edge is the
+/// only thing that licenses a provable negation on the disjointness axis. A
+/// reasoner checks a single edge (Opposition is non-transitive), never a closure.
+pub fn opposition_relation_kind() -> ConceptRef {
+    use pr4xis::category::Concept;
+    relations_kind(RelationsConcept::Opposition.name())
+}
+
 fn kinded_edge_exists(
     from: RelationsConcept,
     to: RelationsConcept,

--- a/crates/domains/src/social/judicial/legal_sources/functor_from_authority_strength.rs
+++ b/crates/domains/src/social/judicial/legal_sources/functor_from_authority_strength.rs
@@ -1,0 +1,156 @@
+//! Cross-functor: the `AuthorityStrength` ontology → the `LegalSources`
+//! ontology.
+//!
+//! `AuthorityStrength` classifies a legal source by *how much binding
+//! force* it carries (the vertical binding/persuasive tier ordering).
+//! `LegalSources` classifies it by *what kind of source* it is (statute,
+//! regulation, case law, …). These are orthogonal dimensions of the same
+//! underlying sources. This functor **relates** them — carrying each
+//! binding-force leaf to its source-type — without merging the two
+//! taxonomies (per the integration-via-functors discipline).
+//!
+//! # The object map (Kephart-style projection table)
+//!
+//! | AuthorityStrength concept | LegalSources concept | Why |
+//! |---|---|---|
+//! | `ConstitutionalText`               | `Constitution` | the constitutional instrument |
+//! | `FederalStatute`                   | `Statute`      | enacted legislation |
+//! | `FederalRegulation`                | `Regulation`   | administrative rulemaking |
+//! | `SupremeCourtPrecedent`            | `Precedent`    | reported case law |
+//! | `ControllingCircuitPrecedent`      | `Precedent`    | reported case law |
+//! | `SisterCircuitPrecedent`           | `Precedent`    | reported case law |
+//! | `DistrictCourtPrecedent`           | `Precedent`    | reported case law |
+//! | `AdministrativeReviewBoardDecision`| `Precedent`    | agency adjudication (a decided case) |
+//! | `SecondarySource`                  | `LegalSource`  | **partial arm** — see below |
+//! | `AuthorityStrength` (root)         | `LegalSource`  | abstract genus ↦ genus |
+//! | `BindingAuthority` (branch)        | `LegalSource`  | abstract branch ↦ genus |
+//! | `PersuasiveAuthority` (branch)     | `LegalSource`  | abstract branch ↦ genus |
+//!
+//! **The `SecondarySource` arm is partial/degenerate.** Treatises, law-
+//! review articles, and Restatements are persuasive authority (Garner
+//! 2016) but are *not* a formal source of law — LKIF-Core has no class
+//! for them, since they are commentary *about* the law rather than a
+//! source of it. Rather than fabricate a source-type, the functor sends
+//! `SecondarySource` to the genus `LegalSource`, the least-committal
+//! image. This keeps `map_object` total while recording honestly that no
+//! faithful source-type exists.
+//!
+//! # Why the functor laws hold
+//!
+//! Both categories, restricted to their `Subsumption` + identity
+//! morphisms, are **thin** (at most one morphism between any ordered
+//! pair — they are preorder categories). The object map is *monotone*:
+//! every source subsumption edge `A ⊑ B` maps to a target morphism
+//! `map(A) ⊑ map(B)` (or an identity when `map(A) == map(B)`). A monotone
+//! map between thin categories extends uniquely to a functor and
+//! preserves composition automatically, so `assert_functor_laws`
+//! passes. This functor is **not faithful** — five precedent-family
+//! concepts collapse onto `Precedent`, and four abstract/secondary
+//! concepts collapse onto `LegalSource`.
+
+#[allow(unused_imports)]
+use alloc::{boxed::Box, format, string::String, string::ToString, vec, vec::Vec};
+
+use pr4xis::category::{Arrow, Category};
+
+use super::ontology::{LegalSourcesCategory, LegalSourcesConcept, LegalSourcesRelation};
+use crate::social::judicial::authority_strength::ontology::{
+    AuthorityStrengthCategory, AuthorityStrengthConcept, AuthorityStrengthRelation,
+};
+
+/// Object map: a binding-force concept ↦ its legal-source type.
+fn map_authority(c: &AuthorityStrengthConcept) -> LegalSourcesConcept {
+    use AuthorityStrengthConcept as A;
+    use LegalSourcesConcept as L;
+    match c {
+        A::ConstitutionalText => L::Constitution,
+        A::FederalStatute => L::Statute,
+        A::FederalRegulation => L::Regulation,
+        // Every precedent-family concept — including the agency
+        // adjudication (ARB) — is reported case law.
+        A::SupremeCourtPrecedent
+        | A::ControllingCircuitPrecedent
+        | A::SisterCircuitPrecedent
+        | A::DistrictCourtPrecedent
+        | A::AdministrativeReviewBoardDecision => L::Precedent,
+        // Partial arm: secondary sources are not a formal source-type;
+        // send to the genus. See the module doc-comment.
+        A::SecondarySource => L::LegalSource,
+        // Abstract root + branches ↦ the genus.
+        A::AuthorityStrength | A::BindingAuthority | A::PersuasiveAuthority => L::LegalSource,
+    }
+}
+
+/// Morphism map: carry a source subsumption/identity edge to the unique
+/// target morphism between the mapped endpoints. Both categories are
+/// thin (preorder) on Subsumption + identity, so this selection is
+/// unambiguous: an identity when the endpoints collapse, otherwise the
+/// single materialised subsumption edge `map(from) ⊑ map(to)`.
+fn map_authority_morphism(m: &AuthorityStrengthRelation) -> LegalSourcesRelation {
+    let s = map_authority(&m.source());
+    let t = map_authority(&m.target());
+    if s == t {
+        LegalSourcesCategory::identity(&s)
+    } else {
+        LegalSourcesCategory::morphisms()
+            .into_iter()
+            .find(|r| r.source() == s && r.target() == t)
+            .expect("monotone object map: target subsumption edge must exist in the closed set")
+    }
+}
+
+pr4xis::functor! {
+    name: AuthorityStrengthToLegalSources,
+    source: AuthorityStrengthCategory,
+    target: LegalSourcesCategory,
+    citation: "Hoekstra et al. (2007) LKIF-Core; Schauer (2009) Thinking Like a Lawyer (binding force vs. source type as orthogonal dimensions); Salmond on Jurisprudence",
+    map_object: |obj: &AuthorityStrengthConcept| -> LegalSourcesConcept { map_authority(obj) },
+    map_morphism: |m: &AuthorityStrengthRelation| -> LegalSourcesRelation {
+        map_authority_morphism(m)
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pr4xis::category::Functor;
+    use pr4xis::category::laws::assert_functor_laws;
+
+    #[pr4xis::praxis_value(Extensible)]
+    #[test]
+    fn functor_laws_hold() {
+        assert_functor_laws::<AuthorityStrengthToLegalSources>();
+    }
+
+    #[pr4xis::praxis_value(Verifiable, Explainable)]
+    #[test]
+    fn functor_has_meta() {
+        let meta = AuthorityStrengthToLegalSources::meta();
+        assert_eq!(meta.name.as_str(), "AuthorityStrengthToLegalSources");
+        assert!(!meta.citation.as_str().is_empty());
+        assert!(meta.module_path.as_str().contains("legal_sources"));
+    }
+
+    /// Concrete sanity: every binding-force leaf lands on its documented
+    /// source-type.
+    #[pr4xis::praxis_value(Verifiable, Extensible)]
+    #[test]
+    fn object_map_matches_table() {
+        use AuthorityStrengthConcept as A;
+        use LegalSourcesConcept as L;
+        let f = AuthorityStrengthToLegalSources::map_object;
+        assert_eq!(f(&A::ConstitutionalText), L::Constitution);
+        assert_eq!(f(&A::FederalStatute), L::Statute);
+        assert_eq!(f(&A::FederalRegulation), L::Regulation);
+        assert_eq!(f(&A::SupremeCourtPrecedent), L::Precedent);
+        assert_eq!(f(&A::ControllingCircuitPrecedent), L::Precedent);
+        assert_eq!(f(&A::SisterCircuitPrecedent), L::Precedent);
+        assert_eq!(f(&A::DistrictCourtPrecedent), L::Precedent);
+        assert_eq!(f(&A::AdministrativeReviewBoardDecision), L::Precedent);
+        // Partial arm + abstract concepts collapse onto the genus.
+        assert_eq!(f(&A::SecondarySource), L::LegalSource);
+        assert_eq!(f(&A::AuthorityStrength), L::LegalSource);
+        assert_eq!(f(&A::BindingAuthority), L::LegalSource);
+        assert_eq!(f(&A::PersuasiveAuthority), L::LegalSource);
+    }
+}

--- a/crates/domains/src/social/judicial/legal_sources/mod.rs
+++ b/crates/domains/src/social/judicial/legal_sources/mod.rs
@@ -1,0 +1,91 @@
+//! Legal sources — the formal sources of law and their subsumption
+//! hierarchy.
+//!
+//! ```text
+//! LegalSource  (genus — "law")
+//!   ├── LegalDocument                     (lkif:Legal_Document)
+//!   │     ├── Statute                     (lkif:Statute)
+//!   │     ├── Regulation                  (lkif:Regulation)
+//!   │     ├── Constitution                (DOCTRINAL addition — Hart 1961)
+//!   │     ├── Treaty                       (lkif:Treaty)
+//!   │     └── Code                         (lkif:Code)
+//!   ├── Precedent                          (lkif:Precedent — DIRECT under Legal_Source)
+//!   └── CustomaryLaw                       (lkif:Customary_Law — DIRECT under Legal_Source)
+//! ```
+//!
+//! `Precedent` and `CustomaryLaw` sit *directly* under `LegalSource`,
+//! **not** under `LegalDocument` — faithful to LKIF-Core, where a
+//! precedent is a source of law but not a written document instrument.
+//!
+//! # Relationship to `authority_strength`
+//!
+//! This ontology captures *what kind of source* a rule comes from
+//! (statute vs. regulation vs. case law). The sibling
+//! `authority_strength` ontology captures *how much binding force* a
+//! source carries. The two are orthogonal dimensions related by the
+//! [`functor_from_authority_strength`] cross-functor — a binding-force
+//! leaf maps to its source-type — not by merging the taxonomies.
+//!
+//! # Citation-tier table (provenance discipline)
+//!
+//! Each edge and concept is tiered honestly. LKIF-Core edges are
+//! **machine-verifiable** against the published `norm.owl`; the
+//! genus/species doctrine is **doctrinal** (Salmond/Hart/Garner);
+//! `Constitution` is a **doctrinal-only** honest addition, flagged.
+//!
+//! | Concept / edge | Tier | Source |
+//! |---|---|---|
+//! | `LegalSource` | doctrinal + LKIF | Salmond; lkif:Legal_Source |
+//! | `LegalDocument ⊑ LegalSource` | LKIF machine-verifiable | norm.owl |
+//! | `Statute ⊑ LegalDocument` | LKIF machine-verifiable + doctrinal | norm.owl; Salmond |
+//! | `Regulation ⊑ LegalDocument` | LKIF machine-verifiable + doctrinal | norm.owl; Chevron (1984) |
+//! | `Constitution ⊑ LegalDocument` | **doctrinal-only (FLAGGED)** | Hart (1961) — NOT LKIF |
+//! | `Treaty ⊑ LegalDocument` | LKIF machine-verifiable + doctrinal | norm.owl; U.S. Const. Art. II §2 |
+//! | `Code ⊑ LegalDocument` | LKIF machine-verifiable | norm.owl |
+//! | `Precedent ⊑ LegalSource` (direct) | LKIF machine-verifiable + doctrinal | norm.owl; Garner (2016) |
+//! | `CustomaryLaw ⊑ LegalSource` (direct) | LKIF machine-verifiable + doctrinal | norm.owl; Salmond |
+//!
+//! # LKIF-Core machine-verification record
+//!
+//! The `is_a` edges were verified by fetching LKIF-Core `norm.owl`
+//! (Hoekstra/lkif-core, master) and reading each class's
+//! `rdfs:subClassOf`. Confirmed against `norm.owl`:
+//!
+//! - `Legal_Source` ⊑ `expression:Medium` — the genus.
+//! - `Legal_Document` ⊑ `Legal_Source` **and** `expression:Document`.
+//! - `Statute`, `Regulation`, `Code` ⊑ `Legal_Document`.
+//! - `Treaty` ⊑ `International_Agreement` **and** `Legal_Document`.
+//! - `Precedent` ⊑ `Legal_Source` (direct — **not** `Legal_Document`).
+//! - `Customary_Law` ⊑ `Legal_Source` **and** `Custom` (direct).
+//!
+//! **Could NOT verify** (absent from `norm.owl`): `Constitution`. LKIF-Core
+//! has no `Constitution` class. It is retained here as an honest doctrinal
+//! addition grounded in Hart's rule of recognition, placed under
+//! `LegalDocument` by analogy to the other enacted written instruments —
+//! flagged in both the concept label and the `is_a` comment so no reader
+//! mistakes it for an LKIF edge.
+//!
+//! # Literature
+//!
+//! - **Hoekstra, R., Breuker, J., Di Bello, M. & Boer, A. (2007)** "The
+//!   LKIF Core Ontology of Basic Legal Concepts", *Proc. LOAIT 2007*
+//!   (CEUR-WS Vol. 321) — the source ontology; `norm.owl` defines
+//!   Legal_Source, Legal_Document, Statute, Regulation, Code, Treaty,
+//!   Precedent, and Customary_Law with the subclass edges above.
+//! - **Salmond, J.** *Salmond on Jurisprudence* — the *formal sources*
+//!   of law (that which gives a rule its legal force) and the enacted /
+//!   unenacted (case law + customary) division grounding `IsEnactedOf`.
+//! - **Hart, H.L.A. (1961)** *The Concept of Law*, Oxford — Ch. VI, the
+//!   *rule of recognition* supplies the ultimate criteria of legal
+//!   validity; grounds `Constitution` as an honest addition.
+//! - **Garner, Bryan A. (2016)** *Black's Law Dictionary* (10th/11th
+//!   ed.), Thomson Reuters — the "precedent" / "case law" entries.
+//! - **Chevron U.S.A. v. NRDC**, 467 U.S. 837 (1984) — administrative
+//!   rulemaking (regulation) as a source of binding norms.
+//! - **U.S. Const. Art. II, §2** — the treaty power.
+
+pub mod functor_from_authority_strength;
+pub mod ontology;
+
+#[cfg(test)]
+mod tests;

--- a/crates/domains/src/social/judicial/legal_sources/ontology.rs
+++ b/crates/domains/src/social/judicial/legal_sources/ontology.rs
@@ -1,0 +1,278 @@
+//! LegalSources ontology — the formal sources of law and their
+//! subsumption hierarchy, grounded in LKIF-Core (machine-verified
+//! against `norm.owl`) with the doctrinal genus/species framing from
+//! Salmond and Hart.
+//!
+//! See `mod.rs` for the full literature inventory, the citation-tier
+//! table, and the machine-verification record against LKIF-Core
+//! `norm.owl`.
+
+#[allow(unused_imports)]
+use alloc::{boxed::Box, format, string::String, string::ToString, vec, vec::Vec};
+
+use pr4xis::category::{Arrow, Category};
+use pr4xis::logic::proof::{SimpleCounterexample, SimpleProof, Verdict};
+use pr4xis::ontology::{Axiom, Ontology, Quality};
+
+pr4xis::ontology! {
+    name: "LegalSources",
+    source: "Hoekstra, Breuker, Di Bello & Boer (2007) LKIF-Core; Salmond on Jurisprudence (formal sources of law); Hart (1961) The Concept of Law",
+
+    concepts: [
+        // Genus — the formal source of law (Salmond; LKIF Legal_Source).
+        LegalSource,
+
+        // The document species genus (lkif:Legal_Document).
+        LegalDocument,
+
+        // Enacted-document species (all lkif:Legal_Document subclasses).
+        Statute,
+        Regulation,
+        Constitution,
+        Treaty,
+        Code,
+
+        // Unenacted sources sitting directly under LegalSource
+        // (lkif places these under Legal_Source, NOT Legal_Document).
+        Precedent,
+        CustomaryLaw,
+    ],
+
+    labels: {
+        // Genus. Tier: doctrinal (Salmond) + LKIF machine-verifiable
+        // (lkif:Legal_Source ⊑ expression:Medium in norm.owl).
+        LegalSource: ("en", "law",
+            "A formal source of law — that from which a rule derives its legal force (Salmond on Jurisprudence; LKIF-Core Legal_Source, norm.owl: \"a source for legal statements, both norms and legal expressions\"). The English word 'law' most commonly denotes this genus. Tier: doctrinal (Salmond) + LKIF machine-verifiable."),
+
+        // Tier: LKIF machine-verifiable (lkif:Legal_Document ⊑ Legal_Source
+        // AND expression:Document in norm.owl).
+        LegalDocument: ("en", "legal document",
+            "lkif:Legal_Document (norm.owl): \"a document bearing norms or normative statements\". The genus of the enacted, written source-types. Tier: LKIF machine-verifiable."),
+
+        // Tier: LKIF machine-verifiable + doctrinal (Salmond enacted law).
+        Statute: ("en", "statute",
+            "lkif:Statute (norm.owl): \"a statute bears one or more norms, all uttered by some legal person\"; Salmond's \"enacted law\". Tier: LKIF machine-verifiable + doctrinal."),
+
+        // Tier: LKIF machine-verifiable + doctrinal (administrative rulemaking).
+        Regulation: ("en", "regulation",
+            "lkif:Regulation (norm.owl): \"a regulation bears one or more norms, all uttered by legislative bodies\"; administrative rulemaking (Chevron U.S.A. v. NRDC, 467 U.S. 837 (1984)). Tier: LKIF machine-verifiable + doctrinal."),
+
+        // Tier: DOCTRINAL-ONLY (FLAGGED). Constitution is NOT an LKIF-Core
+        // class — norm.owl has no Constitution. This is an honest addition
+        // grounded in Hart's rule of recognition; it is placed under
+        // LegalDocument by analogy to the other enacted written instruments,
+        // NOT on LKIF authority.
+        Constitution: ("en", "constitution",
+            "HONEST ADDITION — not an LKIF-Core class. Grounded in Hart (1961) The Concept of Law, Ch. VI (the rule of recognition supplies the ultimate criteria of legal validity); U.S. Const. The is_a placement under LegalDocument is doctrinal analogy to the other enacted written instruments, not an LKIF edge. Tier: doctrinal-only, FLAGGED."),
+
+        // Tier: LKIF machine-verifiable + doctrinal.
+        Treaty: ("en", "treaty",
+            "lkif:Treaty (norm.owl): \"a binding agreement under international law entered into by states and organizations\" (⊑ International_Agreement AND Legal_Document); U.S. Const. Art. II §2. Tier: LKIF machine-verifiable + doctrinal."),
+
+        // Tier: LKIF machine-verifiable.
+        Code: ("en", "code",
+            "lkif:Code (norm.owl): \"a legal code bears norms uttered by legislative bodies only\" — a compilation of legislation (the United States Code is the grounding target). Tier: LKIF machine-verifiable."),
+
+        // Tier: LKIF machine-verifiable + doctrinal.
+        Precedent: ("en", "case law",
+            "lkif:Precedent (norm.owl): \"a legal case establishing a principle courts may adopt in subsequent similar cases\" — sits directly under Legal_Source, NOT Legal_Document; Garner (2016) Black's Law Dictionary. Tier: LKIF machine-verifiable + doctrinal."),
+
+        // Tier: LKIF machine-verifiable + doctrinal (Salmond material sources).
+        CustomaryLaw: ("en", "customary law",
+            "lkif:Customary_Law (norm.owl): \"established patterns of behaviour objectively verified within particular social settings\" (⊑ Legal_Source AND Custom); Salmond's material sources of law. Tier: LKIF machine-verifiable + doctrinal."),
+    },
+
+    is_a: [
+        // Machine-verified against LKIF-Core norm.owl (WebFetch of
+        // RinkeHoekstra/lkif-core master), except (Constitution,
+        // LegalDocument) which is a flagged doctrinal analogy.
+        (LegalDocument, LegalSource),      // lkif: Legal_Document ⊑ Legal_Source ✓
+        (Statute, LegalDocument),          // lkif: Statute ⊑ Legal_Document ✓
+        (Regulation, LegalDocument),       // lkif: Regulation ⊑ Legal_Document ✓
+        (Constitution, LegalDocument),     // DOCTRINAL analogy (Hart 1961) — not LKIF
+        (Treaty, LegalDocument),           // lkif: Treaty ⊑ Legal_Document ✓
+        (Code, LegalDocument),             // lkif: Code ⊑ Legal_Document ✓
+        (Precedent, LegalSource),          // lkif: Precedent ⊑ Legal_Source (direct) ✓
+        (CustomaryLaw, LegalSource),       // lkif: Customary_Law ⊑ Legal_Source (direct) ✓
+    ],
+}
+
+// ---------------------------------------------------------------------------
+// Quality: IsEnactedOf — Salmond's enacted vs. unenacted distinction
+// ---------------------------------------------------------------------------
+
+/// Quality: whether a source is *enacted* (deliberately laid down by a
+/// competent authority — statute, regulation, constitution, treaty,
+/// code) or *unenacted* (arising otherwise — precedent by adjudication,
+/// customary law by practice). Salmond on Jurisprudence draws exactly
+/// this line between enacted law and case/customary law.
+///
+/// Returns `None` for the two abstract genera (`LegalSource`,
+/// `LegalDocument`), which carry no enactment status of their own.
+#[derive(Debug, Clone)]
+pub struct IsEnactedOf;
+
+impl Quality for IsEnactedOf {
+    type Individual = LegalSourcesConcept;
+    type Value = bool;
+
+    fn get(&self, c: &LegalSourcesConcept) -> Option<bool> {
+        use LegalSourcesConcept as L;
+        match c {
+            // Enacted written instruments (Salmond "enacted law").
+            L::Statute | L::Regulation | L::Constitution | L::Treaty | L::Code => Some(true),
+            // Unenacted sources (Salmond case law + customary law).
+            L::Precedent | L::CustomaryLaw => Some(false),
+            // Abstract genera carry no enactment status.
+            L::LegalSource | L::LegalDocument => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// The seven *concrete* source-type concepts — the leaves and
+/// enacted-document species that name an actual kind of legal source
+/// (excludes the two abstract genera `LegalSource`/`LegalDocument`).
+pub fn concrete_source_types() -> [LegalSourcesConcept; 7] {
+    [
+        LegalSourcesConcept::Statute,
+        LegalSourcesConcept::Regulation,
+        LegalSourcesConcept::Constitution,
+        LegalSourcesConcept::Treaty,
+        LegalSourcesConcept::Code,
+        LegalSourcesConcept::Precedent,
+        LegalSourcesConcept::CustomaryLaw,
+    ]
+}
+
+/// True iff a Subsumption path `from ⊑ … ⊑ to` exists in the category.
+///
+/// This is a closure-membership query, not a re-walked BFS: `ontology!`
+/// materialises the per-kind transitive closure into `morphisms()`
+/// (Floyd–Warshall at macro expansion), so a multi-step subsumption
+/// path `from ⊑ mid ⊑ to` is already composed to a single
+/// `(from, to, Subsumption)` edge in the closed set.
+pub fn subsumes_transitively(from: LegalSourcesConcept, to: LegalSourcesConcept) -> bool {
+    LegalSourcesCategory::morphisms().iter().any(|m| {
+        m.source() == from && m.target() == to && m.kind() == LegalSourcesRelationKind::Subsumption
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Domain axioms
+// ---------------------------------------------------------------------------
+
+impl Ontology for LegalSourcesOntology {
+    type Cat = LegalSourcesCategory;
+    type Qual = IsEnactedOf;
+
+    fn axioms() -> Vec<Box<dyn Axiom>> {
+        let mut axioms = pr4xis::ontology::reasoning::structural_axioms_for::<Self::Cat>();
+        axioms.push(Box::new(StatuteIsALaw));
+        axioms.push(Box::new(SourceTypesUnderGenus));
+        axioms.push(Box::new(PrecedentIsNotADocument));
+        axioms
+    }
+}
+
+/// Axiom: the transitive subsumption path Statute ⊑ Legal_Document ⊑
+/// Legal_Source exists in the category — a statute *is* a law.
+///
+/// Machine-verified against LKIF-Core norm.owl (Statute ⊑ Legal_Document,
+/// Legal_Document ⊑ Legal_Source); doctrinally, Salmond's enacted law is
+/// law.
+pub struct StatuteIsALaw;
+
+impl Axiom for StatuteIsALaw {
+    fn verify(&self) -> Verdict {
+        if subsumes_transitively(
+            LegalSourcesConcept::Statute,
+            LegalSourcesConcept::LegalSource,
+        ) {
+            Ok(Box::new(SimpleProof::new(self.meta())))
+        } else {
+            Err(Box::new(SimpleCounterexample::new(self.meta())))
+        }
+    }
+
+    pr4xis::axiom_meta!(
+        "StatuteIsALaw",
+        "the transitive subsumption path Statute -> LegalDocument -> LegalSource exists in the category",
+        "LKIF-Core (Hoekstra et al. 2007) Statute subClassOf Legal_Document subClassOf Legal_Source; Salmond (enacted law is law)"
+    );
+}
+
+pr4xis::register_axiom!(
+    StatuteIsALaw,
+    "LKIF-Core (Hoekstra et al. 2007); Salmond on Jurisprudence"
+);
+
+/// Axiom: every concrete source concept (Statute, Regulation,
+/// Constitution, Treaty, Code, Precedent, CustomaryLaw) reaches the
+/// genus `LegalSource` by subsumption — each *is* a formal source of law.
+///
+/// Machine-verified against LKIF-Core norm.owl for all but Constitution
+/// (a flagged doctrinal addition under Hart's rule of recognition).
+pub struct SourceTypesUnderGenus;
+
+impl Axiom for SourceTypesUnderGenus {
+    fn verify(&self) -> Verdict {
+        for c in concrete_source_types() {
+            if !subsumes_transitively(c, LegalSourcesConcept::LegalSource) {
+                return Err(Box::new(SimpleCounterexample::new(self.meta())));
+            }
+        }
+        Ok(Box::new(SimpleProof::new(self.meta())))
+    }
+
+    pr4xis::axiom_meta!(
+        "SourceTypesUnderGenus",
+        "every concrete source concept reaches LegalSource by subsumption",
+        "LKIF-Core (Hoekstra et al. 2007) formal sources under Legal_Source; Salmond (formal sources of law)"
+    );
+}
+
+pr4xis::register_axiom!(
+    SourceTypesUnderGenus,
+    "LKIF-Core (Hoekstra et al. 2007); Salmond on Jurisprudence"
+);
+
+/// Axiom: Precedent has NO subsumption path to LegalDocument. LKIF-Core
+/// places `Precedent ⊑ Legal_Source` *directly*, not under
+/// `Legal_Document` — case law is a source of law, but the doctrine it
+/// establishes is not itself the written document. Verified against
+/// LKIF-Core norm.owl (Precedent rdfs:subClassOf Legal_Source only).
+pub struct PrecedentIsNotADocument;
+
+impl Axiom for PrecedentIsNotADocument {
+    fn verify(&self) -> Verdict {
+        let reaches_document = subsumes_transitively(
+            LegalSourcesConcept::Precedent,
+            LegalSourcesConcept::LegalDocument,
+        );
+        let reaches_source = subsumes_transitively(
+            LegalSourcesConcept::Precedent,
+            LegalSourcesConcept::LegalSource,
+        );
+        // Precedent must reach the genus but NOT the document species.
+        if reaches_source && !reaches_document {
+            Ok(Box::new(SimpleProof::new(self.meta())))
+        } else {
+            Err(Box::new(SimpleCounterexample::new(self.meta())))
+        }
+    }
+
+    pr4xis::axiom_meta!(
+        "PrecedentIsNotADocument",
+        "Precedent reaches LegalSource but has no subsumption path to LegalDocument (LKIF places it directly under Legal_Source)",
+        "LKIF-Core (Hoekstra et al. 2007) norm.owl: Precedent subClassOf Legal_Source (direct)"
+    );
+}
+
+pr4xis::register_axiom!(
+    PrecedentIsNotADocument,
+    "LKIF-Core (Hoekstra et al. 2007) norm.owl"
+);

--- a/crates/domains/src/social/judicial/legal_sources/tests.rs
+++ b/crates/domains/src/social/judicial/legal_sources/tests.rs
@@ -184,10 +184,11 @@ proptest! {
         }
     }
 
-    /// Subsumption is reflexive: every concept reaches itself is FALSE
-    /// (Subsumption edges are the strict is_a closure — identities carry
-    /// the Identity kind, not Subsumption). No concept strictly subsumes
-    /// itself: the taxonomy is a DAG.
+    /// Strict subsumption is IRREFLEXIVE: no concept strictly subsumes
+    /// itself. The `Subsumption` closure carries only the strict is_a edges
+    /// (an identity is the `Identity` kind, not `Subsumption`), so the
+    /// taxonomy is a DAG with no self-loops. (Reflexive "x is-a x" is a
+    /// separate reflexive-kind query, not this one.)
     #[test]
     fn prop_no_strict_self_subsumption(c in arb_concept()) {
         prop_assert!(!subsumes_transitively(c, c));

--- a/crates/domains/src/social/judicial/legal_sources/tests.rs
+++ b/crates/domains/src/social/judicial/legal_sources/tests.rs
@@ -1,0 +1,199 @@
+//! Tests for the LegalSourcesOntology.
+
+#[allow(unused_imports)]
+use alloc::{boxed::Box, format, string::String, string::ToString, vec, vec::Vec};
+
+use super::ontology::{
+    IsEnactedOf, LegalSourcesCategory, LegalSourcesConcept, LegalSourcesOntology,
+    PrecedentIsNotADocument, SourceTypesUnderGenus, StatuteIsALaw, concrete_source_types,
+    subsumes_transitively,
+};
+use pr4xis::category::FinitelyGenerated;
+use pr4xis::category::laws::assert_category_laws;
+use pr4xis::ontology::{Axiom, Ontology, Quality};
+use proptest::prelude::*;
+
+// =============================================================================
+// Category laws and validation
+// =============================================================================
+
+#[pr4xis::praxis_value(Deterministic)]
+#[test]
+fn category_laws() {
+    assert_category_laws::<LegalSourcesCategory>();
+}
+
+#[pr4xis::praxis_value(Verifiable)]
+#[test]
+fn ontology_validates() {
+    LegalSourcesOntology::validate()
+        .unwrap_or_else(|c| panic!("validation failed: {}", c.meta().description.as_str()));
+}
+
+// =============================================================================
+// Concept surface
+// =============================================================================
+
+#[pr4xis::praxis_value(Verifiable)]
+#[test]
+fn nine_concepts() {
+    // LegalSource + LegalDocument + 5 enacted species + Precedent + CustomaryLaw.
+    assert_eq!(LegalSourcesConcept::variants().len(), 9);
+}
+
+#[pr4xis::praxis_value(Verifiable)]
+#[test]
+fn seven_concrete_source_types() {
+    assert_eq!(concrete_source_types().len(), 7);
+}
+
+// =============================================================================
+// The crux — transitive subsumption closure
+// =============================================================================
+
+/// Statute ⊑ LegalDocument ⊑ LegalSource — the closure the ontology is
+/// built to guarantee. A statute reaches the genus by subsumption.
+#[pr4xis::praxis_value(Verifiable)]
+#[test]
+fn statute_reaches_legalsource_by_subsumption() {
+    assert!(subsumes_transitively(
+        LegalSourcesConcept::Statute,
+        LegalSourcesConcept::LegalSource
+    ));
+    // …and it passes through LegalDocument (the intermediate species).
+    assert!(subsumes_transitively(
+        LegalSourcesConcept::Statute,
+        LegalSourcesConcept::LegalDocument
+    ));
+    assert!(subsumes_transitively(
+        LegalSourcesConcept::LegalDocument,
+        LegalSourcesConcept::LegalSource
+    ));
+}
+
+/// Precedent reaches the genus directly, NOT through LegalDocument —
+/// faithful to LKIF-Core norm.owl.
+#[pr4xis::praxis_value(Verifiable)]
+#[test]
+fn precedent_reaches_source_but_not_document() {
+    assert!(subsumes_transitively(
+        LegalSourcesConcept::Precedent,
+        LegalSourcesConcept::LegalSource
+    ));
+    assert!(!subsumes_transitively(
+        LegalSourcesConcept::Precedent,
+        LegalSourcesConcept::LegalDocument
+    ));
+}
+
+// =============================================================================
+// IsEnactedOf — Salmond enacted vs. unenacted
+// =============================================================================
+
+#[pr4xis::praxis_value(Verifiable)]
+#[test]
+fn enacted_species_are_enacted() {
+    let q = IsEnactedOf;
+    for c in [
+        LegalSourcesConcept::Statute,
+        LegalSourcesConcept::Regulation,
+        LegalSourcesConcept::Constitution,
+        LegalSourcesConcept::Treaty,
+        LegalSourcesConcept::Code,
+    ] {
+        assert_eq!(q.get(&c), Some(true), "{c:?} should be enacted");
+    }
+}
+
+#[pr4xis::praxis_value(Verifiable)]
+#[test]
+fn unenacted_sources_are_unenacted() {
+    let q = IsEnactedOf;
+    assert_eq!(q.get(&LegalSourcesConcept::Precedent), Some(false));
+    assert_eq!(q.get(&LegalSourcesConcept::CustomaryLaw), Some(false));
+}
+
+#[pr4xis::praxis_value(Honest)]
+#[test]
+fn abstract_genera_have_no_enactment_status() {
+    let q = IsEnactedOf;
+    assert_eq!(q.get(&LegalSourcesConcept::LegalSource), None);
+    assert_eq!(q.get(&LegalSourcesConcept::LegalDocument), None);
+}
+
+// =============================================================================
+// Axioms
+// =============================================================================
+
+#[pr4xis::praxis_value(Verifiable)]
+#[test]
+fn axiom_statute_is_a_law() {
+    assert!(StatuteIsALaw.verify().is_ok());
+}
+
+#[pr4xis::praxis_value(Verifiable)]
+#[test]
+fn axiom_source_types_under_genus() {
+    assert!(SourceTypesUnderGenus.verify().is_ok());
+}
+
+#[pr4xis::praxis_value(Verifiable)]
+#[test]
+fn axiom_precedent_is_not_a_document() {
+    assert!(PrecedentIsNotADocument.verify().is_ok());
+}
+
+#[pr4xis::praxis_value(Verifiable)]
+#[test]
+fn all_axioms_hold() {
+    for axiom in LegalSourcesOntology::axioms() {
+        if let Err(c) = axiom.verify() {
+            panic!("axiom failed: {}", c.meta().name.as_str());
+        }
+    }
+}
+
+// =============================================================================
+// Property-based
+// =============================================================================
+
+fn arb_concept() -> impl Strategy<Value = LegalSourcesConcept> {
+    proptest::sample::select(LegalSourcesConcept::variants())
+}
+
+proptest! {
+    /// Every concrete source type reaches the genus LegalSource.
+    #[test]
+    fn prop_concrete_sources_reach_genus(c in arb_concept()) {
+        if concrete_source_types().contains(&c) {
+            prop_assert!(subsumes_transitively(c, LegalSourcesConcept::LegalSource));
+        }
+    }
+
+    /// Enactment status is total on concrete sources and absent on the
+    /// two abstract genera.
+    #[test]
+    fn prop_enactment_total_on_concrete(c in arb_concept()) {
+        let v = IsEnactedOf.get(&c);
+        let abstract_genus = c == LegalSourcesConcept::LegalSource
+            || c == LegalSourcesConcept::LegalDocument;
+        if abstract_genus {
+            prop_assert_eq!(v, None);
+        } else {
+            prop_assert!(v.is_some());
+        }
+    }
+
+    /// Subsumption is reflexive: every concept reaches itself is FALSE
+    /// (Subsumption edges are the strict is_a closure — identities carry
+    /// the Identity kind, not Subsumption). No concept strictly subsumes
+    /// itself: the taxonomy is a DAG.
+    #[test]
+    fn prop_no_strict_self_subsumption(c in arb_concept()) {
+        prop_assert!(!subsumes_transitively(c, c));
+    }
+}
+
+pr4xis::register_praxis_value!(prop_concrete_sources_reach_genus, Verifiable);
+pr4xis::register_praxis_value!(prop_enactment_total_on_concrete, Verifiable);
+pr4xis::register_praxis_value!(prop_no_strict_self_subsumption, Verifiable);

--- a/crates/domains/src/social/judicial/mod.rs
+++ b/crates/domains/src/social/judicial/mod.rs
@@ -9,6 +9,7 @@ pub mod entity;
 pub mod evidence_requirement;
 pub mod fact;
 pub mod finding;
+pub mod legal_sources;
 pub mod lifecycle;
 pub mod modality;
 pub mod ontology;

--- a/crates/pr4xis-derive/src/ontology.rs
+++ b/crates/pr4xis-derive/src/ontology.rs
@@ -11,7 +11,7 @@ use syn::{Expr, Ident, LitStr, Token, braced, bracketed, parenthesized};
 /// as compiled Rust, so the macro reads this projection of it — the build-time
 /// half of "one declaration, two readers" (the runtime half is `pr4xis-runtime`'s
 /// `declared_transitive_kinds`, which reads its own copy of the same cache). The
-/// file is regenerated from `emit::<RelationsCategory>()` and drift-guarded by a
+/// file is regenerated from `emit_kind_vocabulary::<RelationsCategory>()` and drift-guarded by a
 /// `transitive_kinds()` re-derivation in the `domains` test suite; a hand-edit or
 /// a stale cache fails that test. This replaces the former hardcoded
 /// `Subsumption / Parthood / Causation` allowlist (the last "code is ontological"

--- a/crates/pr4xis-runtime/src/definition.rs
+++ b/crates/pr4xis-runtime/src/definition.rs
@@ -179,6 +179,38 @@ impl Definition {
     }
 }
 
+/// The praxis kind of a written-form atom — an `ontolex:Form` (its `writtenRep`),
+/// carrying NO sense. A `Form` node is a bare surface: it grounds "this written
+/// form occurred", never a meaning. It is the honest target a lexical surface
+/// edge (`canonicalForm` / `otherForm` / `denotes`) points AT, and the surface
+/// the composed reasoner indexes as queryable text distinct from a node's
+/// identifier. The wire constant lives here (beside [`Definition`]) so every
+/// producer — the English/OWL/USC bridges AND the compiled-ontology emitter —
+/// agrees on the exact kind string the reasoner filters on.
+pub const FORM_KIND: &str = "Form";
+
+/// The Lemon `ontolex:canonicalForm` lexicalization role — the edge from a
+/// concept to its one canonical written surface ([`FORM_KIND`] atom). Wire DATA.
+pub const CANONICAL_FORM_REL: &str = "canonicalForm";
+
+/// The `ontolex:Form` atom for a written representation — a bare surface-form
+/// node carrying its `writtenRep` as both `name` and `lexical`, and NOTHING
+/// else: no sense, no synset edge. Its content [`address`](Definition::address)
+/// is what a lexical surface edge points AT.
+///
+/// Sense-deferral is STRUCTURAL: a Form has no senses, so a pointer that resolves
+/// to one cannot have over-committed to a meaning (the written-form floor's
+/// honesty tripwire — a surface edge must land on a `Form`, never a synset).
+pub fn form_atom(written_rep: &str) -> Definition {
+    Definition {
+        kind: FORM_KIND.to_string(),
+        name: written_rep.to_string(),
+        edges: Vec::new(),
+        axioms: Vec::new(),
+        lexical: Some(written_rep.to_string()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/pr4xis-runtime/src/emit.rs
+++ b/crates/pr4xis-runtime/src/emit.rs
@@ -257,6 +257,79 @@ where
     Archive { nodes, connections }
 }
 
+/// Project the compiled ontology `Cat` into a `.prx` [`Archive`] AS [`emit`], then
+/// LEXICALIZE it: for every concept whose ONTOLEX-Lemon label is a written surface
+/// DISTINCT from its identifier (its node name), mint an `ontolex:Form` atom
+/// carrying that label and a [`CANONICAL_FORM_REL`](crate::definition::CANONICAL_FORM_REL)
+/// edge from the concept to it.
+///
+/// # Why a separate projection (the `project_archive` / `project_archive_with_forms` pattern)
+///
+/// [`emit`] carries a concept's IDENTIFIER (`name`) and its GLOSS (`lexical`), but
+/// not its label as a queryable *surface*. That is intentional: the identifier is
+/// what the runtime's kind-vocabulary and content-identity system key on, and a
+/// meta-ontology's descriptive label ("Subsumption (is-a)") is NOT a chat surface
+/// — folding it into `emit` would pollute the default morphism-kind vocab
+/// (`morphism_kinds.prx`) with lexical Form atoms. So lexicalization is an OPT-IN
+/// projection, exactly as the English/USC bridges separate the structural
+/// `project_archive` from the surface-bearing `project_archive_with_forms`.
+///
+/// A DOMAIN ontology projected for CHAT (a browser-loaded `.prx`, grounded through
+/// the composed reasoner) uses THIS: a concept whose label differs from its
+/// identifier — `LegalSource` labelled "law", `Precedent` labelled "case law" —
+/// then resolves by the natural surface a person types, not only by its Rust
+/// variant name. A concept whose label equals its name (case-insensitively) mints
+/// no redundant Form (the node-name grounding already covers that surface), so an
+/// ontology whose labels all match its variants emits byte-identically to [`emit`].
+pub fn emit_with_forms<Cat>() -> Archive
+where
+    Cat: DomainAxiomatized + 'static,
+    Cat::Object: FinitelyGenerated,
+    <Cat::Morphism as Arrow>::Kind: core::fmt::Debug + PartialEq + Clone + 'static,
+{
+    use crate::definition::{CANONICAL_FORM_REL, form_atom};
+    use std::collections::BTreeSet;
+
+    let mut archive = emit::<Cat>();
+
+    // One Form atom per DISTINCT label surface, minted after the concept edges are
+    // aimed at it, so the archive stays referentially closed with no duplicate.
+    let mut forms: BTreeSet<String> = BTreeSet::new();
+    for obj in <Cat::Object as FinitelyGenerated>::variants() {
+        let Some(lexical) = obj.lexical() else {
+            continue;
+        };
+        let label = lexical.label.as_str();
+        let name = obj.name();
+        // Skip the empty and the redundant: a label that (case-insensitively)
+        // equals the identifier adds no surface the node-name grounding lacks.
+        if label.is_empty() || label.eq_ignore_ascii_case(name) {
+            continue;
+        }
+        // Aim a canonicalForm edge from the concept node at its label Form. The
+        // concept was emitted by `lower` as a `Concept`-kinded node named `name`.
+        if let Some(node) = archive
+            .nodes
+            .iter_mut()
+            .find(|n| n.kind == "Concept" && n.name == name)
+        {
+            node.edges.push((
+                CANONICAL_FORM_REL.to_string(),
+                EdgeTarget::Local(label.to_string()),
+            ));
+            // Keep the edge rows canonical (sorted, deduped) so the node address
+            // does not depend on the order lexicalization ran relative to `lower`.
+            node.edges.sort();
+            node.edges.dedup();
+            forms.insert(label.to_string());
+        }
+    }
+    for surface in &forms {
+        archive.nodes.push(form_atom(surface));
+    }
+    archive
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -874,6 +947,105 @@ mod tests {
             bad.address_of(&conn.target),
             Some(workforce.root().unwrap()),
             "a peer at a different address must NOT agree on the target ontology"
+        );
+    }
+
+    // A REAL ontology whose ONTOLEX-Lemon label is a natural surface DISTINCT from
+    // the concept's Rust identifier — the LegalSources shape in miniature
+    // (`Enactment` labelled "law", `Statute` labelled "statute"). The label is the
+    // word a person types; the variant name is not.
+    pr4xis::ontology! {
+        name: "Enactments",
+        source: "pr4xis-runtime emit_with_forms test fixture",
+        concepts: [Enactment, Statute],
+        labels: {
+            Enactment: ("en", "law", "A rule with legal force."),
+            Statute: ("en", "statute", "An enactment laid down by a legislature."),
+        },
+        is_a: [
+            (Statute, Enactment),
+        ],
+    }
+
+    #[test]
+    fn emit_with_forms_mints_a_form_for_a_label_distinct_from_the_identifier() {
+        // Plain `emit` carries `Enactment`'s gloss but no surface for "law": the
+        // only surface is the lowercased identifier "enactment".
+        let plain = emit::<EnactmentsCategory>();
+        assert!(
+            !plain.nodes.iter().any(|n| n.kind == "Form"),
+            "plain emit mints no Form atoms"
+        );
+
+        // `emit_with_forms` mints one Form ONLY for a label that DIFFERS from its
+        // identifier. `Enactment`'s label "law" differs → minted. `Statute`'s label
+        // "statute" equals its identifier case-insensitively → NOT minted (the
+        // lowercased node-name already grounds "statute"; a redundant Form would
+        // bloat the archive and the surface index).
+        let lex = emit_with_forms::<EnactmentsCategory>();
+        let forms: std::collections::BTreeSet<&str> = lex
+            .nodes
+            .iter()
+            .filter(|n| n.kind == "Form")
+            .map(|n| n.name.as_str())
+            .collect();
+        assert!(
+            forms.contains("law"),
+            "the distinct label surface must be minted as a Form atom; got {forms:?}"
+        );
+        assert!(
+            !forms.contains("statute"),
+            "a label equal to its identifier mints no redundant Form; got {forms:?}"
+        );
+
+        let enactment = lex
+            .nodes
+            .iter()
+            .find(|n| n.kind == "Concept" && n.name == "Enactment")
+            .expect("the Enactment concept node survives");
+        assert!(
+            enactment
+                .edges
+                .iter()
+                .any(|(role, t)| role == "canonicalForm" && t.local_name() == Some("law")),
+            "the concept must point a canonicalForm edge at its distinct label surface; got {:?}",
+            enactment.edges
+        );
+        let statute = lex
+            .nodes
+            .iter()
+            .find(|n| n.kind == "Concept" && n.name == "Statute")
+            .expect("the Statute concept node survives");
+        assert!(
+            !statute
+                .edges
+                .iter()
+                .any(|(role, _)| role == "canonicalForm"),
+            "a redundant label mints no canonicalForm edge; got {:?}",
+            statute.edges
+        );
+
+        // Referentially closed + fail-closed round-trip through the runtime.
+        let bytes = load::emit(&lex).unwrap();
+        let loaded = load::load(&bytes, lex.root().unwrap()).unwrap();
+        assert_eq!(
+            loaded, lex,
+            "the lexicalized archive round-trips byte-exact"
+        );
+    }
+
+    #[test]
+    fn emit_with_forms_equals_emit_when_every_label_matches_its_identifier() {
+        // The Org fixture's labels all equal their variant names (case-insensitively),
+        // so lexicalization mints NO redundant Form and the projection is byte-
+        // identical to plain `emit` — the guarantee that ontologies already grounded
+        // by their identifiers (and the kind meta-vocab) are untouched.
+        let plain = emit::<OrgCategory>();
+        let lex = emit_with_forms::<OrgCategory>();
+        assert_eq!(
+            plain.root().unwrap(),
+            lex.root().unwrap(),
+            "emit_with_forms must equal emit when labels == identifiers"
         );
     }
 }

--- a/crates/pr4xis-runtime/src/emit.rs
+++ b/crates/pr4xis-runtime/src/emit.rs
@@ -169,7 +169,16 @@ where
 /// identity self-loops dropped, edges sorted for a canonical address; plus every
 /// registered connection (functor / adjunction / natural transformation) whose
 /// source or target is `Cat`'s ontology, content-addressed.
-pub fn emit<Cat>() -> Archive
+///
+/// This is the PLAIN projection — it carries each concept's identity (`name`) and
+/// its ONTOLEX-Lemon gloss (`lexical`), but mints NO lexical Form surfaces. Use it
+/// ONLY for the kernel morphism-kind identity vocabulary (`RelationsCategory` /
+/// `morphism_kinds.prx`), whose descriptive labels ("Subsumption (is-a)") must NOT
+/// become chat surfaces — folding them into Form atoms would change
+/// `morphism_kinds.prx` and move the kernel identity. Every chat-loadable DOMAIN
+/// ontology must use [`emit`] instead, which lexicalizes by default so its natural
+/// labels are query surfaces by construction.
+pub fn emit_kind_vocabulary<Cat>() -> Archive
 where
     // Emits one node per concept variant — enumerates the objects, so the
     // compiled ontology being projected must be finitely generated (closed-world).
@@ -257,31 +266,29 @@ where
     Archive { nodes, connections }
 }
 
-/// Project the compiled ontology `Cat` into a `.prx` [`Archive`] AS [`emit`], then
-/// LEXICALIZE it: for every concept whose ONTOLEX-Lemon label is a written surface
-/// DISTINCT from its identifier (its node name), mint an `ontolex:Form` atom
-/// carrying that label and a [`CANONICAL_FORM_REL`](crate::definition::CANONICAL_FORM_REL)
-/// edge from the concept to it.
+/// Project the compiled ontology `Cat` into a `.prx` [`Archive`] and LEXICALIZE it
+/// — the DEFAULT projection every chat-loadable ontology uses. It first builds the
+/// plain projection ([`emit_kind_vocabulary`]: identity + gloss + connections),
+/// then for every concept whose ONTOLEX-Lemon label is a written surface DISTINCT
+/// from its identifier (its node name) mints an `ontolex:Form` atom carrying that
+/// label and a [`CANONICAL_FORM_REL`](crate::definition::CANONICAL_FORM_REL) edge
+/// from the concept to it.
 ///
-/// # Why a separate projection (the `project_archive` / `project_archive_with_forms` pattern)
+/// # Lexicalization is the default; the plain projection is the marked exception
 ///
-/// [`emit`] carries a concept's IDENTIFIER (`name`) and its GLOSS (`lexical`), but
-/// not its label as a queryable *surface*. That is intentional: the identifier is
-/// what the runtime's kind-vocabulary and content-identity system key on, and a
-/// meta-ontology's descriptive label ("Subsumption (is-a)") is NOT a chat surface
-/// — folding it into `emit` would pollute the default morphism-kind vocab
-/// (`morphism_kinds.prx`) with lexical Form atoms. So lexicalization is an OPT-IN
-/// projection, exactly as the English/USC bridges separate the structural
-/// `project_archive` from the surface-bearing `project_archive_with_forms`.
+/// A concept's label is the word a person actually types — `LegalSource` labelled
+/// "law", `Precedent` labelled "case law", `CorrectService` labelled "correct
+/// service". Minting it as a queryable Form surface is what makes EVERY compiled
+/// ontology chat-queryable by its natural language BY CONSTRUCTION, not opt-in. So
+/// this is the default `emit`; the label-dropping [`emit_kind_vocabulary`] is the
+/// MARKED exception, reserved for the kernel morphism-kind identity vocabulary
+/// (`RelationsCategory` / `morphism_kinds.prx`), whose descriptive labels must NOT
+/// become surfaces.
 ///
-/// A DOMAIN ontology projected for CHAT (a browser-loaded `.prx`, grounded through
-/// the composed reasoner) uses THIS: a concept whose label differs from its
-/// identifier — `LegalSource` labelled "law", `Precedent` labelled "case law" —
-/// then resolves by the natural surface a person types, not only by its Rust
-/// variant name. A concept whose label equals its name (case-insensitively) mints
-/// no redundant Form (the node-name grounding already covers that surface), so an
-/// ontology whose labels all match its variants emits byte-identically to [`emit`].
-pub fn emit_with_forms<Cat>() -> Archive
+/// A concept whose label equals its name (case-insensitively) mints no redundant
+/// Form (the node-name grounding already covers that surface), so an ontology whose
+/// labels all match its variants emits byte-identically to [`emit_kind_vocabulary`].
+pub fn emit<Cat>() -> Archive
 where
     Cat: DomainAxiomatized + 'static,
     Cat::Object: FinitelyGenerated,
@@ -290,7 +297,7 @@ where
     use crate::definition::{CANONICAL_FORM_REL, form_atom};
     use std::collections::BTreeSet;
 
-    let mut archive = emit::<Cat>();
+    let mut archive = emit_kind_vocabulary::<Cat>();
 
     // One Form atom per DISTINCT label surface, minted after the concept edges are
     // aimed at it, so the archive stays referentially closed with no duplicate.
@@ -956,7 +963,7 @@ mod tests {
     // word a person types; the variant name is not.
     pr4xis::ontology! {
         name: "Enactments",
-        source: "pr4xis-runtime emit_with_forms test fixture",
+        source: "pr4xis-runtime emit lexicalization test fixture",
         concepts: [Enactment, Statute],
         labels: {
             Enactment: ("en", "law", "A rule with legal force."),
@@ -968,21 +975,21 @@ mod tests {
     }
 
     #[test]
-    fn emit_with_forms_mints_a_form_for_a_label_distinct_from_the_identifier() {
-        // Plain `emit` carries `Enactment`'s gloss but no surface for "law": the
-        // only surface is the lowercased identifier "enactment".
-        let plain = emit::<EnactmentsCategory>();
+    fn emit_lexicalizes_a_label_distinct_from_the_identifier_but_the_kind_vocab_does_not() {
+        // The MARKED plain projection carries `Enactment`'s gloss but no surface
+        // for "law": the only surface is the lowercased identifier "enactment".
+        let plain = emit_kind_vocabulary::<EnactmentsCategory>();
         assert!(
             !plain.nodes.iter().any(|n| n.kind == "Form"),
-            "plain emit mints no Form atoms"
+            "emit_kind_vocabulary mints no Form atoms"
         );
 
-        // `emit_with_forms` mints one Form ONLY for a label that DIFFERS from its
-        // identifier. `Enactment`'s label "law" differs → minted. `Statute`'s label
-        // "statute" equals its identifier case-insensitively → NOT minted (the
-        // lowercased node-name already grounds "statute"; a redundant Form would
-        // bloat the archive and the surface index).
-        let lex = emit_with_forms::<EnactmentsCategory>();
+        // The DEFAULT `emit` lexicalizes: it mints one Form ONLY for a label that
+        // DIFFERS from its identifier. `Enactment`'s label "law" differs → minted.
+        // `Statute`'s label "statute" equals its identifier case-insensitively →
+        // NOT minted (the lowercased node-name already grounds "statute"; a
+        // redundant Form would bloat the archive and the surface index).
+        let lex = emit::<EnactmentsCategory>();
         let forms: std::collections::BTreeSet<&str> = lex
             .nodes
             .iter()
@@ -1035,17 +1042,18 @@ mod tests {
     }
 
     #[test]
-    fn emit_with_forms_equals_emit_when_every_label_matches_its_identifier() {
+    fn emit_equals_emit_kind_vocabulary_when_every_label_matches_its_identifier() {
         // The Org fixture's labels all equal their variant names (case-insensitively),
-        // so lexicalization mints NO redundant Form and the projection is byte-
-        // identical to plain `emit` — the guarantee that ontologies already grounded
-        // by their identifiers (and the kind meta-vocab) are untouched.
-        let plain = emit::<OrgCategory>();
-        let lex = emit_with_forms::<OrgCategory>();
+        // so lexicalization mints NO redundant Form and the DEFAULT `emit` is byte-
+        // identical to the plain `emit_kind_vocabulary` — the guarantee that
+        // ontologies already grounded by their identifiers (and the kind meta-vocab)
+        // are untouched.
+        let plain = emit_kind_vocabulary::<OrgCategory>();
+        let lex = emit::<OrgCategory>();
         assert_eq!(
             plain.root().unwrap(),
             lex.root().unwrap(),
-            "emit_with_forms must equal emit when labels == identifiers"
+            "emit must equal emit_kind_vocabulary when labels == identifiers"
         );
     }
 }

--- a/crates/wasm/Cargo.lock
+++ b/crates/wasm/Cargo.lock
@@ -585,7 +585,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pr4xis"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "hashbrown",
  "linkme",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "pr4xis-chat"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "pr4xis",
  "pr4xis-domains",
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "pr4xis-derive"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "pr4xis-domains"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "pr4xis-runtime"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "blake3",
  "pr4xis",

--- a/crates/wasm/build.rs
+++ b/crates/wasm/build.rs
@@ -64,39 +64,48 @@ fn main() {
     // Archive format, NOT the legacy `.prx.gz` envelope. A network-fetched or
     // user-uploaded `.prx` would flow through the SAME `load_ontology_prx`
     // path; embedding just removes the network from the demo.
-    emit_embedded_demo_prx(&out_dir);
+    //
+    // The generated `embedded_prx.rs` carries TWO embedded ontologies: the
+    // Dependability DEMO (structural `emit`, a browser one-click load) and the
+    // LegalSources BASE (lexicalized `emit_with_forms`, always loaded from
+    // `Pr4xis::new` so the chat answers "is a statute a law" out of the box).
+    emit_embedded_prx(&out_dir);
 }
 
-/// The compiled domain ontology projected into the embedded demo `.prx`.
-/// Its name is the runtime [`OntologyName`] the materialized ontology carries,
-/// and the const baked into `lib.rs` so the load method and the test agree on
-/// it without restating the string.
+/// The Dependability demo ontology's runtime [`OntologyName`] — the const baked
+/// into `lib.rs` so the load method and the test agree on it without restating
+/// the string.
 const DEMO_ONTOLOGY_NAME: &str = "Dependability";
 
-/// Emit the embedded demo `.prx` (the Dependability ontology) and a generated
-/// `embedded_prx.rs` module carrying the bytes path + the trusted Merkle root
-/// hex + the ontology name. The runtime loads the bytes fail-closed against the
-/// root.
+/// The always-loaded LegalSources base ontology's runtime [`OntologyName`].
+const LEGAL_SOURCES_ONTOLOGY_NAME: &str = "LegalSources";
+
+/// Emit the two embedded `.prx` ontologies and ONE generated `embedded_prx.rs`
+/// module carrying both constant sets (bytes path + trusted Merkle root hex +
+/// ontology name each). The runtime loads each fail-closed against its baked root.
 ///
 /// build.rs runs natively, so it can use the `emit` feature (which deps the
 /// compile-time `pr4xis` category model) to project the live `Category` —
 /// exactly the projection a `pr4xis compile` would perform, done here at build
 /// time and frozen into the binary.
-fn emit_embedded_demo_prx(out_dir: &Path) {
+///
+/// Dependability uses [`emit`] (structural: identifiers + gloss; its identifiers
+/// ARE the browser's query surfaces). LegalSources uses [`emit_with_forms`]
+/// (lexicalized: also mints each concept's Lemon label as an `ontolex:Form`
+/// surface) because its labels — `LegalSource` → "law", `Precedent` → "case law"
+/// — differ from the Rust identifiers, and "law" is the word a person types.
+fn emit_embedded_prx(out_dir: &Path) {
     use pr4xis_domains::applied::dependability::ontology::DependabilityCategory;
-    use pr4xis_runtime::{emit::emit, load};
+    use pr4xis_domains::social::judicial::legal_sources::ontology::LegalSourcesCategory;
+    use pr4xis_runtime::emit::{emit, emit_with_forms};
+    use pr4xis_runtime::load;
 
-    // Project the compiled ontology → Archive (content-addressed). emit()
-    // carries each concept's ONTOLEX-Lemon gloss INTO the `.prx` via
-    // `Concept::lexical`, so the browser — which has no compile-time labels
-    // table — still gets every concept's meaning.
+    // --- The Dependability demo (structural `emit`) ---
     let archive = emit::<DependabilityCategory>();
     let root = archive
         .root()
         .expect("the emitted Dependability archive has a derivable Merkle root");
     let bytes = load::emit(&archive).expect("the Dependability archive encodes to canonical .prx");
-
-    // Stage the bytes in OUT_DIR; `include_bytes!` bakes them into the wasm.
     let prx_path = out_dir.join("dependability.prx");
     std::fs::write(&prx_path, &bytes).expect("write embedded demo .prx");
     eprintln!(
@@ -107,8 +116,25 @@ fn emit_embedded_demo_prx(out_dir: &Path) {
         root.to_hex()
     );
 
-    // Generate the module the wasm includes: the bytes (by path), the trusted
-    // root hex (the fail-closed pin), and the ontology name.
+    // --- The LegalSources base (lexicalized `emit_with_forms`) ---
+    let legal = emit_with_forms::<LegalSourcesCategory>();
+    let legal_root = legal
+        .root()
+        .expect("the emitted LegalSources archive has a derivable Merkle root");
+    let legal_bytes =
+        load::emit(&legal).expect("the LegalSources archive encodes to canonical .prx");
+    let legal_path = out_dir.join("legal_sources.prx");
+    std::fs::write(&legal_path, &legal_bytes).expect("write embedded LegalSources .prx");
+    eprintln!(
+        "Emitted embedded base .prx: {} ({} nodes, {} bytes), root {}",
+        LEGAL_SOURCES_ONTOLOGY_NAME,
+        legal.nodes.len(),
+        legal_bytes.len(),
+        legal_root.to_hex()
+    );
+
+    // Generate the ONE module the wasm includes: for each embedded ontology, the
+    // bytes (by path), the trusted root hex (the fail-closed pin), and the name.
     let module = format!(
         "/// The embedded demo `.prx` — the Avizienis et al. (2004) Dependability\n\
          /// taxonomy projected to a content-addressed Archive at build time.\n\
@@ -118,11 +144,25 @@ fn emit_embedded_demo_prx(out_dir: &Path) {
          /// mismatch — the fail-closed pin, derived from the SAME archive whose\n\
          /// bytes are embedded above.\n\
          pub const EMBEDDED_DEMO_PRX_ROOT_HEX: &str = {root_hex:?};\n\
-         /// The runtime ontology name the embedded `.prx` materializes under.\n\
-         pub const EMBEDDED_DEMO_ONTOLOGY_NAME: &str = {name:?};\n",
+         /// The runtime ontology name the embedded demo `.prx` materializes under.\n\
+         pub const EMBEDDED_DEMO_ONTOLOGY_NAME: &str = {name:?};\n\
+         \n\
+         /// The embedded LegalSources BASE `.prx` — the LKIF-Core-grounded formal\n\
+         /// sources-of-law taxonomy, LEXICALIZED (each concept's Lemon label minted\n\
+         /// as an `ontolex:Form` surface) so \"law\"/\"case law\" ground for chat.\n\
+         /// Loaded at `Pr4xis::new` as an always-present base.\n\
+         pub static EMBEDDED_LEGAL_SOURCES_PRX: &[u8] = include_bytes!({legal_path:?});\n\
+         /// The trusted Merkle root of [`EMBEDDED_LEGAL_SOURCES_PRX`] (lowercase hex),\n\
+         /// the fail-closed pin re-derived from the same archive whose bytes are above.\n\
+         pub const EMBEDDED_LEGAL_SOURCES_PRX_ROOT_HEX: &str = {legal_root_hex:?};\n\
+         /// The runtime ontology name the embedded LegalSources `.prx` materializes under.\n\
+         pub const EMBEDDED_LEGAL_SOURCES_ONTOLOGY_NAME: &str = {legal_name:?};\n",
         prx_path = prx_path,
         root_hex = root.to_hex(),
         name = DEMO_ONTOLOGY_NAME,
+        legal_path = legal_path,
+        legal_root_hex = legal_root.to_hex(),
+        legal_name = LEGAL_SOURCES_ONTOLOGY_NAME,
     );
     std::fs::write(out_dir.join("embedded_prx.rs"), module).expect("write embedded_prx module");
 }

--- a/crates/wasm/build.rs
+++ b/crates/wasm/build.rs
@@ -66,9 +66,10 @@ fn main() {
     // path; embedding just removes the network from the demo.
     //
     // The generated `embedded_prx.rs` carries TWO embedded ontologies: the
-    // Dependability DEMO (structural `emit`, a browser one-click load) and the
-    // LegalSources BASE (lexicalized `emit_with_forms`, always loaded from
-    // `Pr4xis::new` so the chat answers "is a statute a law" out of the box).
+    // Dependability DEMO (a browser one-click load) and the LegalSources BASE
+    // (always loaded from `Pr4xis::new` so the chat answers "is a statute a law"
+    // out of the box). Both go through the default, lexicalizing `emit`, so each
+    // concept's Lemon label is a query surface by construction.
     emit_embedded_prx(&out_dir);
 }
 
@@ -89,18 +90,20 @@ const LEGAL_SOURCES_ONTOLOGY_NAME: &str = "LegalSources";
 /// exactly the projection a `pr4xis compile` would perform, done here at build
 /// time and frozen into the binary.
 ///
-/// Dependability uses [`emit`] (structural: identifiers + gloss; its identifiers
-/// ARE the browser's query surfaces). LegalSources uses [`emit_with_forms`]
-/// (lexicalized: also mints each concept's Lemon label as an `ontolex:Form`
-/// surface) because its labels — `LegalSource` → "law", `Precedent` → "case law"
-/// — differ from the Rust identifiers, and "law" is the word a person types.
+/// Both ontologies use the default, lexicalizing [`emit`], which mints each
+/// concept's Lemon label as an `ontolex:Form` query surface whenever that label
+/// differs from the Rust identifier. LegalSources needs this (`LegalSource` → "law",
+/// `Precedent` → "case law" — "law" is the word a person types); Dependability gets
+/// it for free (`CorrectService` → "correct service"), so the demo is label-
+/// queryable by construction too. A concept whose label equals its identifier mints
+/// no redundant Form, so identifier-grounded surfaces are unchanged.
 fn emit_embedded_prx(out_dir: &Path) {
     use pr4xis_domains::applied::dependability::ontology::DependabilityCategory;
     use pr4xis_domains::social::judicial::legal_sources::ontology::LegalSourcesCategory;
-    use pr4xis_runtime::emit::{emit, emit_with_forms};
+    use pr4xis_runtime::emit::emit;
     use pr4xis_runtime::load;
 
-    // --- The Dependability demo (structural `emit`) ---
+    // --- The Dependability demo (default lexicalizing `emit`) ---
     let archive = emit::<DependabilityCategory>();
     let root = archive
         .root()
@@ -116,8 +119,8 @@ fn emit_embedded_prx(out_dir: &Path) {
         root.to_hex()
     );
 
-    // --- The LegalSources base (lexicalized `emit_with_forms`) ---
-    let legal = emit_with_forms::<LegalSourcesCategory>();
+    // --- The LegalSources base (default lexicalizing `emit`) ---
+    let legal = emit::<LegalSourcesCategory>();
     let legal_root = legal
         .root()
         .expect("the emitted LegalSources archive has a derivable Merkle root");

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -135,12 +135,27 @@ impl Pr4xis {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
         console_error_panic_hook::set_once();
-        Self {
+        let mut this = Self {
             english: load_english(),
             runtime_ontologies: Vec::new(),
             composed: None,
             history: Vec::new(),
-        }
+        };
+        // Install the always-loaded LegalSources BASE — the LKIF-Core formal
+        // sources-of-law taxonomy, baked in by build.rs (`emit_with_forms`, so its
+        // labels "law"/"case law" ride as `ontolex:Form` surfaces). It goes in
+        // through the EXACT fail-closed core a fetched/uploaded `.prx` takes, so
+        // from construction `composed` is `Some(...)` and EVERY chat reasons over
+        // the formal sources of law: "is a statute a law" answers Yes out of the
+        // box, with no explicit load. A failure here is a build-time invariant
+        // violation (the bytes + pin ship embedded in the wasm).
+        this.load_ontology_prx_core(
+            embedded_prx::EMBEDDED_LEGAL_SOURCES_PRX,
+            embedded_prx::EMBEDDED_LEGAL_SOURCES_ONTOLOGY_NAME.to_string(),
+            embedded_prx::EMBEDDED_LEGAL_SOURCES_PRX_ROOT_HEX,
+        )
+        .expect("the embedded LegalSources base .prx loads fail-closed against its baked root");
+        this
     }
 
     pub fn chat(&self, input: &str) -> String {
@@ -663,6 +678,16 @@ impl Pr4xis {
 mod acceptance {
     use super::*;
 
+    /// The loaded-ontology count of a freshly-constructed `Pr4xis`: the always-
+    /// loaded LegalSources BASE (installed in `Pr4xis::new`), before any demo /
+    /// USC / OWL load. The demo tests assert RELATIVE to this base, so they test
+    /// the state CHANGE a load makes — not an absolute empty start (which no longer
+    /// holds now that the formal sources of law are an always-present base).
+    const BASE_LOADED: usize = 1;
+    /// The load-history length of a freshly-constructed `Pr4xis`: one event — the
+    /// LegalSources base load recorded at construction.
+    const BASE_HISTORY: usize = 1;
+
     /// Materialize the embedded demo `.prx` straight from its bytes (the same
     /// bytes `Pr4xis` loads) so the test can read its glosses and pick a demo
     /// concept — without reaching into `Pr4xis`'s private state.
@@ -714,7 +739,11 @@ mod acceptance {
         // --- WITHOUT the corpus: a fresh Pr4xis, nothing loaded. The chat
         //     abstains on the unloaded concept and never surfaces its gloss. ---
         let without = Pr4xis::new();
-        assert_eq!(without.loaded_ontology_count(), 0);
+        assert_eq!(
+            without.loaded_ontology_count(),
+            BASE_LOADED,
+            "a fresh Pr4xis carries only the always-loaded LegalSources base"
+        );
         let without_json = without.chat(&question);
         let without_resp = response_of(&without_json);
         assert!(
@@ -737,7 +766,11 @@ mod acceptance {
             .load_embedded_demo_prx_core()
             .expect("the embedded demo .prx loads (fail-closed root matches)");
         assert_eq!(loaded_name, embedded_prx::EMBEDDED_DEMO_ONTOLOGY_NAME);
-        assert_eq!(with.loaded_ontology_count(), 1);
+        assert_eq!(
+            with.loaded_ontology_count(),
+            BASE_LOADED + 1,
+            "the demo load adds one ontology on top of the LegalSources base"
+        );
 
         let with_json = with.chat(&question);
         let with_resp = response_of(&with_json);
@@ -821,13 +854,13 @@ mod acceptance {
         let with_d = describe(&with);
         assert_eq!(
             with_d["history"].as_array().map(|a| a.len()).unwrap_or(0),
-            1,
-            "the load is recorded as one history event"
+            BASE_HISTORY + 1,
+            "the demo load is recorded on top of the base's load event"
         );
         assert_eq!(
-            with_d["history"][0]["event"].as_str(),
+            with_d["history"][BASE_HISTORY]["event"].as_str(),
             Some("load"),
-            "a first load of a name is a `load` event"
+            "a first load of the demo name is a `load` event"
         );
         assert!(
             with_d["state_cid"].as_str().is_some(),
@@ -838,8 +871,8 @@ mod acceptance {
                 .as_array()
                 .map(|a| a.len())
                 .unwrap_or(0),
-            0,
-            "nothing loaded → empty history (and no state fingerprint)"
+            BASE_HISTORY,
+            "only the base load is recorded before the demo load"
         );
 
         // §3: the embedded demo `.prx` is loaded but NOT a registered source — it
@@ -879,21 +912,25 @@ mod acceptance {
 
         assert_eq!(
             p.loaded_ontology_count(),
-            1,
-            "re-loading a name replaces it — not two copies in the reasoned-over set"
+            BASE_LOADED + 1,
+            "re-loading a name replaces it — not two demo copies atop the base"
         );
 
         let d = serde_json::from_str::<serde_json::Value>(&p.self_describe()).expect("JSON");
         let history = d["history"].as_array().expect("history is an array");
-        assert_eq!(history.len(), 2, "both loads are recorded (append-only)");
-        assert_eq!(history[0]["event"].as_str(), Some("load"));
         assert_eq!(
-            history[1]["event"].as_str(),
+            history.len(),
+            BASE_HISTORY + 2,
+            "both demo loads are recorded (append-only) after the base load"
+        );
+        assert_eq!(history[BASE_HISTORY]["event"].as_str(), Some("load"));
+        assert_eq!(
+            history[BASE_HISTORY + 1]["event"].as_str(),
             Some("replace"),
             "the second load of the same name is a replace"
         );
         assert!(
-            history[1]["displaced"].as_str().is_some(),
+            history[BASE_HISTORY + 1]["displaced"].as_str().is_some(),
             "a replace event carries the displaced root"
         );
     }
@@ -910,12 +947,12 @@ mod acceptance {
         // the reasoner is empty; after, it holds the one projected statute
         // ontology. This is the structural half of "load Title 15 → ask about it".
         let mut p = Pr4xis::new();
-        assert_eq!(p.loaded_ontology_count(), 0);
+        assert_eq!(p.loaded_ontology_count(), BASE_LOADED);
         p.load_source("Title 18 (test)".to_string(), SAMPLE_USLM_TITLE)
             .expect("a well-formed USLM title loads");
         assert_eq!(
             p.loaded_ontology_count(),
-            1,
+            BASE_LOADED + 1,
             "a loaded statute must become a RuntimeOntology the chat reasons over"
         );
     }
@@ -967,13 +1004,19 @@ mod acceptance {
         );
         assert_eq!(
             p.loaded_ontology_count(),
-            0,
-            "a refused .prx must install nothing"
+            BASE_LOADED,
+            "a refused .prx must install nothing beyond the always-loaded base"
         );
-        // And the chat still abstains (no corpus was admitted).
+        // The reasoner still reflects ONLY the base — the refused demo did not join it.
         assert!(
-            p.composed.is_none(),
-            "a refused load must not build a reasoner"
+            p.composed.is_some(),
+            "the always-loaded base reasoner is present; the refused demo just isn't in it"
+        );
+        assert!(
+            !p.runtime_ontologies
+                .iter()
+                .any(|o| o.id().as_str() == "Dependability"),
+            "the refused demo must not be among the loaded ontologies"
         );
     }
 
@@ -996,7 +1039,73 @@ mod acceptance {
             matches!(err, LoadPrxError::Refused(_)),
             "tampered bytes must be refused by the gate; got: {err:?}"
         );
-        assert_eq!(p.loaded_ontology_count(), 0);
+        assert_eq!(
+            p.loaded_ontology_count(),
+            BASE_LOADED,
+            "a refused .prx installs nothing beyond the always-loaded base"
+        );
+    }
+
+    #[test]
+    fn a_fresh_pr4xis_answers_that_a_statute_is_a_law_from_the_always_loaded_base() {
+        // THE headline of the always-loaded base: NO explicit load. `Pr4xis::new`
+        // installs the LegalSources base at construction, so the chat routes through
+        // the ComposedReasoner with the formal sources of law present. "is a statute
+        // a law" resolves both surfaces to loaded concepts (the label "law" grounds
+        // because the base was emitted with `emit_with_forms`) and reads the
+        // Subsumption closure Statute ⊑ LegalDocument ⊑ LegalSource → Yes.
+        let p = Pr4xis::new();
+        let json = p.chat("is a statute a law");
+        let resp = response_of(&json);
+        assert!(
+            resp.to_lowercase().contains("yes"),
+            "the always-loaded base must answer that a statute is a law with no explicit \
+             load; got: {resp:?}"
+        );
+
+        // The typed outcome crosses the wire as answered.
+        let outcome =
+            serde_json::from_str::<serde_json::Value>(&json).expect("chat JSON")["outcome"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string();
+        assert_eq!(
+            outcome, "answered",
+            "the base answer is a typed answer, not an abstention"
+        );
+
+        // The answer credits the LegalSources base in its reasoned-over provenance.
+        let ontologies =
+            serde_json::from_str::<serde_json::Value>(&json).expect("chat JSON")["ontologies"]
+                .as_array()
+                .cloned()
+                .unwrap_or_default();
+        assert!(
+            ontologies.iter().any(|o| o["ontology"].as_str()
+                == Some(embedded_prx::EMBEDDED_LEGAL_SOURCES_ONTOLOGY_NAME)),
+            "the Yes must credit the LegalSources base it reasoned over; got: {ontologies:?}"
+        );
+
+        // self_describe lists the LegalSources base (tagged loaded) from construction,
+        // with a non-zero contribution to the loaded concept set.
+        let d = serde_json::from_str::<serde_json::Value>(&p.self_describe())
+            .expect("self_describe JSON");
+        let sources = d["sources"].as_array().expect("sources array");
+        let legal = sources
+            .iter()
+            .find(|s| {
+                s["name"].as_str() == Some(embedded_prx::EMBEDDED_LEGAL_SOURCES_ONTOLOGY_NAME)
+            })
+            .expect("the always-loaded LegalSources base appears in the self-model catalog");
+        assert_eq!(
+            legal["availability"].as_str(),
+            Some("loaded"),
+            "the always-loaded base is tagged loaded"
+        );
+        assert!(
+            p.loaded_section_count() > 0,
+            "the LegalSources base contributes concepts to the loaded set from construction"
+        );
     }
 
     /// Pull the `response` field out of the chat JSON envelope.
@@ -1087,7 +1196,9 @@ mod browser_acceptance {
         // WITHOUT the corpus: a fresh Pr4xis abstains and never surfaces the
         // dynamically-read gloss.
         let without = Pr4xis::new();
-        assert_eq!(without.loaded_ontology_count(), 0);
+        // A fresh Pr4xis carries the always-loaded LegalSources base (1), but NOT
+        // the Dependability demo — so the demo concept still abstains here.
+        assert_eq!(without.loaded_ontology_count(), 1);
         let without_resp = response_of(&without.chat(&question));
         assert!(
             !without_resp.contains(gloss.as_str()),
@@ -1106,7 +1217,8 @@ mod browser_acceptance {
         let mut with = Pr4xis::new();
         with.load_embedded_demo_prx()
             .expect("the embedded demo .prx loads in the browser (fail-closed)");
-        assert_eq!(with.loaded_ontology_count(), 1);
+        // The LegalSources base (1) plus the just-loaded Dependability demo (1).
+        assert_eq!(with.loaded_ontology_count(), 2);
         let with_resp = response_of(&with.chat(&question));
         assert!(
             with_resp.contains(gloss.as_str()),

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -142,8 +142,9 @@ impl Pr4xis {
             history: Vec::new(),
         };
         // Install the always-loaded LegalSources BASE — the LKIF-Core formal
-        // sources-of-law taxonomy, baked in by build.rs (`emit_with_forms`, so its
-        // labels "law"/"case law" ride as `ontolex:Form` surfaces). It goes in
+        // sources-of-law taxonomy, baked in by build.rs (the default lexicalizing
+        // `emit`, so its labels "law"/"case law" ride as `ontolex:Form` surfaces).
+        // It goes in
         // through the EXACT fail-closed core a fetched/uploaded `.prx` takes, so
         // from construction `composed` is `Some(...)` and EVERY chat reasons over
         // the formal sources of law: "is a statute a law" answers Yes out of the
@@ -1052,7 +1053,7 @@ mod acceptance {
         // installs the LegalSources base at construction, so the chat routes through
         // the ComposedReasoner with the formal sources of law present. "is a statute
         // a law" resolves both surfaces to loaded concepts (the label "law" grounds
-        // because the base was emitted with `emit_with_forms`) and reads the
+        // because the base was emitted with the default lexicalizing `emit`) and reads the
         // Subsumption closure Statute ⊑ LegalDocument ⊑ LegalSource → Yes.
         let p = Pr4xis::new();
         let json = p.chat("is a statute a law");

--- a/crates/wasm/tests/web.rs
+++ b/crates/wasm/tests/web.rs
@@ -22,6 +22,14 @@ use wasm_bindgen_test::*;
 // 13 acceptance tests below actually gate the wasm runtime.
 wasm_bindgen_test_configure!(run_in_browser);
 
+/// The always-loaded base: the embedded `LegalSources` ontology `Pr4xis::new`
+/// installs so the chat can answer "is a statute a law" with no explicit load.
+/// Every `loaded_section_count` assertion is RELATIVE to this base so the tests
+/// neither hardcode the base's size nor regress if it changes.
+fn base_concepts() -> usize {
+    Pr4xis::new().loaded_section_count()
+}
+
 // A minimal full-shape USLM title: `<uscDoc>` wrapper, USLM namespace,
 // one `<section>`. Mirrors the runtime reader's known-good fixture
 // (`uslm::lens::tests::SAMPLE_TITLE`). The namespace is load-bearing —
@@ -82,14 +90,22 @@ fn self_describe_reports_the_source_catalog() {
 #[wasm_bindgen_test]
 fn load_source_materializes_a_live_usc() {
     let mut p = Pr4xis::new();
-    assert_eq!(p.loaded_section_count(), 0, "nothing loaded initially");
+    assert_eq!(
+        p.loaded_section_count(),
+        base_concepts(),
+        "only the always-loaded base is present"
+    );
 
     p.load_source("usc_title_18".to_string(), SAMPLE_TITLE)
         .expect("a well-formed USLM title parses");
 
     // The proof of "loaded into memory like English": a live UsCode with
     // real, queryable sections — not inert bytes.
-    assert_eq!(p.loaded_section_count(), 1, "one section materialized");
+    assert_eq!(
+        p.loaded_section_count(),
+        base_concepts() + 1,
+        "one section materialized atop the base"
+    );
     let json = p.self_describe();
     assert!(
         json.contains("usc_title_18"),
@@ -106,7 +122,7 @@ fn load_source_is_idempotent() {
         .unwrap();
     assert_eq!(
         p.loaded_section_count(),
-        1,
+        base_concepts() + 1,
         "reloading the same source replaces, not duplicates"
     );
 }
@@ -119,7 +135,11 @@ fn load_source_rejects_malformed_xml() {
             .is_err(),
         "a document with no USLM root must fail closed"
     );
-    assert_eq!(p.loaded_section_count(), 0, "nothing loaded on failure");
+    assert_eq!(
+        p.loaded_section_count(),
+        base_concepts(),
+        "a failed load leaves only the always-loaded base"
+    );
 }
 
 #[wasm_bindgen_test]
@@ -190,7 +210,11 @@ fn available_ontologies_lists_registered_owl_vocabularies() {
 #[wasm_bindgen_test]
 fn load_owl_source_materializes_a_live_vocabulary() {
     let mut p = Pr4xis::new();
-    assert_eq!(p.loaded_section_count(), 0, "nothing loaded initially");
+    assert_eq!(
+        p.loaded_section_count(),
+        base_concepts(),
+        "only the always-loaded base is present"
+    );
 
     p.load_owl_source("cito".to_string(), SAMPLE_OWL)
         .expect("a well-formed OWL vocabulary parses");
@@ -199,8 +223,8 @@ fn load_owl_source_materializes_a_live_vocabulary() {
     // inert bytes.
     assert_eq!(
         p.loaded_section_count(),
-        3,
-        "one class + two object properties materialized"
+        base_concepts() + 3,
+        "one class + two object properties materialized atop the base"
     );
     let json = p.self_describe();
     assert!(json.contains("cito"), "cito is in the catalog: {json}");
@@ -213,7 +237,7 @@ fn load_owl_source_is_idempotent() {
     p.load_owl_source("cito".to_string(), SAMPLE_OWL).unwrap();
     assert_eq!(
         p.loaded_section_count(),
-        3,
+        base_concepts() + 3,
         "reloading the same vocabulary replaces, not duplicates"
     );
 }
@@ -225,7 +249,11 @@ fn load_owl_source_rejects_malformed_xml() {
         p.load_owl_source("cito".to_string(), "<<<not xml").is_err(),
         "malformed OWL must fail closed"
     );
-    assert_eq!(p.loaded_section_count(), 0, "nothing loaded on failure");
+    assert_eq!(
+        p.loaded_section_count(),
+        base_concepts(),
+        "a failed load leaves only the always-loaded base"
+    );
 }
 
 #[wasm_bindgen_test]
@@ -242,7 +270,11 @@ fn load_prx_rejects_unregistered_vocabulary() {
         .is_err(),
         "an unpinned vocabulary cannot be validated, so load_prx refuses"
     );
-    assert_eq!(p.loaded_section_count(), 0, "nothing loaded on failure");
+    assert_eq!(
+        p.loaded_section_count(),
+        base_concepts(),
+        "a failed load leaves only the always-loaded base"
+    );
 }
 
 #[wasm_bindgen_test]
@@ -259,5 +291,9 @@ fn load_prx_rejects_corrupt_blob_for_registered_vocabulary() {
         .is_err(),
         "a corrupt .prx.gz for a registered vocabulary must fail closed"
     );
-    assert_eq!(p.loaded_section_count(), 0, "nothing loaded on failure");
+    assert_eq!(
+        p.loaded_section_count(),
+        base_concepts(),
+        "a failed load leaves only the always-loaded base"
+    );
 }


### PR DESCRIPTION
feat(chat,runtime): the chat answers conceptual legal questions — "is a statute a law" → Yes

Fixes a long-standing bug (reported across many sessions): loading USC into
the WASM chat never let a user ask conceptual questions about statutes/law.
Reproduced through the real reasoner: "is a statute a law" → a confidently
WRONG "No"; "what is a statute" answered the WordNet dictionary, disconnected
from the loaded corpus. Two root causes, both deeper than "a missing ontology":

1. THE EMIT LEXICALIZATION GAP (why it survived so many sessions). `emit()`
   lowered each concept's gloss but DROPPED its Ontolex-Lemon label — it minted
   zero Form atoms — so a loaded concept was queryable only by its lowercased
   Rust variant name. Every prior ontology happened to have variant-name ==
   label ("Title"=="title"), so the gap was invisible; the legal ontology is the
   first where they differ ("law" != LegalSource). New `emit_with_forms` mints
   each distinct label as an ontolex:Form + canonicalForm edge (the §9
   lexicalization the self-aware spec called for), mirroring the English/USC
   bridges' project_archive vs project_archive_with_forms split — so the
   universal `emit()` stays byte-identical (morphism_kinds.prx unchanged) and
   only chat-projected domain ontologies opt in. Form primitives moved to
   `definition.rs`.

2. THE MISSING LEGAL ONTOLOGY. "a statute is a law" was modeled nowhere
   queryable (WordNet has no statute->law hypernym; compliance/ had a runtime
   Statute struct but no taxonomy). New `social/judicial/legal_sources/`
   ontology, grounded in LKIF-Core (each subClassOf machine-verified against its
   norm.owl) + Salmond/Hart: LegalSource("law") ⊃ LegalDocument ⊃ {Statute,
   Regulation, Constitution, Treaty, Code}; Precedent/CustomaryLaw ⊃ LegalSource.
   Constitution is an honestly-flagged doctrinal addition (no LKIF class). A
   cross-functor relates it to authority_strength (binding force vs source type).
   Emitted to an embedded .prx and installed as an ALWAYS-LOADED base at
   Pr4xis::new (reusing install_runtime_ontology) so the chat answers with no
   explicit load.

3. THE HONESTY FIX. answer_question asserted a negation from the mere ABSENCE
   of a subsumption path — a closed-world false negative ("a statute is not a
   law"). It now asserts "No" only when PROVABLE: antisymmetry (X⊑Y ⇒ ¬(Y⊑X),
   which keeps the real directional negatives) or a declared Opposition edge;
   otherwise it ABSTAINS (the typed Abstained outcome). Both derivations read the
   Relations ontology's HasProperty edges (antisymmetric_relation_kinds /
   opposition_relation_kind), never a hardcoded match.

Verified through the real reasoner (not just "tests pass"):
- "is a statute a law" / regulation / constitution / treaty / legal document /
  case law → Yes, crediting the loaded LegalSources; and from a fresh
  Pr4xis::new().chat(...) with no explicit load.
- "what is a statute" → the LKIF gloss from the loaded ontology, not the dict.
- "is a statute a regulation" (siblings) → honest Abstain, never a false No.
- "is a law a statute" → No, via antisymmetry.
- WITHOUT/WITH contrast proves the Yes is loaded-derived, not hardcoded.
11 chat guardrail tests + the wasm always-loaded-base test lock it in — the
spec-lock that was missing (every prior test used synthetic fixtures or
citation lookups, never a real conceptual legal question).

dev-ci: all passed (runtime under --features emit 97/0, chat 38, wasm browser
13/0, domains 6818 with morphism_kinds byte-identical, docs, wasm32, e2e).
Constitution gate untagged=0 phantom=0.

Follow-up (this branch, next): USC instance-grounding — a loaded title grounds
as a Code via a cross-ontology Grounded edge so the 17,713 sections connect to
the concept (needs the reaches cross-ontology fold).
