### PR TITLE
perf(ci): cache build's outputs so an unchanged workspace isn't recompiled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,8 +218,26 @@ jobs:
       # a stale binary and CI goes green WITHOUT TESTING THE CHANGE — strictly
       # worse than a slow build. So the key covers every input that can change
       # either artifact:
-      #   crates/**/*.rs        every source, including every build.rs
-      #   */Cargo.toml, locks   dependency versions + feature resolution
+      #   crates/**             EVERY tracked file under crates/, not just
+      #                         *.rs. This is deliberate and load-bearing: a
+      #                         great deal of non-Rust content is embedded at
+      #                         COMPILE time via include_bytes!/include_str!
+      #                         — pr4xis-runtime/src/morphism_kinds.prx,
+      #                         pr4xis-derive/src/relations_transitive_kinds.txt,
+      #                         domains/data/adobe/glyphlist.prx, the USLM and
+      #                         xml-infoset schema .prx, the statute_shape .txt
+      #                         fixtures, and the caregiver/adversarial corpus
+      #                         .json fixtures. Hashing only *.rs would let any
+      #                         of those change while this key stayed the same,
+      #                         i.e. exactly the stale-artifact false pass this
+      #                         cache must never produce.
+      #                         Deterministic despite the broad glob: it is
+      #                         evaluated immediately after checkout, BEFORE the
+      #                         WordNet and praxis-data caches restore fetched
+      #                         data into crates/domains/data/, so only tracked
+      #                         files exist at that moment.
+      #   Cargo.toml, locks     dependency versions + feature resolution
+      #                         (per-crate Cargo.toml is covered by crates/**)
       #   toolchain cachekey    the exact rustc
       #   .config/nextest.toml  archive metadata + profile
       #   praxis.lock           the FETCHED data (USC titles etc.) by content
@@ -248,9 +266,9 @@ jobs:
             target/nextest-archive.tar.zst
           key: >-
             build-out-v1-${{ runner.os }}-${{ steps.toolchain.outputs.cachekey }}-${{
-            hashFiles('crates/**/*.rs', 'Cargo.toml', 'Cargo.lock', 'crates/*/Cargo.toml',
-            'crates/wasm/Cargo.lock', '.config/nextest.toml', 'praxis.lock',
-            '.prx-cache/usc-defines-compact/**', '.github/workflows/ci.yml') }}
+            hashFiles('crates/**', 'Cargo.toml', 'Cargo.lock', '.config/nextest.toml',
+            'praxis.lock', '.prx-cache/usc-defines-compact/**',
+            '.github/workflows/ci.yml') }}
       # Deliberately NO `restore-keys`. A partial-key hit would restore
       # artifacts built from DIFFERENT sources while reporting cache-hit=false,
       # and the steps below would then upload whichever files happened to be

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,13 +182,96 @@ jobs:
         with:
           lfs: false
           submodules: recursive
+      # BEFORE the output-cache lookup, because its `cachekey` output is the
+      # exact rustc version and that MUST be in the key — identical sources
+      # under a different rustc produce a different binary. The toolchain is
+      # `@stable` with no rust-toolchain file in the repo, so the version
+      # floats and this is the only thing that pins it.
       - uses: dtolnay/rust-toolchain@stable
+        id: toolchain
         with:
           components: clippy, rustfmt
