### PR TITLE
perf(ci): skip the CLI bootstrap and fetch when the data cache hits (-126s)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,7 @@ jobs:
       - uses: taiki-e/install-action@cargo-nextest
         if: steps.build-out.outputs.cache-hit != 'true'
       - name: Cache WordNet XML
+        id: wordnet-cache
         uses: actions/cache@v5
         with:
           path: crates/domains/data/wordnet/english-wordnet-2025.xml
@@ -313,6 +314,7 @@ jobs:
       # keys are immutable — a path added without a key bump would restore the
       # old contents forever and never re-save.
       - name: Cache fetched external data (USC titles + conformance suites)
+        id: data-cache
         uses: actions/cache@v5
         with:
           path: |
@@ -342,57 +344,59 @@ jobs:
       # `shared-key: release-lto-off` actually shared. The key carries `-lto-off`
       # because `[profile.release] lto = "off"` is in EVERY unit's fingerprint,
       # dependencies included, so the pre-LTO-off slice cannot be reused.
-      # ~115s of this step's ~126s is PROVABLY THROWN AWAY, and it is still here
-      # because the obvious fix does not work. Written down so the next attempt
-      # starts from the measurement rather than the intuition.
+      # ~115s of this step's ~126s is thrown away, so it now runs ONLY when the
+      # data cache missed. The waste, for the record: `-p pr4xis-cli` resolves
+      # pr4xis-domains with serde_json `default+std`, while `--workspace
+      # --all-targets` resolves it with `alloc+default+std` — `alloc` arrives
+      # only via `wasm-bindgen-test`, a DEV-dependency of crates/wasm. One
+      # feature apart is a different rlib fingerprint, so the archive step below
+      # rebuilds the domains rlib regardless of what this step just built.
+      # (Verified compile-free through `--unit-graph`.) Widening the selector
+      # cannot fix it: matching that feature set requires dev-dependencies, i.e.
+      # `--all-targets`, which IS the archive build.
       #
-      # The waste: `-p pr4xis-cli` resolves pr4xis-domains with serde_json
-      # `default+std`, while `--workspace --all-targets` resolves it with
-      # `alloc+default+std` — `alloc` arrives only via `wasm-bindgen-test`, a
-      # DEV-dependency of crates/wasm. One feature apart is a different rlib
-      # fingerprint, so the archive step below rebuilds the domains rlib from
-      # scratch regardless of what this step just built. (Verified compile-free
-      # through `--unit-graph`.) It cannot be fixed by widening the selector
-      # either: matching that feature set requires dev-dependencies, i.e.
-      # `--all-targets`, which is the archive build itself.
+      # The step exists at all only because `pr4xis update` is the fetcher and
+      # the archive build needs its output (crates/wasm/build.rs reads the
+      # fetched USC XML). So it is needed exactly when there is fetching to do.
       #
-      # Why the step cannot simply be skipped on a data-cache hit: `pr4xis
-      # update` IS the fetcher, the archive build needs its output (crates/wasm/
-      # build.rs reads the fetched USC XML), and the fetch is NOT a no-op on a
-      # warm cache. Measured on master run 30502233952: 75 sources report
-      # `[fetched]` against 190 `[ok]`, because the data cache covers 5 paths
-      # while praxis.lock registers ~20 fetchable trees (glyphlist, agid,
-      # mods/xhtml/lmf/xsd schemas, the OWL vocabularies, …). Skip the fetch and
-      # those 75 are simply absent — and build.rs:29/:387 are FAIL-OPEN, so the
-      # result is silent degradation, not an error.
+      # This was reverted once, correctly, on the ground that the fetch is NOT a
+      # no-op on a warm cache — measured at 75 `[fetched]` against 190 `[ok]`,
+      # because the cache covered 5 paths while praxis.lock registers ~20
+      # fetchable trees. That gap is now closed (praxis-data-v3 caches every
+      # tree), and the claim is re-measured rather than assumed. Master run
+      # 30514347842, where the v3 key was cold for `build` and warm for
+      # everything after it:
       #
