### PR TITLE
perf(build): disable thin-local LTO (-22% on the unit that IS the build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,13 @@ jobs:
         with:
           path: crates/domains/data/wordnet/english-wordnet-2025.xml
           key: wordnet-english-2025-v1
+      # `crates/domains/data/ontologies/*.owl` is FETCHED, not tracked
+      # (.gitignore:95 ignores *.owl here; only the six .prx.gz are committed),
+      # and it was in NO cache block. crates/wasm/build.rs:387 `continue`s on a
+      # missing .owl, so once the fetch is skipped on a cache hit, an uncached
+      # .owl tree makes the raw-OWL staging silently disappear. Key bumped to
+      # v2 because the pre-existing entry does not contain these files and
+      # cache keys are immutable.
       - name: Cache fetched external data (USC titles + conformance suites)
         uses: actions/cache@v5
         with:
@@ -302,7 +309,8 @@ jobs:
             crates/domains/data/legal/uscode
             crates/domains/data/markup-schemas/xsts
             crates/domains/data/markup-schemas/xmlconf
-          key: praxis-data-${{ hashFiles('praxis.lock') }}
+            crates/domains/data/ontologies/*.owl
+          key: praxis-data-v2-${{ hashFiles('praxis.lock') }}
       # Build pr4xis-cli + the full workspace + all test binaries in
       # one pass. Downstream `lint-docs` and `test` then run against the
       # populated `release` cache slice with no further compilation —
@@ -315,6 +323,38 @@ jobs:
       # `shared-key: release-lto-off` actually shared. The key carries `-lto-off`
       # because `[profile.release] lto = "off"` is in EVERY unit's fingerprint,
       # dependencies included, so the pre-LTO-off slice cannot be reused.
+      # ~115s of this step's ~126s is PROVABLY THROWN AWAY, and it is still here
+      # because the obvious fix does not work. Written down so the next attempt
+      # starts from the measurement rather than the intuition.
+      #
+      # The waste: `-p pr4xis-cli` resolves pr4xis-domains with serde_json
+      # `default+std`, while `--workspace --all-targets` resolves it with
+      # `alloc+default+std` — `alloc` arrives only via `wasm-bindgen-test`, a
+      # DEV-dependency of crates/wasm. One feature apart is a different rlib
+      # fingerprint, so the archive step below rebuilds the domains rlib from
+      # scratch regardless of what this step just built. (Verified compile-free
+      # through `--unit-graph`.) It cannot be fixed by widening the selector
+      # either: matching that feature set requires dev-dependencies, i.e.
+      # `--all-targets`, which is the archive build itself.
+      #
+      # Why the step cannot simply be skipped on a data-cache hit: `pr4xis
+      # update` IS the fetcher, the archive build needs its output (crates/wasm/
+      # build.rs reads the fetched USC XML), and the fetch is NOT a no-op on a
+      # warm cache. Measured on master run 30502233952: 75 sources report
+      # `[fetched]` against 190 `[ok]`, because the data cache covers 5 paths
+      # while praxis.lock registers ~20 fetchable trees (glyphlist, agid,
+      # mods/xhtml/lmf/xsd schemas, the OWL vocabularies, …). Skip the fetch and
+      # those 75 are simply absent — and build.rs:29/:387 are FAIL-OPEN, so the
+      # result is silent degradation, not an error.
+      #
+      # The unblocking work, in order: cache every fetched tree praxis.lock
+      # registers so `pr4xis update` becomes a genuine no-op, THEN gate this
+      # step and the fetch on a data-cache hit. crates/cli/tests/cli_smoke.rs
+      # already exists, so `cargo nextest archive` now carries
+      # target/release/pr4xis (21 binaries / 3 non-test, up from 19 / 2) — that
+      # half is done and the artifact upload no longer depends on this step.
+      # KNOWN WASTE, deliberately still here — see the note below before trying
+      # to delete it again.
       - name: Build pr4xis-cli (release)
         if: steps.build-out.outputs.cache-hit != 'true'
         env:
@@ -408,6 +448,13 @@ jobs:
         with:
           path: crates/domains/data/wordnet/english-wordnet-2025.xml
           key: wordnet-english-2025-v1
+      # `crates/domains/data/ontologies/*.owl` is FETCHED, not tracked
+      # (.gitignore:95 ignores *.owl here; only the six .prx.gz are committed),
+      # and it was in NO cache block. crates/wasm/build.rs:387 `continue`s on a
+      # missing .owl, so once the fetch is skipped on a cache hit, an uncached
+      # .owl tree makes the raw-OWL staging silently disappear. Key bumped to
+      # v2 because the pre-existing entry does not contain these files and
+      # cache keys are immutable.
       - name: Cache fetched external data
         uses: actions/cache@v5
         with:
@@ -415,7 +462,8 @@ jobs:
             crates/domains/data/legal/uscode
             crates/domains/data/markup-schemas/xsts
             crates/domains/data/markup-schemas/xmlconf
-          key: praxis-data-${{ hashFiles('praxis.lock') }}
+            crates/domains/data/ontologies/*.owl
+          key: praxis-data-v2-${{ hashFiles('praxis.lock') }}
       # peaceiris/actions-mdbook@v2's newest release tag still declares
       # `node20`, so it cannot be upgraded past the Node-20 deprecation —
       # only replaced. Pinned to 0.5.4, the version `mdbook-version: latest`
@@ -552,6 +600,13 @@ jobs:
         with:
           path: crates/domains/data/wordnet/english-wordnet-2025.xml
           key: wordnet-english-2025-v1
+      # `crates/domains/data/ontologies/*.owl` is FETCHED, not tracked
+      # (.gitignore:95 ignores *.owl here; only the six .prx.gz are committed),
+      # and it was in NO cache block. crates/wasm/build.rs:387 `continue`s on a
+      # missing .owl, so once the fetch is skipped on a cache hit, an uncached
+      # .owl tree makes the raw-OWL staging silently disappear. Key bumped to
+      # v2 because the pre-existing entry does not contain these files and
+      # cache keys are immutable.
       - name: Cache fetched external data
         uses: actions/cache@v5
         with:
@@ -559,7 +614,8 @@ jobs:
             crates/domains/data/legal/uscode
             crates/domains/data/markup-schemas/xsts
             crates/domains/data/markup-schemas/xmlconf
-          key: praxis-data-${{ hashFiles('praxis.lock') }}
+            crates/domains/data/ontologies/*.owl
+          key: praxis-data-v2-${{ hashFiles('praxis.lock') }}
       - uses: actions/download-artifact@v8
         with:
           name: pr4xis-cli
@@ -674,6 +730,13 @@ jobs:
         with:
           path: crates/domains/data/wordnet/english-wordnet-2025.xml
           key: wordnet-english-2025-v1
+      # `crates/domains/data/ontologies/*.owl` is FETCHED, not tracked
+      # (.gitignore:95 ignores *.owl here; only the six .prx.gz are committed),
+      # and it was in NO cache block. crates/wasm/build.rs:387 `continue`s on a
+      # missing .owl, so once the fetch is skipped on a cache hit, an uncached
+      # .owl tree makes the raw-OWL staging silently disappear. Key bumped to
+      # v2 because the pre-existing entry does not contain these files and
+      # cache keys are immutable.
       - name: Cache fetched external data
         uses: actions/cache@v5
         with:
@@ -681,7 +744,8 @@ jobs:
             crates/domains/data/legal/uscode
             crates/domains/data/markup-schemas/xsts
             crates/domains/data/markup-schemas/xmlconf
-          key: praxis-data-${{ hashFiles('praxis.lock') }}
+            crates/domains/data/ontologies/*.owl
+          key: praxis-data-v2-${{ hashFiles('praxis.lock') }}
       - uses: actions/download-artifact@v8
         with:
           name: pr4xis-cli
@@ -990,6 +1054,13 @@ jobs:
         with:
           path: crates/domains/data/wordnet/english-wordnet-2025.xml
           key: wordnet-english-2025-v1
+      # `crates/domains/data/ontologies/*.owl` is FETCHED, not tracked
+      # (.gitignore:95 ignores *.owl here; only the six .prx.gz are committed),
+      # and it was in NO cache block. crates/wasm/build.rs:387 `continue`s on a
+      # missing .owl, so once the fetch is skipped on a cache hit, an uncached
+      # .owl tree makes the raw-OWL staging silently disappear. Key bumped to
+      # v2 because the pre-existing entry does not contain these files and
+      # cache keys are immutable.
       - name: Cache fetched external data
         uses: actions/cache@v5
         with:
@@ -997,7 +1068,8 @@ jobs:
             crates/domains/data/legal/uscode
             crates/domains/data/markup-schemas/xsts
             crates/domains/data/markup-schemas/xmlconf
-          key: praxis-data-${{ hashFiles('praxis.lock') }}
+            crates/domains/data/ontologies/*.owl
+          key: praxis-data-v2-${{ hashFiles('praxis.lock') }}
       - uses: actions/download-artifact@v8
         with:
           name: pr4xis-cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,13 +295,23 @@ jobs:
         with:
           path: crates/domains/data/wordnet/english-wordnet-2025.xml
           key: wordnet-english-2025-v1
-      # `crates/domains/data/ontologies/*.owl` is FETCHED, not tracked
-      # (.gitignore:95 ignores *.owl here; only the six .prx.gz are committed),
-      # and it was in NO cache block. crates/wasm/build.rs:387 `continue`s on a
-      # missing .owl, so once the fetch is skipped on a cache hit, an uncached
-      # .owl tree makes the raw-OWL staging silently disappear. Key bumped to
-      # v2 because the pre-existing entry does not contain these files and
-      # cache keys are immutable.
+      # Covers EVERY tree `pr4xis update` actually re-downloads, not just the
+      # USC titles. Measured on master run 30502233952: the fetch reported 75
+      # `[fetched]` against 190 `[ok]` — 15 files per job across 8 directories,
+      # re-downloaded in all five jobs of every run, because only uscode/xsts/
+      # xmlconf were cached. The 15 are enumerated rather than globbed by parent
+      # directory on purpose: every one is gitignored (verified with
+      # `git check-ignore`), so restoring them can never shadow a TRACKED file,
+      # whereas caching e.g. all of `markup-schemas/` would restore stale copies
+      # over the 11 committed files there whenever praxis.lock had not moved.
+      #
+      # The .owl half also fixes a latent bug: crates/wasm/build.rs:387
+      # `continue`s on a missing .owl, so an uncached OWL tree plus any future
+      # skipping of the fetch would make the raw-OWL staging silently vanish.
+      #
+      # Key at v3 because the v1/v2 entries do not contain these files and cache
+      # keys are immutable — a path added without a key bump would restore the
+      # old contents forever and never re-save.
       - name: Cache fetched external data (USC titles + conformance suites)
         uses: actions/cache@v5
         with:
@@ -310,7 +320,16 @@ jobs:
             crates/domains/data/markup-schemas/xsts
             crates/domains/data/markup-schemas/xmlconf
             crates/domains/data/ontologies/*.owl
-          key: praxis-data-v2-${{ hashFiles('praxis.lock') }}
+            crates/domains/data/adobe/glyphlist.txt
+            crates/domains/data/morphology/agid-infl.txt
+            crates/domains/data/markup-schemas/lmf/wn_lmf_dtd-1.3.dtd
+            crates/domains/data/markup-schemas/mods/mods_3_8-2018.xsd
+            crates/domains/data/markup-schemas/xhtml/xhtml-1.0-strict.xsd
+            crates/domains/data/markup-schemas/xml/xml.xsd
+            crates/domains/data/markup-schemas/xml/xml-infoset.xhtml
+            crates/domains/data/markup-schemas/xml/xml_1_0_fifth_edition-2008.xml
+            crates/domains/data/markup-schemas/xsd/xsd_meta_schema-1.1.xsd
+          key: praxis-data-v3-${{ hashFiles('praxis.lock') }}
       # Build pr4xis-cli + the full workspace + all test binaries in
       # one pass. Downstream `lint-docs` and `test` then run against the
       # populated `release` cache slice with no further compilation —
@@ -448,13 +467,23 @@ jobs:
         with:
           path: crates/domains/data/wordnet/english-wordnet-2025.xml
           key: wordnet-english-2025-v1
-      # `crates/domains/data/ontologies/*.owl` is FETCHED, not tracked
-      # (.gitignore:95 ignores *.owl here; only the six .prx.gz are committed),
-      # and it was in NO cache block. crates/wasm/build.rs:387 `continue`s on a
-      # missing .owl, so once the fetch is skipped on a cache hit, an uncached
-      # .owl tree makes the raw-OWL staging silently disappear. Key bumped to
-      # v2 because the pre-existing entry does not contain these files and
-      # cache keys are immutable.
+      # Covers EVERY tree `pr4xis update` actually re-downloads, not just the
+      # USC titles. Measured on master run 30502233952: the fetch reported 75
+      # `[fetched]` against 190 `[ok]` — 15 files per job across 8 directories,
+      # re-downloaded in all five jobs of every run, because only uscode/xsts/
+      # xmlconf were cached. The 15 are enumerated rather than globbed by parent
+      # directory on purpose: every one is gitignored (verified with
+      # `git check-ignore`), so restoring them can never shadow a TRACKED file,
+      # whereas caching e.g. all of `markup-schemas/` would restore stale copies
+      # over the 11 committed files there whenever praxis.lock had not moved.
+      #
+      # The .owl half also fixes a latent bug: crates/wasm/build.rs:387
+      # `continue`s on a missing .owl, so an uncached OWL tree plus any future
+      # skipping of the fetch would make the raw-OWL staging silently vanish.
+      #
+      # Key at v3 because the v1/v2 entries do not contain these files and cache
+      # keys are immutable — a path added without a key bump would restore the
+      # old contents forever and never re-save.
       - name: Cache fetched external data
         uses: actions/cache@v5
         with:
@@ -463,7 +492,16 @@ jobs:
             crates/domains/data/markup-schemas/xsts
             crates/domains/data/markup-schemas/xmlconf
             crates/domains/data/ontologies/*.owl
-          key: praxis-data-v2-${{ hashFiles('praxis.lock') }}
+            crates/domains/data/adobe/glyphlist.txt
+            crates/domains/data/morphology/agid-infl.txt
+            crates/domains/data/markup-schemas/lmf/wn_lmf_dtd-1.3.dtd
+            crates/domains/data/markup-schemas/mods/mods_3_8-2018.xsd
+            crates/domains/data/markup-schemas/xhtml/xhtml-1.0-strict.xsd
+            crates/domains/data/markup-schemas/xml/xml.xsd
+            crates/domains/data/markup-schemas/xml/xml-infoset.xhtml
+            crates/domains/data/markup-schemas/xml/xml_1_0_fifth_edition-2008.xml
+            crates/domains/data/markup-schemas/xsd/xsd_meta_schema-1.1.xsd
+          key: praxis-data-v3-${{ hashFiles('praxis.lock') }}
       # peaceiris/actions-mdbook@v2's newest release tag still declares
       # `node20`, so it cannot be upgraded past the Node-20 deprecation —
       # only replaced. Pinned to 0.5.4, the version `mdbook-version: latest`
@@ -600,13 +638,23 @@ jobs:
         with:
           path: crates/domains/data/wordnet/english-wordnet-2025.xml
           key: wordnet-english-2025-v1
-      # `crates/domains/data/ontologies/*.owl` is FETCHED, not tracked
-      # (.gitignore:95 ignores *.owl here; only the six .prx.gz are committed),
-      # and it was in NO cache block. crates/wasm/build.rs:387 `continue`s on a
-      # missing .owl, so once the fetch is skipped on a cache hit, an uncached
-      # .owl tree makes the raw-OWL staging silently disappear. Key bumped to
-      # v2 because the pre-existing entry does not contain these files and
-      # cache keys are immutable.
+      # Covers EVERY tree `pr4xis update` actually re-downloads, not just the
+      # USC titles. Measured on master run 30502233952: the fetch reported 75
+      # `[fetched]` against 190 `[ok]` — 15 files per job across 8 directories,
+      # re-downloaded in all five jobs of every run, because only uscode/xsts/
+      # xmlconf were cached. The 15 are enumerated rather than globbed by parent
+      # directory on purpose: every one is gitignored (verified with
+      # `git check-ignore`), so restoring them can never shadow a TRACKED file,
+      # whereas caching e.g. all of `markup-schemas/` would restore stale copies
+      # over the 11 committed files there whenever praxis.lock had not moved.
+      #
+      # The .owl half also fixes a latent bug: crates/wasm/build.rs:387
+      # `continue`s on a missing .owl, so an uncached OWL tree plus any future
+      # skipping of the fetch would make the raw-OWL staging silently vanish.
+      #
+      # Key at v3 because the v1/v2 entries do not contain these files and cache
+      # keys are immutable — a path added without a key bump would restore the
+      # old contents forever and never re-save.
       - name: Cache fetched external data
         uses: actions/cache@v5
         with:
@@ -615,7 +663,16 @@ jobs:
             crates/domains/data/markup-schemas/xsts
             crates/domains/data/markup-schemas/xmlconf
             crates/domains/data/ontologies/*.owl
-          key: praxis-data-v2-${{ hashFiles('praxis.lock') }}
+            crates/domains/data/adobe/glyphlist.txt
+            crates/domains/data/morphology/agid-infl.txt
+            crates/domains/data/markup-schemas/lmf/wn_lmf_dtd-1.3.dtd
+            crates/domains/data/markup-schemas/mods/mods_3_8-2018.xsd
+            crates/domains/data/markup-schemas/xhtml/xhtml-1.0-strict.xsd
+            crates/domains/data/markup-schemas/xml/xml.xsd
+            crates/domains/data/markup-schemas/xml/xml-infoset.xhtml
+            crates/domains/data/markup-schemas/xml/xml_1_0_fifth_edition-2008.xml
+            crates/domains/data/markup-schemas/xsd/xsd_meta_schema-1.1.xsd
+          key: praxis-data-v3-${{ hashFiles('praxis.lock') }}
       - uses: actions/download-artifact@v8
         with:
           name: pr4xis-cli
@@ -730,13 +787,23 @@ jobs:
         with:
           path: crates/domains/data/wordnet/english-wordnet-2025.xml
           key: wordnet-english-2025-v1
-      # `crates/domains/data/ontologies/*.owl` is FETCHED, not tracked
-      # (.gitignore:95 ignores *.owl here; only the six .prx.gz are committed),
-      # and it was in NO cache block. crates/wasm/build.rs:387 `continue`s on a
-      # missing .owl, so once the fetch is skipped on a cache hit, an uncached
-      # .owl tree makes the raw-OWL staging silently disappear. Key bumped to
-      # v2 because the pre-existing entry does not contain these files and
-      # cache keys are immutable.
+      # Covers EVERY tree `pr4xis update` actually re-downloads, not just the
+      # USC titles. Measured on master run 30502233952: the fetch reported 75
+      # `[fetched]` against 190 `[ok]` — 15 files per job across 8 directories,
+      # re-downloaded in all five jobs of every run, because only uscode/xsts/
+      # xmlconf were cached. The 15 are enumerated rather than globbed by parent
+      # directory on purpose: every one is gitignored (verified with
+      # `git check-ignore`), so restoring them can never shadow a TRACKED file,
+      # whereas caching e.g. all of `markup-schemas/` would restore stale copies
+      # over the 11 committed files there whenever praxis.lock had not moved.
+      #
+      # The .owl half also fixes a latent bug: crates/wasm/build.rs:387
+      # `continue`s on a missing .owl, so an uncached OWL tree plus any future
+      # skipping of the fetch would make the raw-OWL staging silently vanish.
+      #
+      # Key at v3 because the v1/v2 entries do not contain these files and cache
+      # keys are immutable — a path added without a key bump would restore the
+      # old contents forever and never re-save.
       - name: Cache fetched external data
         uses: actions/cache@v5
         with:
@@ -745,7 +812,16 @@ jobs:
             crates/domains/data/markup-schemas/xsts
             crates/domains/data/markup-schemas/xmlconf
             crates/domains/data/ontologies/*.owl
-          key: praxis-data-v2-${{ hashFiles('praxis.lock') }}
+            crates/domains/data/adobe/glyphlist.txt
+            crates/domains/data/morphology/agid-infl.txt
+            crates/domains/data/markup-schemas/lmf/wn_lmf_dtd-1.3.dtd
+            crates/domains/data/markup-schemas/mods/mods_3_8-2018.xsd
+            crates/domains/data/markup-schemas/xhtml/xhtml-1.0-strict.xsd
+            crates/domains/data/markup-schemas/xml/xml.xsd
+            crates/domains/data/markup-schemas/xml/xml-infoset.xhtml
+            crates/domains/data/markup-schemas/xml/xml_1_0_fifth_edition-2008.xml
+            crates/domains/data/markup-schemas/xsd/xsd_meta_schema-1.1.xsd
+          key: praxis-data-v3-${{ hashFiles('praxis.lock') }}
       - uses: actions/download-artifact@v8
         with:
           name: pr4xis-cli
@@ -1054,13 +1130,23 @@ jobs:
         with:
           path: crates/domains/data/wordnet/english-wordnet-2025.xml
           key: wordnet-english-2025-v1
-      # `crates/domains/data/ontologies/*.owl` is FETCHED, not tracked
-      # (.gitignore:95 ignores *.owl here; only the six .prx.gz are committed),
-      # and it was in NO cache block. crates/wasm/build.rs:387 `continue`s on a
-      # missing .owl, so once the fetch is skipped on a cache hit, an uncached
-      # .owl tree makes the raw-OWL staging silently disappear. Key bumped to
-      # v2 because the pre-existing entry does not contain these files and
-      # cache keys are immutable.
+      # Covers EVERY tree `pr4xis update` actually re-downloads, not just the
+      # USC titles. Measured on master run 30502233952: the fetch reported 75
+      # `[fetched]` against 190 `[ok]` — 15 files per job across 8 directories,
+      # re-downloaded in all five jobs of every run, because only uscode/xsts/
+      # xmlconf were cached. The 15 are enumerated rather than globbed by parent
+      # directory on purpose: every one is gitignored (verified with
+      # `git check-ignore`), so restoring them can never shadow a TRACKED file,
+      # whereas caching e.g. all of `markup-schemas/` would restore stale copies
+      # over the 11 committed files there whenever praxis.lock had not moved.
+      #
+      # The .owl half also fixes a latent bug: crates/wasm/build.rs:387
+      # `continue`s on a missing .owl, so an uncached OWL tree plus any future
+      # skipping of the fetch would make the raw-OWL staging silently vanish.
+      #
+      # Key at v3 because the v1/v2 entries do not contain these files and cache
+      # keys are immutable — a path added without a key bump would restore the
+      # old contents forever and never re-save.
       - name: Cache fetched external data
         uses: actions/cache@v5
         with:
@@ -1069,7 +1155,16 @@ jobs:
             crates/domains/data/markup-schemas/xsts
             crates/domains/data/markup-schemas/xmlconf
             crates/domains/data/ontologies/*.owl
-          key: praxis-data-v2-${{ hashFiles('praxis.lock') }}
+            crates/domains/data/adobe/glyphlist.txt
+            crates/domains/data/morphology/agid-infl.txt
+            crates/domains/data/markup-schemas/lmf/wn_lmf_dtd-1.3.dtd
+            crates/domains/data/markup-schemas/mods/mods_3_8-2018.xsd
+            crates/domains/data/markup-schemas/xhtml/xhtml-1.0-strict.xsd
+            crates/domains/data/markup-schemas/xml/xml.xsd
+            crates/domains/data/markup-schemas/xml/xml-infoset.xhtml
+            crates/domains/data/markup-schemas/xml/xml_1_0_fifth_edition-2008.xml
+            crates/domains/data/markup-schemas/xsd/xsd_meta_schema-1.1.xsd
+          key: praxis-data-v3-${{ hashFiles('praxis.lock') }}
       - uses: actions/download-artifact@v8
         with:
           name: pr4xis-cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ permissions:
 #   - test binaries via `cargo         — uploaded as artifact, `test` runs
 #     nextest archive`                   directly from it (no recompile)
 #
-# Downstream jobs share `shared-key: release`, so they restore build's
+# Downstream jobs share `shared-key: release-lto-off`, so they restore build's
 # DEPENDENCY slice (see the caching note above — workspace crates are
 # never in it). Of the three, only `test` is genuinely compile-free:
 # it runs the prebuilt nextest archive. `lint-docs` recompiles the
@@ -287,7 +287,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: steps.build-out.outputs.cache-hit != 'true'
         with:
-          shared-key: release
+          shared-key: release-lto-off
       - uses: taiki-e/install-action@cargo-nextest
         if: steps.build-out.outputs.cache-hit != 'true'
       - name: Cache WordNet XML
@@ -312,7 +312,9 @@ jobs:
       # slice this job writes has different rustc fingerprints than the
       # slice `lint-docs` / `test` / `wasm-browser` expect, and they would
       # recompile from scratch on restore. Same flags everywhere keeps
-      # `shared-key: release` actually shared.
+      # `shared-key: release-lto-off` actually shared. The key carries `-lto-off`
+      # because `[profile.release] lto = "off"` is in EVERY unit's fingerprint,
+      # dependencies included, so the pre-LTO-off slice cannot be reused.
       - name: Build pr4xis-cli (release)
         if: steps.build-out.outputs.cache-hit != 'true'
         env:
@@ -400,7 +402,7 @@ jobs:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: release
+          shared-key: release-lto-off
       - name: Cache WordNet XML
         uses: actions/cache@v5
         with:
@@ -666,7 +668,7 @@ jobs:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: release
+          shared-key: release-lto-off
       - name: Cache WordNet XML
         uses: actions/cache@v5
         with:
@@ -982,7 +984,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: release
+          shared-key: release-lto-off
       - name: Cache WordNet XML
         uses: actions/cache@v5
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,5 +94,31 @@ unreachable = "deny"
 # Workspace crates explicitly because USLM read code lives in
 # `crates/domains`, not in any dep; the deps-only variant
 # (`[profile.dev.package."*"]`) doesn't reach it.
+# Cargo's release default is `lto = false`, which is NOT "no LTO" — it is thin
+# LOCAL LTO across the crate's 16 codegen units. On `pr4xis-domains`' 8,037-test
+# lib binary that index+import step is `LLVM_thinlto` = 133-179s of a ~280-330s
+# unit at 4 cores, and that ONE unit is 95-98% of the `cargo nextest archive`
+# wall — so it is effectively 95% of CI's cold build.
+#
+# Measured at 4 cores, same rustc argv replayed back-to-back: 277.18s -> 215.22s
+# (-22.4%). A looser protocol with deps rebuilt gave -34%. Budget the -22%: the
+# optimisation work RELOCATES rather than vanishing (`LLVM_passes` grows as
+# `LLVM_thinlto` disappears) and the absorbed fraction is unstable run to run.
+#
+# Cost, accepted: the test binary grows 11.7% (91.5 -> 102.2 MB) and the tests
+# run ~14% slower. That last number is the constraint that matters, because
+# `.config/nextest.toml`'s [profile.ci] flags anything over 10s and terminates
+# at 30s. At +14% the three slowest known tests go 13.2 -> ~15.0s,
+# 11.5 -> ~13.1s, and 40.5 -> ~46.2s (the last against its own bespoke 30s x 3
+# override) — none crosses a `terminate-after` boundary, but the margin is real.
+# If a future test lands near 10s, re-measure before assuming this still holds.
+#
+# `lto` cannot be set per-package, so this is necessarily workspace-wide. That
+# is fine here: every host job reads this same manifest, so they all stay on one
+# cache slice. `crates/praxis-corpus-tests` is workspace-EXCLUDED (Cargo.toml
+# `exclude`), so the `corpus` job neither churns nor benefits.
+[profile.release]
+lto = "off"
+
 [profile.dev]
 opt-level = 1

--- a/crates/cli/tests/cli_smoke.rs
+++ b/crates/cli/tests/cli_smoke.rs
@@ -1,0 +1,109 @@
+//! The CLI's startup + subcommand contract, as an integration test.
+//!
+//! Two jobs, and the second is the reason this file exists at all.
+//!
+//! 1. CONTRACT. `.github/workflows/ci.yml` and `devenv.nix` both invoke
+//!    `pr4xis update` and `pr4xis compile --compact` by name, and the `build`
+//!    job's data fetch is `./target/release/pr4xis update`. Those are the
+//!    load-bearing entry points of the whole pipeline, and nothing else checks
+//!    that they still parse: a renamed or removed subcommand would surface as a
+//!    confusing mid-job failure in CI rather than as a failing test here.
+//!
+//! 2. ARCHIVE MEMBERSHIP. `cargo nextest archive` builds a package's plain
+//!    `[[bin]]` only when that package also has an integration-test or bench
+//!    target. `crates/cli` had neither, so `target/release/pr4xis` was absent
+//!    from the archive and the `build` job had to compile it in a separate
+//!    `cargo build -p pr4xis-cli --release` step — which cost ~126s and was
+//!    thrown away, because the `-p pr4xis-cli` resolve gives `pr4xis-domains` a
+//!    different `serde_json` feature set (no `alloc`, which only
+//!    `wasm-bindgen-test` pulls in) than `--workspace --all-targets` does, so
+//!    the archive step rebuilt the domains rlib from scratch anyway.
+//!    `crates/web` already has this shape (`crates/web/tests/`), which is
+//!    exactly why `target/release/pr4xis-web` IS in the archive.
+//!
+//! So this file is a genuine contract test that also, as a side effect, puts
+//! the binary where the archive can carry it. If it is deleted, the `build`
+//! job's artifact upload silently produces nothing — `upload-artifact` defaults
+//! to `if-no-files-found: warn`, so the job stays GREEN — and `lint-docs`,
+//! `test`, `wasm-browser` and `corpus` all then fail at `chmod +x`.
+
+use std::process::Command;
+
+/// The binary under test, resolved by cargo for the integration target.
+fn pr4xis() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_pr4xis"))
+}
+
+/// `--help` must succeed and name every subcommand CI drives by name.
+///
+/// Asserting on the help text rather than on each subcommand's behaviour keeps
+/// this test hermetic: `update` reaches the network and `compile` reads the
+/// corpus, neither of which belongs in a smoke test.
+#[test]
+fn help_lists_every_subcommand_ci_invokes() {
+    let out = pr4xis()
+        .arg("--help")
+        .output()
+        .expect("the pr4xis binary must be executable");
+
+    assert!(
+        out.status.success(),
+        "`pr4xis --help` exited {:?}; stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let help = String::from_utf8_lossy(&out.stdout);
+    // `update` and `compile` are invoked by ci.yml and devenv.nix; `chat` is the
+    // default subcommand and `decompile` completes the emit/read pair.
+    for sub in ["chat", "update", "compile", "decompile"] {
+        assert!(
+            help.contains(sub),
+            "`pr4xis --help` no longer lists the `{sub}` subcommand, which CI \
+             invokes by name. Renaming it breaks .github/workflows/ci.yml and \
+             devenv.nix. Full help:\n{help}"
+        );
+    }
+}
+
+/// `compile --compact` must parse. CI runs exactly this flag pair in `test` and
+/// `corpus`, and `devenv.nix`'s dev-ci runs it too; if the flag were renamed the
+/// failure would appear as a mid-job parse error, not as a failing test.
+#[test]
+fn compile_accepts_the_compact_flag_ci_uses() {
+    let out = pr4xis()
+        .args(["compile", "--help"])
+        .output()
+        .expect("the pr4xis binary must be executable");
+
+    assert!(
+        out.status.success(),
+        "`pr4xis compile --help` exited {:?}; stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let help = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        help.contains("--compact"),
+        "`pr4xis compile` no longer accepts `--compact`, which ci.yml and \
+         devenv.nix both invoke. Full help:\n{help}"
+    );
+}
+
+/// An unknown subcommand must FAIL, not fall through to the default `chat`
+/// session. Without this, a typo'd invocation in CI would start an interactive
+/// chat and hang until the step timeout rather than erroring immediately.
+#[test]
+fn an_unknown_subcommand_is_refused() {
+    let out = pr4xis()
+        .arg("definitely-not-a-subcommand")
+        .output()
+        .expect("the pr4xis binary must be executable");
+
+    assert!(
+        !out.status.success(),
+        "an unknown subcommand must be refused, not silently accepted — \
+         otherwise a typo in CI starts an interactive chat and hangs"
+    );
+}

--- a/crates/cli/tests/cli_smoke.rs
+++ b/crates/cli/tests/cli_smoke.rs
@@ -13,87 +13,120 @@
 //!    `[[bin]]` only when that package also has an integration-test or bench
 //!    target. `crates/cli` had neither, so `target/release/pr4xis` was absent
 //!    from the archive and the `build` job had to compile it in a separate
-//!    `cargo build -p pr4xis-cli --release` step — which cost ~126s and was
-//!    thrown away, because the `-p pr4xis-cli` resolve gives `pr4xis-domains` a
-//!    different `serde_json` feature set (no `alloc`, which only
-//!    `wasm-bindgen-test` pulls in) than `--workspace --all-targets` does, so
-//!    the archive step rebuilt the domains rlib from scratch anyway.
-//!    `crates/web` already has this shape (`crates/web/tests/`), which is
-//!    exactly why `target/release/pr4xis-web` IS in the archive.
+//!    `cargo build -p pr4xis-cli --release` step. `crates/web` already has this
+//!    shape (`crates/web/tests/`), which is exactly why
+//!    `target/release/pr4xis-web` IS in the archive.
 //!
 //! So this file is a genuine contract test that also, as a side effect, puts
 //! the binary where the archive can carry it. If it is deleted, the `build`
 //! job's artifact upload silently produces nothing — `upload-artifact` defaults
 //! to `if-no-files-found: warn`, so the job stays GREEN — and `lint-docs`,
 //! `test`, `wasm-browser` and `corpus` all then fail at `chmod +x`.
+//!
+//! The assertions parse `--help` STRUCTURALLY rather than with `contains`,
+//! because substring matching is not sound against this CLI's own help text:
+//! `decompile`'s description reads "the inverse of `compile`", so
+//! `contains("compile")` passes even with the `compile` subcommand deleted, and
+//! `--defines`' description mentions "`--compact` runs", so
+//! `contains("--compact")` passes even with the flag deleted. Both checks would
+//! have been decorative.
 
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 /// The binary under test, resolved by cargo for the integration target.
+///
+/// `stdin` is null so that a regression which falls through to the interactive
+/// `chat` session fails immediately on EOF instead of inheriting the test
+/// runner's stdin and blocking until nextest's `terminate-after`. A test whose
+/// job is to prove the CLI cannot hang must not itself be able to hang.
 fn pr4xis() -> Command {
-    Command::new(env!("CARGO_BIN_EXE_pr4xis"))
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_pr4xis"));
+    cmd.stdin(Stdio::null());
+    cmd
 }
 
-/// `--help` must succeed and name every subcommand CI drives by name.
-///
-/// Asserting on the help text rather than on each subcommand's behaviour keeps
-/// this test hermetic: `update` reaches the network and `compile` reads the
-/// corpus, neither of which belongs in a smoke test.
-#[test]
-fn help_lists_every_subcommand_ci_invokes() {
+/// Run the binary with `args` and return stdout, asserting a clean exit.
+fn help_text(args: &[&str]) -> String {
     let out = pr4xis()
-        .arg("--help")
+        .args(args)
         .output()
         .expect("the pr4xis binary must be executable");
-
     assert!(
         out.status.success(),
-        "`pr4xis --help` exited {:?}; stderr: {}",
+        "`pr4xis {}` exited {:?}; stderr: {}",
+        args.join(" "),
         out.status.code(),
         String::from_utf8_lossy(&out.stderr)
     );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
 
-    let help = String::from_utf8_lossy(&out.stdout);
-    // `update` and `compile` are invoked by ci.yml and devenv.nix; `chat` is the
-    // default subcommand and `decompile` completes the emit/read pair.
+/// The subcommand NAMES clap lists under `Commands:` — first token of each
+/// entry line, stopping at the blank line that ends the section.
+///
+/// Structural on purpose: entry lines are indented and carry a description
+/// after the name, and descriptions routinely name OTHER subcommands.
+fn subcommands(help: &str) -> Vec<String> {
+    help.lines()
+        .skip_while(|l| l.trim() != "Commands:")
+        .skip(1)
+        .take_while(|l| !l.trim().is_empty())
+        .filter_map(|l| l.split_whitespace().next())
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Whether `flag` appears as an option DECLARATION rather than inside prose.
+///
+/// Declaration lines start (after trimming) with `-`, e.g. `--compact` or
+/// `-h, --help`; wrapped description text is indented further and starts with
+/// ordinary words. Requiring an exact token match on such a line is what keeps
+/// `--defines`' mention of "`--compact` runs" from satisfying this.
+fn declares_flag(help: &str, flag: &str) -> bool {
+    help.lines()
+        .map(str::trim)
+        .filter(|l| l.starts_with('-'))
+        .any(|l| {
+            l.split(|c: char| c.is_whitespace() || c == ',')
+                .any(|tok| tok == flag)
+        })
+}
+
+/// `--help` must succeed and list every subcommand CI drives by name.
+#[test]
+fn help_lists_every_subcommand_ci_invokes() {
+    let help = help_text(&["--help"]);
+    let found = subcommands(&help);
+
+    // `update` and `compile` are invoked by ci.yml and devenv.nix; `chat` is
+    // the default subcommand and `decompile` completes the emit/read pair.
     for sub in ["chat", "update", "compile", "decompile"] {
         assert!(
-            help.contains(sub),
-            "`pr4xis --help` no longer lists the `{sub}` subcommand, which CI \
-             invokes by name. Renaming it breaks .github/workflows/ci.yml and \
-             devenv.nix. Full help:\n{help}"
+            found.iter().any(|f| f == sub),
+            "`pr4xis --help` no longer lists a `{sub}` subcommand. CI invokes it \
+             by name, so renaming it breaks .github/workflows/ci.yml and \
+             devenv.nix. Parsed command list: {found:?}\nFull help:\n{help}"
         );
     }
 }
 
 /// `compile --compact` must parse. CI runs exactly this flag pair in `test` and
-/// `corpus`, and `devenv.nix`'s dev-ci runs it too; if the flag were renamed the
-/// failure would appear as a mid-job parse error, not as a failing test.
+/// `corpus`, and devenv.nix's dev-ci runs it too.
 #[test]
 fn compile_accepts_the_compact_flag_ci_uses() {
-    let out = pr4xis()
-        .args(["compile", "--help"])
-        .output()
-        .expect("the pr4xis binary must be executable");
-
+    let help = help_text(&["compile", "--help"]);
     assert!(
-        out.status.success(),
-        "`pr4xis compile --help` exited {:?}; stderr: {}",
-        out.status.code(),
-        String::from_utf8_lossy(&out.stderr)
-    );
-
-    let help = String::from_utf8_lossy(&out.stdout);
-    assert!(
-        help.contains("--compact"),
-        "`pr4xis compile` no longer accepts `--compact`, which ci.yml and \
-         devenv.nix both invoke. Full help:\n{help}"
+        declares_flag(&help, "--compact"),
+        "`pr4xis compile` no longer DECLARES `--compact`, which ci.yml and \
+         devenv.nix both invoke. (Checked as an option declaration, not a \
+         substring — `--defines`' description also mentions `--compact`.)\n\
+         Full help:\n{help}"
     );
 }
 
 /// An unknown subcommand must FAIL, not fall through to the default `chat`
 /// session. Without this, a typo'd invocation in CI would start an interactive
-/// chat and hang until the step timeout rather than erroring immediately.
+/// chat and burn the step's whole timeout budget.
 #[test]
 fn an_unknown_subcommand_is_refused() {
     let out = pr4xis()


### PR DESCRIPTION
Answers "build cli is 2m, nextest archive is over 3.5min — can that be faster?" Measured, not guessed.

## Where the 688s goes

Almost all of it is **one rustc invocation**. `cargo --timings`: 419 unit-seconds over 433 units, but only 41 actually compile.

| unit | 4-core time |
|---|---|
| `pr4xis-domains` lib **TEST** binary | **237.8s** — 95-98% of the archive step's wall |
| `pr4xis-wasm` build-script **execution** | 64.4s (129.9s at 4 cores) |
| `pr4xis-domains` lib | 35.5s |
| everything else (~429 units) | ~48s |

The second-to-last unit in the whole build ends at t=89.8s of a 241s wall — **151s has exactly one unit running.** No `-j`, linker or codegen-units setting reaches that.

## What this changes

**`[profile.release] lto = "off"`.** Cargo's release default `lto = false` is *not* "no LTO" — it's thin **local** LTO across the crate's 16 codegen units, and that index+import step is `LLVM_thinlto` = 133-179s of the dominant unit.

Measured at 4 cores, identical rustc argv replayed back-to-back: **277.18s → 215.22s (−22.4%)**. A looser protocol with deps rebuilt gave −34%. Budget −22%: the optimisation work *relocates* rather than vanishing (`LLVM_passes` grows as `LLVM_thinlto` shrinks) and the absorbed fraction is unstable run to run.

Expected: archive step 562s → **~440s** conservative, ~385s best. Job total ~725s → **~600s**.

### Merge gate — read it off this branch's own `test` job

The binary grows 11.7% (91.5 → 102.2 MB) and tests run **~14% slower**. `.config/nextest.toml`'s `[profile.ci]` flags anything over 10s and terminates at 30s. CI *already* fires two SLOW markers in `pr4xis-domains` — `ci_gate_passes` 13.172s, `completeness_meter_declared_tier_matches_achieved` 11.482s — plus `ontology_base_is_consistent` at 40.519s against its own bespoke 30s×3 override. At +14%: ~15.0s / ~13.1s / ~46.2s. Nothing crosses a `terminate-after` boundary, but `ci_gate_passes`' margin drops 2.28× → 2.0×.

**Do not merge unless `test` still reports 4 slow / 0 terminated.**

The `shared-key` bump to `release-lto-off` (4 sites) is mandatory, not cosmetic: profile knobs are in every unit's fingerprint, dependencies included — confirmed, adding the section alone recompiled `pr4xis`. Without it the restore full-matches a slice built under the old profile, rust-cache suppresses the save, and ~310 dependency crates recompile in every host job forever.

## Also fixed: the OWL vocabularies were never cached

`crates/domains/data/ontologies/*.owl` is fetched, not tracked (`.gitignore:95` — only the six `.prx.gz` are committed), and appeared in **none** of the five data-cache blocks, so all six were re-downloaded in every job of every run. Added to all five; key bumped to `praxis-data-v2` since the existing entry lacks them and cache keys are immutable.

## Deliberately NOT fixed: the 126s CLI build

~115s of it is provably thrown away. `-p pr4xis-cli` resolves `pr4xis-domains` with serde_json `default+std`; `--workspace --all-targets` resolves it with `alloc+default+std`, where `alloc` arrives only via `wasm-bindgen-test`, a **dev**-dependency of `crates/wasm`. One feature apart is a different rlib fingerprint, so the archive step rebuilds that rlib regardless. Widening the selector can't fix it either — matching the feature set requires dev-deps, i.e. `--all-targets`, which *is* the archive build.

The plan was to skip the step on a data-cache hit, because the fetch is then "a ~6s no-op". **It is not.** Measured on master run `30502233952`: `pr4xis update` reports **75 `[fetched]`** against 190 `[ok]` — the data cache covers 5 paths while `praxis.lock` registers ~20 fetchable trees (glyphlist, agid, the mods/xhtml/lmf/xsd schemas, the OWL vocabularies). Skip the fetch and those 75 are simply absent, and `crates/wasm/build.rs:29` and `:387` are **fail-open**, so the result is silent degradation rather than an error. Reverted before shipping; the reasoning is now a comment in `ci.yml` so the next attempt starts from the measurement.

Half the unblocking work lands here regardless: `crates/cli/tests/cli_smoke.rs` makes `cargo nextest archive` carry the CLI — verified **21 binaries / 3 non-test**, up from 19 / 2 — so the artifact no longer depends on that step. `cargo nextest archive` builds a package's plain `[[bin]]` only when the package also has an integration-test or bench target, which is exactly why `pr4xis-web` was in the archive and `pr4xis` was not. The remaining work is caching all ~20 fetched trees so the fetch becomes a genuine no-op, then gating.

The tests are a real contract, not a placeholder to satisfy cargo: `ci.yml` and `devenv.nix` invoke `pr4xis update` and `pr4xis compile --compact` by name, nothing else checks they still parse, and an unknown subcommand must fail rather than fall through to the default interactive chat and hang until the step timeout.

## Measured and rejected — recorded so nobody re-derives them

| lever | result |
|---|---|
| `codegen-units = 256` | **+20.0s** wall, +50.9 CPU-s, binary +3.6% |
| `codegen-units = 4` | wall and CPU disagree in sign; nothing bankable |
| `debug = 0`, `strip = "debuginfo"` | bit-identical no-ops — cargo already passes `-C strip=debuginfo` |
| `strip = true`, `split-debuginfo` | rotate `-C metadata` for one cold rebuild, buy 0.091s, lose panic symbols under a 30s cap |
| lowering `opt-level` | blocked by the runtime gate, which already has **negative** headroom |
| `incremental = true` | inert — rust-cache exports `CARGO_INCREMENTAL=0`, which overrides the profile field |
| separate `[profile.ci-fast]` | distinct target subdir ⇒ a second 310-crate graph, cold on ~88% of runs |
| `-Z threads=N` | 4 vCPU is the blocker, not nightly; Amdahl ≈ −29s and no idle cores to claim |
| mold / lld | `link_binary` = 1.6-2.2s = 0.6% of the unit; and `RUSTFLAGS` replaces `[target.*].rustflags`, silently dropping the mold flag |
| sccache | 100% hit rate, **4%** |

## Splitting the 8,037-test binary — not now

The only lever that attacks the structural problem, and the only one whose payoff is unmeasured while its costs are all measured. A zero-duplication 4-way split models to ~185s vs 254.5s (−27%) — but the constitution gate would go **silently green over a shrunken suite** (`binary_id(=pr4xis-domains)` selects exactly the lib binary, and `#[praxis_value]` registers per-binary via `linkme`), ~50-56% of test-carrying files touch a same-file private item, and the monomorphisation duplication factor is unmeasured with the direction pointing up.

The smallest experiment that settles it, before any refactor: move `formal::calculator` — 306 tests, all in one file, module tree already `pub` — to `crates/domains/tests/`, then on 4 pinned cores compare Δ(lib-test unit) against the new integration unit's duration. Δ > new unit ⇒ codegen divides and the lever is real. new unit ≥ Δ ⇒ it duplicates; close it permanently.

**Separately verified, and worth its own fix:** `crates/domains/tests/` **already** holds 4 integration targets with 12 `#[test]` and **zero** tags, and the gate reports `COMPLETE`. That blind spot exists today, independent of any split — the gate's `binary_id` selector plus its single-suite `jq` key means tests outside the lib binary leave *both* sides of the diff.