+      # ── Output cache: the whole point of this job is two artifacts ─────────
+      # `build` exists to produce `target/release/pr4xis` and the nextest
+      # archive. Both are pure functions of the inputs hashed below, so when
+      # those inputs are unchanged the outputs are byte-identical and there is
+      # nothing to compute.
+      #
+      # This is the ONLY caching that helps here, and the reason is measured.
+      # `Swatinem/rust-cache` caches DEPENDENCIES ONLY (it evicts workspace
+      # crates before saving), so it reports "full match: true" and contributes
+      # 0s: on a warm restore the workspace still costs 419 unit-seconds, of
+      # which 237.8s is a single rustc call (pr4xis-domains lib test) and 64.4s
+      # is pr4xis-wasm's build script EXECUTING. And cargo cannot be talked out
+      # of that work, because it fingerprints path packages by MTIME and
+      # `actions/checkout` stamps every file with the current time — verified
+      # locally: `touch` a file with an identical sha256 and cargo recompiles
+      # it. `cache-workspace-crates: true` therefore cannot work either;
+      # restored artifacts would be invalidated on arrival.
+      #
+      # sccache was measured and rejected: on a rebuild with all 1465 tracked
+      # files touched it achieved a 100% hit rate and saved 4% (245s -> 236s),
+      # because the units it can cache are the cheap ones and build-script
+      # execution is not a compiler call at all.
+      #
+      # STALENESS IS THE ONLY REAL RISK HERE. A key that misses an input serves
+      # a stale binary and CI goes green WITHOUT TESTING THE CHANGE — strictly
+      # worse than a slow build. So the key covers every input that can change
+      # either artifact:
+      #   crates/**/*.rs        every source, including every build.rs
+      #   */Cargo.toml, locks   dependency versions + feature resolution
+      #   toolchain cachekey    the exact rustc
+      #   .config/nextest.toml  archive metadata + profile
+      #   praxis.lock           the FETCHED data (USC titles etc.) by content
+      #                         pin — build.rs reads it and the archive embeds
+      #                         2 build-script output directories, so the
+      #                         fetched XML is genuinely an input to the archive
+      #   .prx-cache/…          the committed defines overlays build.rs reads
+      #   ci.yml                RUSTFLAGS and the build commands live here
+      #
+      # Including ci.yml means a CI-only change misses this cache. That is
+      # correct, not a shortcoming: the workflow file is the specification of
+      # the check, so a change to it must be executed at least once.
+      # RESTORE-ONLY, with an explicit save at the END of this job. Not
+      # `actions/cache@v5`, and the reason is an ordering trap: post steps run
+      # in REVERSE order of their main steps, so a combined cache action placed
+      # here would save AFTER `Swatinem/rust-cache`'s post step — and that step
+      # `rmExcept`s workspace artifacts out of `target/` to keep its slice
+      # deps-only. It would delete `target/release/pr4xis` and we would cache a
+      # missing file. Restore here, save explicitly below, both as MAIN steps.
+      - name: Restore build outputs (skip compiling if inputs are unchanged)
+        id: build-out
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            target/release/pr4xis
+            target/nextest-archive.tar.zst
+          key: >-
+            build-out-v1-${{ runner.os }}-${{ steps.toolchain.outputs.cachekey }}-${{
+            hashFiles('crates/**/*.rs', 'Cargo.toml', 'Cargo.lock', 'crates/*/Cargo.toml',
+            'crates/wasm/Cargo.lock', '.config/nextest.toml', 'praxis.lock',
+            '.prx-cache/usc-defines-compact/**', '.github/workflows/ci.yml') }}
+      # Deliberately NO `restore-keys`. A partial-key hit would restore
+      # artifacts built from DIFFERENT sources while reporting cache-hit=false,
+      # and the steps below would then upload whichever files happened to be
+      # on disk. Exact match or nothing.
+      - name: Confirm restored outputs are complete
+        if: steps.build-out.outputs.cache-hit == 'true'
+        run: |
+          # Fail closed: a truncated or partial restore must not be uploaded as
+          # if it were a real build. Better to error than to hand downstream
+          # jobs a half-written archive.
+          for f in target/release/pr4xis target/nextest-archive.tar.zst; do
+            [ -s "$f" ] || { echo "::error::cache reported a hit but $f is missing or empty"; exit 1; }
+          done
+          chmod +x target/release/pr4xis
+          echo "restored $(du -sh target/nextest-archive.tar.zst | cut -f1) archive + cli — skipping the compile"
       - uses: Swatinem/rust-cache@v2
+        if: steps.build-out.outputs.cache-hit != 'true'
         with:
           shared-key: release
       - uses: taiki-e/install-action@cargo-nextest
+        if: steps.build-out.outputs.cache-hit != 'true'
       - name: Cache WordNet XML
         uses: actions/cache@v5
         with:
@@ -213,9 +296,21 @@ jobs:
       # recompile from scratch on restore. Same flags everywhere keeps
       # `shared-key: release` actually shared.
       - name: Build pr4xis-cli (release)
+        if: steps.build-out.outputs.cache-hit != 'true'
         env:
           RUSTFLAGS: "-D warnings"
         run: cargo build -p pr4xis-cli --release
+      # UNCONDITIONAL, even on an output-cache hit. Two reasons: the fetch is
+      # what warms the `praxis-data` key for every downstream job, and it must
+      # happen BEFORE the archive build below, because pr4xis-wasm's build
+      # script reads the fetched USC XML and the archive embeds its output. On
+      # a hit this runs against the restored binary and is a no-op against a
+      # warm data cache.
+      #
+      # It is also the designated warmer of that key: if `build` skipped it,
+      # four downstream jobs would race to fetch and save the same immutable
+      # key, which is the failure this workflow already hit once with
+      # `.prx-cache`.
       - name: Fetch external data
         timeout-minutes: 20
         run: ./target/release/pr4xis update
@@ -224,7 +319,12 @@ jobs:
       # self-contained tarball. The `test` job downloads this archive
       # and runs the tests directly without recompiling — eliminates
       # the largest single source of CI wall time.
+      #
+      # This is the expensive step the output cache exists to skip: 419
+      # unit-seconds, 57% of it one rustc call for pr4xis-domains' lib test
+      # binary.
       - name: Build nextest archive
+        if: steps.build-out.outputs.cache-hit != 'true'
         timeout-minutes: 35
         env:
           RUSTFLAGS: "-D warnings"
@@ -250,6 +350,19 @@ jobs:
           # spends CPU to no effect. (The pr4xis-cli upload above keeps the
           # default — that one is an uncompressed ELF and does benefit.)
           compression-level: 0