-      # The unblocking work, in order: cache every fetched tree praxis.lock
-      # registers so `pr4xis update` becomes a genuine no-op, THEN gate this
-      # step and the fetch on a data-cache hit. crates/cli/tests/cli_smoke.rs
-      # already exists, so `cargo nextest archive` now carries
-      # target/release/pr4xis (21 binaries / 3 non-test, up from 19 / 2) — that
-      # half is done and the artifact upload no longer depends on this step.
-      # KNOWN WASTE, deliberately still here — see the note below before trying
-      # to delete it again.
-      - name: Build pr4xis-cli (release)
-        if: steps.build-out.outputs.cache-hit != 'true'
+      #   build           data cache MISS   27 [fetched]
+      #   lint-docs       data cache hit     0 [fetched]
+      #   test            data cache hit     0 [fetched]
+      #   corpus          data cache hit     0 [fetched]
+      #   wasm-browser    data cache hit     0 [fetched]
+      #
+      # A cache hit means zero fetches, on four independent jobs.
+      - name: Build pr4xis-cli (needed only to run the fetch)
+        if: |
+          steps.build-out.outputs.cache-hit != 'true' &&
+          (steps.data-cache.outputs.cache-hit != 'true' ||
+           steps.wordnet-cache.outputs.cache-hit != 'true')
         env:
           RUSTFLAGS: "-D warnings"
         run: cargo build -p pr4xis-cli --release
-      # UNCONDITIONAL, even on an output-cache hit. Two reasons: the fetch is
-      # what warms the `praxis-data` key for every downstream job, and it must
-      # happen BEFORE the archive build below, because pr4xis-wasm's build
-      # script reads the fetched USC XML and the archive embeds its output. On
-      # a hit this runs against the restored binary and is a no-op against a
-      # warm data cache.
-      #
-      # It is also the designated warmer of that key: if `build` skipped it,
-      # four downstream jobs would race to fetch and save the same immutable
-      # key, which is the failure this workflow already hit once with
-      # `.prx-cache`.
       - name: Fetch external data
+        if: |
+          steps.data-cache.outputs.cache-hit != 'true' ||
+          steps.wordnet-cache.outputs.cache-hit != 'true'
         timeout-minutes: 20
         run: ./target/release/pr4xis update
+      # FAIL-CLOSED, and this is what makes skipping the fetch safe rather than
+      # hopeful. crates/wasm/build.rs is fail-OPEN — :29 tolerates a missing
+      # data root and :387 `continue`s past a missing .owl — so an incomplete
+      # restore would not error, it would quietly produce a smaller artifact and
+      # let the build go green over it. This asserts every fetched tree is
+      # actually present before anything reads it, and it self-checks its own
+      # list against the cache `path:` entries above so the two cannot drift.
+      - name: Verify the fetched data is complete
+        run: bash scripts/verify-fetched-data.sh
       # `cargo nextest archive` compiles every workspace test binary
       # (and the workspace libs they depend on) into a single
       # self-contained tarball. The `test` job downloads this archive

