### PR TITLE
fix(ci): tolerate release-plz opening no Release PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1294,8 +1294,21 @@ jobs:
           PR_JSON: ${{ steps.release-plz.outputs.pr }}
         run: |
           set -euo pipefail
-          branch=$(jq -r '.head_branch' <<<"$PR_JSON")
-          version=$(jq -r '.releases[0].version' <<<"$PR_JSON")
+          # release-plz emits `{}` — NOT an empty string — when it opened no
+          # Release PR, so the `if:` above does not catch that case ('{}' != ''
+          # is true) and this step used to run with a null branch:
+          #     fatal: couldn't find remote ref null
+          # That is a legitimate, expected outcome, not an error. It happens
+          # whenever a master push leaves nothing to propose — a push that
+          # touches only CI, scripts, docs or a `publish = false` crate, or one
+          # where every Cargo.toml version is already ahead of crates.io.
+          # The real guard has to be here, where the payload can be inspected.
+          branch=$(jq -r '.head_branch // empty' <<<"$PR_JSON")
+          version=$(jq -r '.releases[0].version // empty' <<<"$PR_JSON")
+          if [ -z "$branch" ] || [ -z "$version" ]; then
+            echo "release-plz opened no Release PR this run — nothing to sync."
+            exit 0
+          fi
           gh auth setup-git
           git fetch origin "$branch"
           git checkout "$branch"


### PR DESCRIPTION
Master is red on the merge of #239. **Not the new job graph** — every job passed and `Deploy Pages` correctly skipped (the release gate working on its first real master run). The `Sync CITATION.cff` step died with:

```
fatal: couldn't find remote ref null
```

## Cause

release-plz emits `{}` for `outputs.pr` when it opened no Release PR. The step's guard was `if: steps.release-plz.outputs.pr != ''`, and `'{}' != ''` is **true**, so the step ran with `PR_JSON={}`, `jq -r '.head_branch'` returned the string `null`, and git was asked to fetch a ref named "null".

Opening no PR is a legitimate outcome, not an error — it happens on any master push that leaves release-plz nothing to propose. #239 was the first to hit that path: it changed only `.github/`, `scripts/`, `devenv.nix`, `docs/` and `crates/e2e` (`publish = false`), so no publishable crate moved. A latent bug that had never been reached.

## Fix

A YAML `if:` cannot inspect the payload, so the guard belongs in the script — read both fields with `// empty` and exit 0 early when either is absent.

Verified against four payloads:

| payload | result |
|---|---|
| `{}` — the exact one that broke master | skip |
| a real Release PR | proceeds, correct branch + version |
| `releases: []` | skip |
| `head_branch: null` | skip |

Malformed JSON still fails loudly — jq's non-zero exit trips `set -e`.

## Two things verified healthy while diagnosing

- `Release` correctly no-op'd: *"skipping release: current commit is not from a release PR"* — `release_always = false` behaving as designed.
- The crates.io 503 from run `30458522847` left **no wedge**: `pr4xis-domains` is at 0.28.0 in both the registry and its highest tag, so the publish invariant holds and 0.29.0 will publish with the next release PR.