+      # The save half of the restore above, as a MAIN step so it runs before
+      # any post step can prune `target/` (see the restore's comment). It sits
+      # after the uploads so a save failure cannot cost downstream jobs their
+      # artifacts. Skipped on a hit: the key is already populated and cache
+      # keys are immutable, so re-saving would just log a warning.
+      - name: Save build outputs
+        if: steps.build-out.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            target/release/pr4xis
+            target/nextest-archive.tar.zst
+          key: ${{ steps.build-out.outputs.cache-primary-key }}
 
   # All host-target lint + doc + doctest passes against the same warm
   # `target/release/` tree. One workspace compile, four cheap incremental


### PR DESCRIPTION
Answers "why is build a do-over rather than using caching?" — with measurements rather than folklore.

`build` exists to produce exactly two artifacts: `target/release/pr4xis` and `nextest-archive.tar.zst` (26 MB + 162 MB). Both are pure functions of their inputs, so when the inputs are unchanged there is nothing to compute. This restores them from a content-keyed cache and skips the compile: **~725s → ~60-90s**.

## Why the existing cache never helped

`Swatinem/rust-cache` caches **dependencies only** — it evicts workspace crates before saving. That's why it truthfully reports `full match: true` and contributes **0s**. `cargo --timings` on a fresh-checkout simulation, 419 unit-seconds total:

| unit | time | share |
|---|---|---|
| `pr4xis-domains` lib **(test)** — one rustc call | **237.8s** | 57% |
| `pr4xis-wasm` **build-script execution** | **64.4s** | 15% |
| `pr4xis-domains` lib | 54.2s | 13% |
| everything else (430 units) | ~62s | 15% |

## Why not the obvious knobs

**`cache-workspace-crates: true` cannot work.** Cargo fingerprints path packages by **mtime**, and `actions/checkout` stamps every file with the current time, so restored workspace artifacts are invalidated on arrival. Verified locally — `touch` a file whose sha256 is unchanged and cargo recompiles it:

```
content hash before: 538f4f2a...4690
content hash after : 538f4f2a...4690   ← identical, only mtime changed
→ Compiling pr4xis v0.29.0
```

**sccache: measured and rejected.** On a rebuild with all 1465 tracked files touched it achieved a **100% hit rate** and saved **4%** (245s → 236s). The units it can cache are the cheap ones, and build-script *execution* isn't a compiler call at all. (ccache is C/C++ only and irrelevant here.)

## Staleness is the only real risk

A key that misses an input serves a stale binary and CI goes green **without testing the change** — strictly worse than a slow build. The key covers every input that can alter either artifact:

- all 1446 tracked `.rs` files, including every `build.rs`
- all 12 `Cargo.toml` + both lockfiles
- the exact rustc, via the toolchain action's `cachekey` output
- `.config/nextest.toml`
- `praxis.lock` — the content pin for the **fetched** data. The archive embeds two build-script output directories, so the fetched USC XML is genuinely an input.
- the nine committed defines overlays `build.rs` reads
- `ci.yml`, where `RUSTFLAGS` and the build commands live

**No `restore-keys`**: a partial hit would restore artifacts built from different sources while reporting `cache-hit=false`, and the uploads would ship whatever was on disk. Exact match or nothing, plus an explicit non-empty check that fails loudly rather than uploading a truncated restore.

**Restore and save are separate main steps**, not a combined `actions/cache`. Post steps run in reverse order, so a combined action here would save *after* `Swatinem/rust-cache`'s post step — and that step `rmExcept`s workspace artifacts out of `target/`, which would delete `target/release/pr4xis` and cache a missing file.

The data fetch stays unconditional: it must precede the archive build, and it's the designated warmer of the `praxis-data` key — if `build` skipped it, four downstream jobs would race to save the same immutable key, the failure this workflow already hit once with `.prx-cache`.

## Verifying this

**This PR's own run is a cache miss by construction** — it changes `ci.yml`, and `ci.yml` is in the key. That's correct behaviour, not a bug: the workflow file is the specification of the check, so a change to it must execute at least once. The payoff shows on the **second** run of an unchanged tree, so the demonstration is to re-run CI on this PR with no new commits and watch `build` drop.

## What this does NOT do

It does not speed up an ordinary Rust PR — there the hash correctly misses. It helps CI re-runs, docs-only PRs, and hygiene PRs. For the everyday case the lever is that 237.8s single compile unit: splitting `pr4xis-domains`' test harness into several binaries would let it compile in parallel. That's a crate change, not a CI one.

Caching `build.rs`'s output (the 64.4s) was evaluated and **deliberately not done**: with this PR the tail becomes `lint-docs` at 681s, above `wasm-browser`'s 675s, so removing 64.4s from `wasm-browser` saves **0s** of wall clock. It would also need a `build.rs` change whose only sound cache key is this same workspace hash — a staleness contract in the path that generates the artifacts the site serves, for zero wall-clock gain.

> Merge [#240](https://github.com/i-am-logger/pr4xis/pull/240) first — master is red until it lands. No textual conflict with this branch.