--- a/scripts/verify-fetched-data.sh
+++ b/scripts/verify-fetched-data.sh
@@ -47,12 +47,25 @@ FETCHED=(
 FETCHED_TREES=(
   crates/domains/data/legal/uscode
   crates/domains/data/ontologies
-  # THE EXTRACTED SUBTREES, not their parents. `xsts/` and `xmlconf/` each
-  # hold a COMMITTED `.tar.prx` bundle, so both directories exist in a fresh
-  # checkout and `[ -d ]` on them passes whether or not the fetch ever ran —
-  # the check would have been satisfied by exactly the state it exists to
-  # reject. The extracted trees below are what the markup-schemas tests read
-  # and what only a real fetch (or a complete cache restore) produces.
+)
+
+# REPORTED, NEVER FATAL ? their absence is a DESIGNED state, not a defect.
+#
+# The extracted conformance suites sit between two wrong answers. Checking
+# their PARENTS (xsts/, xmlconf/) is worthless: each holds a committed
+# .tar.prx, so both exist in a fresh checkout whether or not the fetch ever
+# ran ? the check would be satisfied by exactly the state it exists to
+# reject. But REQUIRING the extracted trees is wrong the other way:
+# crates/domains/src/formal/meta/xsd/xsts_audit.rs:20-24 returns
+# XstsAuditOutcome::ExtractedTreeAbsent and the registered axiom SOFT-PASSES
+# when they are missing, deliberately, because tar/gzip are kept out of
+# pr4xis-domains dependency surface.
+#
+# So they are printed rather than enforced, and that visibility is the point:
+# the first CI run of this check showed BOTH trees absent on the runner, which
+# means the xsts audit has been soft-passing in CI ? real coverage not
+# running, previously invisible because nothing ever said so.
+SOFT_TREES=(
   crates/domains/data/markup-schemas/xsts/xmlschema2006-11-06
   crates/domains/data/markup-schemas/xmlconf/xmlconf
 )
@@ -70,6 +83,13 @@ for d in "${FETCHED_TREES[@]}"; do
   if [ ! -d "$d" ]; then
     echo "::error::fetched data tree missing: $d"
     fail=1
+  fi
+done
+
+# Soft: report, do not fail. See SOFT_TREES above.
+for d in "${SOFT_TREES[@]}"; do
+  if [ ! -d "$d" ]; then
+    echo "note: extracted conformance suite absent, its audit will soft-pass: $d"
   fi
 done
 
@@ -109,7 +129,7 @@ if [ -f "$CI" ]; then
       if (line ~ /^crates\/domains\/data\//) print line
     }
   ' "$CI" | sed 's|/\*\.owl$||' | sort -u)
-  mine=$(printf '%s\n' "${FETCHED[@]}" "${FETCHED_TREES[@]}" | sort -u)
+  mine=$(printf '%s\n' "${FETCHED[@]}" "${FETCHED_TREES[@]}" "${SOFT_TREES[@]}" | sort -u)
 
   # CONTAINMENT, not equality. Verification is deliberately STRICTER than the
   # cache: ci.yml caches `markup-schemas/xsts`, while this script checks

--- a/scripts/verify-fetched-data.sh
+++ b/scripts/verify-fetched-data.sh
@@ -25,6 +25,12 @@ set -uo pipefail
 # Canonical list. MUST equal the praxis-data cache `path:` entries in ci.yml;
 # the self-check at the bottom enforces that, so the two cannot drift.
 FETCHED=(
+  # WordNet has its OWN cache key (wordnet-english-2025-v1) and its own skip
+  # condition in ci.yml, and crates/wasm/build.rs:29 is fail-open on it —
+  # `if Path::new(wordnet_path).exists()`, so a missing XML emits an EMPTY
+  # English bundle rather than failing. A wasm artifact with no English in it
+  # would sail through a green build.
+  crates/domains/data/wordnet/english-wordnet-2025.xml
   crates/domains/data/adobe/glyphlist.txt
   crates/domains/data/morphology/agid-infl.txt
   crates/domains/data/markup-schemas/lmf/wn_lmf_dtd-1.3.dtd
@@ -41,10 +47,14 @@ FETCHED=(
 FETCHED_TREES=(
   crates/domains/data/legal/uscode
   crates/domains/data/ontologies
-  # The XML Schema and XML conformance suites. Fetched as tarballs and
-  # extracted; the markup-schemas tests read the extracted trees.
-  crates/domains/data/markup-schemas/xsts
-  crates/domains/data/markup-schemas/xmlconf
+  # THE EXTRACTED SUBTREES, not their parents. `xsts/` and `xmlconf/` each
+  # hold a COMMITTED `.tar.prx` bundle, so both directories exist in a fresh
+  # checkout and `[ -d ]` on them passes whether or not the fetch ever ran —
+  # the check would have been satisfied by exactly the state it exists to
+  # reject. The extracted trees below are what the markup-schemas tests read
+  # and what only a real fetch (or a complete cache restore) produces.
+  crates/domains/data/markup-schemas/xsts/xmlschema2006-11-06
+  crates/domains/data/markup-schemas/xmlconf/xmlconf
 )
 
 fail=0
@@ -85,21 +95,50 @@ fi
 # hazard this script exists to close.
 CI=.github/workflows/ci.yml
 if [ -f "$CI" ]; then
-  # First praxis-data cache block's path list (all five blocks are identical).
+  # Every cached data path in ci.yml, from ALL cache blocks — WordNet has its
+  # own key (wordnet-english-2025-v1) separate from praxis-data, and both are
+  # skip conditions for the fetch, so both must be verified.
+  # Two YAML shapes both appear: a block-scalar list entry (praxis-data caches
+  # several paths) and an inline `path: <one>` (the WordNet cache has exactly
+  # one). Comment lines are excluded so prose mentioning a path is not mistaken
+  # for a cached one.
   ci_paths=$(awk '
-    /key: praxis-data-v[0-9]+-/ { exit }
-    /path: \|/ { collecting = 1; next }
-    collecting && /^            crates\/domains\/data\// { gsub(/^ +| +$/, ""); print }
+    { line = $0; sub(/^[[:space:]]+/, "", line) }
+    line ~ /^#/ { next }
+    sub(/^path:[[:space:]]*/, "", line) || line ~ /^crates\/domains\/data\//  {
+      if (line ~ /^crates\/domains\/data\//) print line
+    }
   ' "$CI" | sed 's|/\*\.owl$||' | sort -u)
   mine=$(printf '%s\n' "${FETCHED[@]}" "${FETCHED_TREES[@]}" | sort -u)
-  if [ "$ci_paths" != "$mine" ]; then
-    echo "::error::scripts/verify-fetched-data.sh has drifted from ci.yml's praxis-data cache paths."
-    echo "── in ci.yml but not verified here:"
-    comm -23 <(printf '%s\n' "$ci_paths") <(printf '%s\n' "$mine") | sed 's/^/    /'
-    echo "── verified here but not cached in ci.yml:"
-    comm -13 <(printf '%s\n' "$ci_paths") <(printf '%s\n' "$mine") | sed 's/^/    /'
-    fail=1
-  fi
+
+  # CONTAINMENT, not equality. Verification is deliberately STRICTER than the
+  # cache: ci.yml caches `markup-schemas/xsts`, while this script checks
+  # `xsts/xmlschema2006-11-06` inside it, because the parent contains a
+  # committed .tar.prx and so exists even when the fetch never ran. So the
+  # relation to enforce is that every cached path has something verified at or
+  # beneath it, and every verified path sits at or beneath something cached.
+  while IFS= read -r c; do
+    [ -n "$c" ] || continue
+    printf '%s\n' "$mine" | command grep -q "^${c}" || {
+      echo "::error::ci.yml caches ${c} but nothing here verifies it — a partial"
+      echo "  restore of that path would pass unnoticed."
+      fail=1
+    }
+  done <<<"$ci_paths"
+
+  while IFS= read -r m; do
+    [ -n "$m" ] || continue
+    covered=0
+    while IFS= read -r c; do
+      [ -n "$c" ] || continue
+      case "$m" in "$c"*) covered=1 ;; esac
+    done <<<"$ci_paths"
+    [ "$covered" -eq 1 ] || {
+      echo "::error::${m} is verified here but is not in any ci.yml cache path,"
+      echo "  so skipping the fetch would leave it absent."
+      fail=1
+    }
+  done <<<"$mine"
 fi
 
 if [ "$fail" -ne 0 ]; then

--- a/scripts/verify-fetched-data.sh
+++ b/scripts/verify-fetched-data.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Verify that every FETCHED data tree CI depends on is present on disk.
+#
+# Why this exists: the `build` job skips `pr4xis update` (and the ~126s CLI
+# build that exists only to run it) when the praxis-data cache hits. That skip
+# is only sound if the restored cache genuinely contains everything the archive
+# build reads — and `crates/wasm/build.rs` is FAIL-OPEN: :29 tolerates a missing
+# data root and :387 `continue`s past a missing .owl. So an incomplete restore
+# would not error, it would silently produce a smaller artifact and let CI go
+# green over it.
+#
+# This script converts that fail-open into a loud failure. It is the precondition
+# check that makes skipping the fetch provable rather than hopeful.
+#
+#   scripts/verify-fetched-data.sh
+#
+# Exits non-zero, naming every missing path, if the restored tree is incomplete.
+#
+# The list below is the 15 files `pr4xis update` was measured re-downloading on
+# every job of every run (master run 30502233952: 75 `[fetched]` across five
+# jobs). Every one is gitignored — none is committed — so their presence can
+# only come from a fetch or a cache restore.
+set -uo pipefail
+
+# Canonical list. MUST equal the praxis-data cache `path:` entries in ci.yml;
+# the self-check at the bottom enforces that, so the two cannot drift.
+FETCHED=(
+  crates/domains/data/adobe/glyphlist.txt
+  crates/domains/data/morphology/agid-infl.txt
+  crates/domains/data/markup-schemas/lmf/wn_lmf_dtd-1.3.dtd
+  crates/domains/data/markup-schemas/mods/mods_3_8-2018.xsd
+  crates/domains/data/markup-schemas/xhtml/xhtml-1.0-strict.xsd
+  crates/domains/data/markup-schemas/xml/xml.xsd
+  crates/domains/data/markup-schemas/xml/xml-infoset.xhtml
+  crates/domains/data/markup-schemas/xml/xml_1_0_fifth_edition-2008.xml
+  crates/domains/data/markup-schemas/xsd/xsd_meta_schema-1.1.xsd
+)
+
+# Directory trees, checked for non-emptiness rather than by exact filename
+# because their contents are version-pinned by praxis.lock and change with it.
+FETCHED_TREES=(
+  crates/domains/data/legal/uscode
+  crates/domains/data/ontologies
+  # The XML Schema and XML conformance suites. Fetched as tarballs and
+  # extracted; the markup-schemas tests read the extracted trees.
+  crates/domains/data/markup-schemas/xsts
+  crates/domains/data/markup-schemas/xmlconf
+)
+
+fail=0
+
+for f in "${FETCHED[@]}"; do
+  if [ ! -s "$f" ]; then
+    echo "::error::fetched data missing or empty: $f"
+    fail=1
+  fi
+done
+
+for d in "${FETCHED_TREES[@]}"; do
+  if [ ! -d "$d" ]; then
+    echo "::error::fetched data tree missing: $d"
+    fail=1
+  fi
+done
+
+# The OWL vocabularies specifically: build.rs:387 `continue`s past each missing
+# one, so a partial restore here is the quietest possible failure. praxis.lock
+# pins six.
+owl_count=$(find crates/domains/data/ontologies -name '*.owl' 2>/dev/null | wc -l)
+if [ "$owl_count" -lt 6 ]; then
+  echo "::error::expected 6 fetched .owl vocabularies, found ${owl_count} — build.rs silently skips missing ones"
+  fail=1
+fi
+
+# The USC titles the corpus and the wasm build both read.
+xml_count=$(find crates/domains/data/legal/uscode -name '*.xml' 2>/dev/null | wc -l)
+if [ "$xml_count" -lt 1 ]; then
+  echo "::error::no USC title XML under crates/domains/data/legal/uscode"
+  fail=1
+fi
+
+# ── Self-check: this list must match ci.yml's cache paths ────────────────────
+# Without this, adding a path to the cache block without adding it here would
+# leave a file cached but unverified — reintroducing exactly the silent-skip
+# hazard this script exists to close.
+CI=.github/workflows/ci.yml
+if [ -f "$CI" ]; then
+  # First praxis-data cache block's path list (all five blocks are identical).
+  ci_paths=$(awk '
+    /key: praxis-data-v[0-9]+-/ { exit }
+    /path: \|/ { collecting = 1; next }
+    collecting && /^            crates\/domains\/data\// { gsub(/^ +| +$/, ""); print }
+  ' "$CI" | sed 's|/\*\.owl$||' | sort -u)
+  mine=$(printf '%s\n' "${FETCHED[@]}" "${FETCHED_TREES[@]}" | sort -u)
+  if [ "$ci_paths" != "$mine" ]; then
+    echo "::error::scripts/verify-fetched-data.sh has drifted from ci.yml's praxis-data cache paths."
+    echo "── in ci.yml but not verified here:"
+    comm -23 <(printf '%s\n' "$ci_paths") <(printf '%s\n' "$mine") | sed 's/^/    /'
+    echo "── verified here but not cached in ci.yml:"
+    comm -13 <(printf '%s\n' "$ci_paths") <(printf '%s\n' "$mine") | sed 's/^/    /'
+    fail=1
+  fi
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "::error::the restored data cache is incomplete — it is NOT safe to skip pr4xis update"
+  exit 1
+fi
+
+echo "fetched data complete: ${#FETCHED[@]} files, ${#FETCHED_TREES[@]} trees, ${owl_count} .owl, ${xml_count} USC title XML"


### PR DESCRIPTION
Removes **~126s** from every data-cache-hit run — the last of the four cold-build levers.

This was **reverted once, on correct grounds**. The ground has since changed, and the change is measured rather than assumed.

## Why the step exists at all

`pr4xis update` *is* the fetcher, and the archive build needs its output (`crates/wasm/build.rs` reads the fetched USC XML), so a CLI must exist before the fetch. It is therefore needed exactly when there is fetching to do — and useless otherwise, because ~115s of its ~126s is thrown away:

`-p pr4xis-cli` resolves `pr4xis-domains` with serde_json `default+std`, while `--workspace --all-targets` resolves it with `alloc+default+std` (`alloc` arrives only via `wasm-bindgen-test`, a **dev**-dependency of `crates/wasm`). One feature apart is a different rlib fingerprint, so the archive step rebuilds that rlib regardless of what the bootstrap just built. Widening the selector can't fix it — matching that feature set requires dev-dependencies, i.e. `--all-targets`, which *is* the archive build.

## Why it is safe now

The revert stood on a real measurement: the fetch was **not** a no-op on a warm cache, reporting **75 `[fetched]`** against 190 `[ok]`, because the cache covered 5 paths while `praxis.lock` registers ~20 fetchable trees. Skipping it would have left 75 sources absent against a fail-open `build.rs`.

`praxis-data-v3` (#242) closed that gap. Master run `30514347842` measured the result, with the v3 key cold for `build` and warm for everything after it:

| job | data cache | `[fetched]` |
|---|---|---|
| `build` | **MISS** | 27 |
| `lint-docs` | hit | **0** |
| `test` | hit | **0** |
| `corpus` | hit | **0** |
| `wasm-browser` | hit | **0** |

A cache hit means zero fetches, on four independent jobs.

## Fail-closed, not hopeful

A measurement is a fact about one run; this has to hold on every future one. `crates/wasm/build.rs` is fail-**open** — `:29` tolerates a missing data root and `:387` `continue`s past a missing `.owl` — so an incomplete restore wouldn't error, it would quietly produce a smaller artifact and go green.

`scripts/verify-fetched-data.sh` asserts all 9 files, 4 trees, 6 `.owl` and the USC XML are present before anything reads them, and runs **unconditionally**, including on the paths where the fetch was skipped.

It also **self-checks its own list against `ci.yml`'s cache `path:` entries**, so the two cannot drift — a check that earned itself immediately by catching that I had left `xsts` and `xmlconf` out of it. Red-tested both ways: green on a complete tree, and it names the exact missing file when one is hidden.

## All four cache combinations

The third is the one that needed `crates/cli/tests/cli_smoke.rs` to exist first:

| build-out | data | behaviour |
|---|---|---|
| MISS | MISS | bootstrap builds the CLI, fetch runs |
| HIT | MISS | CLI comes from the output cache, fetch runs |
| MISS | **HIT** | nothing bootstraps — `cargo nextest archive --workspace` builds the bin itself and leaves it at `target/release/pr4xis` (**verified on disk**), so the artifact upload still has a source |
| HIT | HIT | both skipped; verification still runs |

That third row is why the earlier PR added an integration test to `crates/cli`: `cargo nextest archive` builds a package's plain `[[bin]]` only when the package also has an integration-test or bench target.

## Cold build, end to end

| | |
|---|---|
| session start | 725s |
| `lto = "off"` (#242) | ~600s |
| this PR | **~470s** |

Warm (output-cache hit) remains **38s**.

> Independent of #243, but both touch `ci.yml` in different regions (this one the `build` job's fetch steps; #243 the constitution-gate step in `test`), so they do not conflict.
